### PR TITLE
M2Crypto failures when starting minion unless swig installed pre-salt

### DIFF
--- a/bootstrap-salt-minion.sh
+++ b/bootstrap-salt-minion.sh
@@ -763,10 +763,12 @@ install_freebsd_git_deps() {
 }
 
 install_freebsd_90_stable() {
+    /usr/local/sbin/pkg install -y swig
     /usr/local/sbin/pkg install -y salt
 }
 
 install_freebsd_git() {
+    /usr/local/sbin/pkg install -y swig
     /usr/local/sbin/pkg install -y git salt
     /usr/local/sbin/pkg delete -y salt
 

--- a/bootstrap-salt-minion.sh
+++ b/bootstrap-salt-minion.sh
@@ -739,6 +739,8 @@ install_freebsd_90_stable_deps() {
     cd
     /usr/local/sbin/pkg2ng
     echo "PACKAGESITE: http://pkgbeta.freebsd.org/freebsd-9-${ARCH}/latest" > /usr/local/etc/pkg.conf
+
+    /usr/local/sbin/pkg install -y swig 
 }
 
 install_freebsd_git_deps() {
@@ -760,6 +762,8 @@ install_freebsd_git_deps() {
     cd
     /usr/local/sbin/pkg2ng
     echo "PACKAGESITE: http://pkgbeta.freebsd.org/freebsd-9-${ARCH}/latest" > /usr/local/etc/pkg.conf
+
+    /usr/local/sbin/pkg install -y swig 
 }
 
 install_freebsd_90_stable() {

--- a/bootstrap-salt-minion.sh
+++ b/bootstrap-salt-minion.sh
@@ -763,12 +763,10 @@ install_freebsd_git_deps() {
 }
 
 install_freebsd_90_stable() {
-    /usr/local/sbin/pkg install -y swig
     /usr/local/sbin/pkg install -y salt
 }
 
 install_freebsd_git() {
-    /usr/local/sbin/pkg install -y swig
     /usr/local/sbin/pkg install -y git salt
     /usr/local/sbin/pkg delete -y salt
 


### PR DESCRIPTION
Installation works fine on FreeBSD, but I'm unable to start the salt minion unless swig was installed before M2Crypto.
