### PR TITLE
correcting epel install rpm location.

### DIFF
--- a/bootstrap-salt-minion.sh
+++ b/bootstrap-salt-minion.sh
@@ -688,7 +688,7 @@ install_centos_63_stable_deps() {
     else
         local ARCH=$CPU_ARCH_L
     fi
-    rpm -Uvh --force http://mirrors.kernel.org/fedora-epel/6/${ARCH}/epel-release-6-7.noarch.rpm
+    rpm -Uvh --force http://mirrors.kernel.org/fedora-epel/6/${ARCH}/epel-release-6-8.noarch.rpm
     yum -y update
 }
 


### PR DESCRIPTION
The minor version for epel changed which causes issues with the script making sure epel is installed.   This just updates epel to the current version. 
