### PR TITLE
default bootstrap works on Centos 6.2

### DIFF
--- a/bootstrap-salt-minion.sh
+++ b/bootstrap-salt-minion.sh
@@ -701,6 +701,18 @@ install_centos_63_stable_post() {
     /etc/init.d/salt-minion start
 }
 
+install_centos_62_stable_deps() {
+    install_centos_63_stable_deps
+}
+
+install_centos_62_stable() {
+    install_centos_63_stable
+}
+
+install_centos_62_stable_post() {
+    install_centos_63_stable_post
+}
+
 install_centos_63_git_deps() {
     install_centos_63_stable_deps
     yum -y install git PyYAML m2crypto python-crypto python-msgpack python-zmq python-jinja2 --enablerepo=epel-testing


### PR DESCRIPTION
I only added `install_centos_62_stable_deps`, `install_centos_62_stable`, and `install_centos_62_stable_post`. (I did not test `daily` or `git` so I did not add support for it.)

It did work on my machine. Is there a test suite to confirm everything is ok ?
