### PR TITLE
Start salt-minion daemon post-install

### DIFF
--- a/bootstrap-salt-minion.sh
+++ b/bootstrap-salt-minion.sh
@@ -961,14 +961,6 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-# Install Salt
-echo " * Running ${INSTALL_FUNC}()"
-$INSTALL_FUNC
-if [ $? -ne 0 ]; then
-    echo " * Failed to run ${INSTALL_FUNC}()!!!"
-    exit 1
-fi
-
 # Configure Salt
 if [ "$TEMP_CONFIG_DIR" != "null" -a "$CONFIG_MINION_FUNC" != "null" ]; then
     echo " * Running ${CONFIG_MINION_FUNC}()"
@@ -977,6 +969,14 @@ if [ "$TEMP_CONFIG_DIR" != "null" -a "$CONFIG_MINION_FUNC" != "null" ]; then
         echo " * Failed to run ${CONFIG_MINION_FUNC}()!!!"
         exit 1
     fi
+fi
+
+# Install Salt
+echo " * Running ${INSTALL_FUNC}()"
+$INSTALL_FUNC
+if [ $? -ne 0 ]; then
+    echo " * Failed to run ${INSTALL_FUNC}()!!!"
+    exit 1
 fi
 
 # Run any post install function

--- a/bootstrap-salt-minion.sh
+++ b/bootstrap-salt-minion.sh
@@ -427,11 +427,6 @@ __apt_get_noinput() {
 #       3. install_<distro>_<install_type>_deps
 #       4. install_<distro>_deps
 #
-#
-#   To install salt, which, of course, is required, one of:
-#       1. install_<distro>_<distro_version>_<install_type>
-#       2. install_<distro>_<install_type>
-#
 #   Optionally, define a minion configuration function, which will be called if
 #   the -c|config-dir option is passed. One of:
 #       1. config_<distro>_<distro_version>_<install_type>_minion
@@ -439,6 +434,10 @@ __apt_get_noinput() {
 #       3. config_<distro>_<install_type>_minion
 #       4. config_<distro>_minion
 #       5. config_minion [THIS ONE IS ALREADY DEFINED AS THE DEFAULT]
+#
+#   To install salt, which, of course, is required, one of:
+#       1. install_<distro>_<distro_version>_<install_type>
+#       2. install_<distro>_<install_type>
 #
 #   Also optionally, define a post install function, one of:
 #       1. install_<distro>_<distro_versions>_<install_type>_post

--- a/bootstrap-salt-minion.sh
+++ b/bootstrap-salt-minion.sh
@@ -579,20 +579,24 @@ install_debian_git_deps() {
         python-jinja2 python-m2crypto python-yaml msgpack-python git python-zmq
 }
 
+config_debian_git_minion() {
+    TEMP_CONFIG_DIR="${SALT_GIT_CHECKOUT_DIR}/conf/"
+    config_minion
+}
+
 install_debian_git() {
     __git_clone_and_checkout
     python setup.py install --install-layout=deb
-
-    # Let's trigger config_minion()
-    if [ "$TEMP_CONFIG_DIR" = "null" ]; then
-        TEMP_CONFIG_DIR="${SALT_GIT_CHECKOUT_DIR}/conf/"
-        CONFIG_MINION_FUNC="config_minion"
-    fi
 }
 
 install_debian_60_git_deps() {
     install_debian_60_deps # Add backports
     install_debian_git_deps # Grab the actual deps
+}
+
+config_debian_60_git_minion() {
+    TEMP_CONFIG_DIR="${SALT_GIT_CHECKOUT_DIR}/conf/"
+    config_minion
 }
 
 install_debian_60_git() {
@@ -601,12 +605,6 @@ install_debian_60_git() {
     __git_clone_and_checkout
 
     python setup.py install --install-layout=deb
-
-    # Let's trigger config_minion()
-    if [ "$TEMP_CONFIG_DIR" = "null" ]; then
-        TEMP_CONFIG_DIR="${SALT_GIT_CHECKOUT_DIR}/conf/"
-        CONFIG_MINION_FUNC="config_minion"
-    fi
 }
 
 install_debian_git_post() {

--- a/bootstrap-salt-minion.sh
+++ b/bootstrap-salt-minion.sh
@@ -580,8 +580,10 @@ install_debian_git_deps() {
 }
 
 config_debian_git_minion() {
-    TEMP_CONFIG_DIR="${SALT_GIT_CHECKOUT_DIR}/conf/"
-    config_minion
+    if [ "$TEMP_CONFIG_DIR" = "null" ]; then
+        TEMP_CONFIG_DIR="${SALT_GIT_CHECKOUT_DIR}/conf/"
+        config_minion
+    fi
 }
 
 install_debian_git() {
@@ -595,8 +597,7 @@ install_debian_60_git_deps() {
 }
 
 config_debian_60_git_minion() {
-    TEMP_CONFIG_DIR="${SALT_GIT_CHECKOUT_DIR}/conf/"
-    config_minion
+    config_debian_git_minion
 }
 
 install_debian_60_git() {


### PR DESCRIPTION
I noticed - the *_git_post functions start the minion daemon while the stable/daily versions do not.  

I'm interested in changing that behavior - what would be the favored way to do that?

I see a few options:
1) Start the daemon in all cases
2) Restart the daemon in all cases
3) Add an additional command line option to allow users to choose whether to start the daemon post-install

I'd be happy to contribute the change for this issue.  

Thanks!

David
