### PR TITLE
improved ARCH detection and bootstrap pkg.txz installation

### DIFF
--- a/bootstrap-salt-minion.sh
+++ b/bootstrap-salt-minion.sh
@@ -721,49 +721,43 @@ install_arch_post() {
 #   FreeBSD Install Functions
 #
 install_freebsd_90_stable_deps() {
-    if [ "$CPU_VENDOR_ID_L" = "AuthenticAMD" -a $CPU_ARCH_L = "x86_64" ]; then
-        local ARCH="amd64"
-    elif [ "$CPU_VENDOR_ID_L" = "GenuineIntel" -a $CPU_ARCH_L = "x86_64" ]; then
+    if [ $CPU_ARCH_L = "amd64" ]; then
         local ARCH="x86:64"
-    elif [ "$CPU_VENDOR_ID_L" = "GenuineIntel" -a $CPU_ARCH_L = "i386" ]; then
-        local ARCH="i386"
-    elif [ "$CPU_VENDOR_ID_L" = "GenuineIntel" -a $CPU_ARCH_L = "i686" ]; then
+    elif [ $CPU_ARCH_L = "x86_64" ]; then
+        local ARCH="x86:64"
+    elif [ $CPU_ARCH_L = "i386" ]; then
         local ARCH="x86:32"
-    else
-        local ARCH=$CPU_ARCH
+    elif [ $CPU_ARCH_L = "i686" ]; then
+        local ARCH="x86:32"
     fi
 
-    portsnap fetch extract update
-    cd /usr/ports/ports-mgmt/pkg
-    make install clean
-    cd
+    fetch http://pkgbeta.freebsd.org/freebsd:9:${ARCH}/latest/Latest/pkg.txz
+    tar xf ./pkg.txz -s ",/.*/,,g" "*/pkg-static"
+    ./pkg-static add ./pkg.txz
     /usr/local/sbin/pkg2ng
-    echo "PACKAGESITE: http://pkgbeta.freebsd.org/freebsd-9-${ARCH}/latest" > /usr/local/etc/pkg.conf
+    echo "PACKAGESITE: http://pkgbeta.freebsd.org/freebsd:9:${ARCH}/latest" > /usr/local/etc/pkg.conf
 
-    /usr/local/sbin/pkg install -y swig 
+    /usr/local/sbin/pkg install -y swig
 }
 
 install_freebsd_git_deps() {
-    if [ "$CPU_VENDOR_ID_L" = "AuthenticAMD" -a $CPU_ARCH_L = "x86_64" ]; then
-        local ARCH="amd64"
-    elif [ "$CPU_VENDOR_ID_L" = "GenuineIntel" -a $CPU_ARCH_L = "x86_64" ]; then
+    if [ $CPU_ARCH_L = "amd64" ]; then
         local ARCH="x86:64"
-    elif [ "$CPU_VENDOR_ID_L" = "GenuineIntel" -a $CPU_ARCH_L = "i386" ]; then
-        local ARCH="i386"
-    elif [ "$CPU_VENDOR_ID_L" = "GenuineIntel" -a $CPU_ARCH_L = "i686" ]; then
+    elif [ $CPU_ARCH_L = "x86_64" ]; then
+        local ARCH="x86:64"
+    elif [ $CPU_ARCH_L = "i386" ]; then
         local ARCH="x86:32"
-    else
-        local ARCH=$CPU_ARCH
+    elif [ $CPU_ARCH_L = "i686" ]; then
+        local ARCH="x86:32"
     fi
 
-    portsnap fetch extract update
-    cd /usr/ports/ports-mgmt/pkg
-    make install clean
-    cd
+    fetch http://pkgbeta.freebsd.org/freebsd:9:${ARCH}/latest/Latest/pkg.txz
+    tar xf ./pkg.txz -s ",/.*/,,g" "*/pkg-static"
+    ./pkg-static add ./pkg.txz
     /usr/local/sbin/pkg2ng
-    echo "PACKAGESITE: http://pkgbeta.freebsd.org/freebsd-9-${ARCH}/latest" > /usr/local/etc/pkg.conf
+    echo "PACKAGESITE: http://pkgbeta.freebsd.org/freebsd:9:${ARCH}/latest" > /usr/local/etc/pkg.conf
 
-    /usr/local/sbin/pkg install -y swig 
+    /usr/local/sbin/pkg install -y swig
 }
 
 install_freebsd_90_stable() {


### PR DESCRIPTION
simplified the ARCH detection by getting rid of the CPU_VENDOR stuff and simply using CPU_ARCH and `uname -m`. Also improved speed by bootstrapping the pkg tool instead of pulling down the entire ports tree first.

TODO: dynamic version detection for the repo path. currently hard-coded to 9.
