### PR TITLE
Place minion keys in minion sub-directory if it exists

### DIFF
--- a/bootstrap-salt-minion.sh
+++ b/bootstrap-salt-minion.sh
@@ -851,19 +851,15 @@ config_minion() {
         exit 1
     fi
 
+    PKI_DIR=/etc/salt/pki/minion
+
     # Let's create the necessary directories
     [ -d /etc/salt ] || mkdir /etc/salt
-    [ -d /etc/salt/pki ] || mkdir /etc/salt/pki && chmod 700 /etc/salt/pki
+    [ -d $PKI_DIR ] || mkdir $PKI_DIR && chmod 700 $PKI_DIR
 
     # Copy the minions configuration if found
     [ -f "$TEMP_CONFIG_DIR/minion" ] && mv "$TEMP_CONFIG_DIR/minion" /etc/salt
 
-    PKI_DIR=/etc/salt/pki
-
-    # Minion keys moved to minion directory in Salt 0.11.0
-    if [[ -d $PKI_DIR/minion ]]; then
-        PKI_DIR=$PKI_DIR/minion
-    fi
 
     # Copy the minion's keys if found
     if [ -f "$TEMP_CONFIG_DIR/minion.pem" ]; then

--- a/bootstrap-salt-minion.sh
+++ b/bootstrap-salt-minion.sh
@@ -858,14 +858,21 @@ config_minion() {
     # Copy the minions configuration if found
     [ -f "$TEMP_CONFIG_DIR/minion" ] && mv "$TEMP_CONFIG_DIR/minion" /etc/salt
 
+    PKI_DIR=/etc/salt/pki
+
+    # Minion keys moved to minion directory in Salt 0.11.0
+    if [[ -d $PKI_DIR/minion ]]; then
+        PKI_DIR=$PKI_DIR/minion
+    fi
+
     # Copy the minion's keys if found
     if [ -f "$TEMP_CONFIG_DIR/minion.pem" ]; then
-        mv "$TEMP_CONFIG_DIR/minion.pem" /etc/salt/pki
-        chmod 400 /etc/salt/pki/minion.pem
+        mv "$TEMP_CONFIG_DIR/minion.pem" $PKI_DIR/
+        chmod 400 $PKI_DIR/minion.pem
     fi
     if [ -f "$TEMP_CONFIG_DIR/minion.pub" ]; then
-        mv "$TEMP_CONFIG_DIR/minion.pub" /etc/salt/pki
-        chmod 664 /etc/salt/pki/minion.pub
+        mv "$TEMP_CONFIG_DIR/minion.pub" $PKI_DIR/
+        chmod 664 $PKI_DIR/minion.pub
     fi
 }
 #

--- a/bootstrap-salt-minion.sh
+++ b/bootstrap-salt-minion.sh
@@ -855,7 +855,7 @@ config_minion() {
 
     # Let's create the necessary directories
     [ -d /etc/salt ] || mkdir /etc/salt
-    [ -d $PKI_DIR ] || mkdir $PKI_DIR && chmod 700 $PKI_DIR
+    [ -d $PKI_DIR ] || mkdir -p $PKI_DIR && chmod 700 $PKI_DIR
 
     # Copy the minions configuration if found
     [ -f "$TEMP_CONFIG_DIR/minion" ] && mv "$TEMP_CONFIG_DIR/minion" /etc/salt


### PR DESCRIPTION
Per http://docs.saltstack.org/en/latest/topics/releases/0.11.0.html#notable-changes, the path for the minion keys have changed.  This change assumes that the directory pki/minion exists.
