### PR TITLE
updated Arch Linux repo config to updated repository

### DIFF
--- a/bootstrap-salt-minion.sh
+++ b/bootstrap-salt-minion.sh
@@ -682,13 +682,13 @@ install_centos_63_git_post() {
 #
 install_arch_stable_deps() {
     echo '[salt]
-Server = http://red45.org/archlinux
+Server = http://intothesaltmine.org/archlinux
 ' >> /etc/pacman.conf
 }
 
 install_arch_git_deps() {
     echo '[salt]
-    Server = http://red45.org/archlinux
+    Server = http://intothesaltmine.org/archlinux
     ' >> /etc/pacman.conf
 }
 


### PR DESCRIPTION
intothesaltmine.org/archlinux is maintained by the
Salt package maintainer and is more current than
red45.org/archlinux.
