### PR TITLE
Let users know that long, double dashed, options are not supported. Fixes #28.

### DIFF
--- a/.run-boostrap-tests.sh
+++ b/.run-boostrap-tests.sh
@@ -45,6 +45,9 @@ passed_echo() {
 title_echo "Running checkbashisms"
 /usr/bin/checkbashisms -pxfn bootstrap-salt-minion.sh && passed_echo || failed_echo
 
+title_echo "Double dashed long options are errors and explained to the user"
+/bin/bash bootstrap-salt-minion.sh --help | grep "Long options are NOT double-dash prefixed" && passed_echo || failed_echo
+
 title_echo "Installing using bash"
 (sudo /bin/bash bootstrap-salt-minion.sh && salt-minion --versions-report && sudo apt-get remove salt-common salt-minion) && passed_echo || failed_echo
 

--- a/bootstrap-salt-minion.sh
+++ b/bootstrap-salt-minion.sh
@@ -45,12 +45,12 @@ usage() {
     $ ${ScriptName} git 8c3fadf15ec183e5ce8c63739850d543617e4357
 
   Options:
-  -h|help       Display this message
-  -v|version    Display script version
-  -c|config-dir Temporary minion configuration directory
-  -M|master     Also install salt-master
-  -S|syndic     Also install salt-syndic
-  -N|no-minion  Do not install salt-minion
+  -h|-help       Display this message
+  -v|-version    Display script version
+  -c|-config-dir Temporary minion configuration directory
+  -M|-master     Also install salt-master
+  -S|-syndic     Also install salt-syndic
+  -N|-no-minion  Do not install salt-minion
 EOT
 }   # ----------  end of function usage  ----------
 
@@ -74,8 +74,15 @@ do
     S|syndic        )  INSTALL_SYNDIC=1 ;;
     N|no-minion     )  INSTALL_MINION=0 ;;
 
-    \?              )  echo "\n  Option does not exist : $OPTARG\n"
-                       usage; exit 1   ;;
+    \?              )  echo
+                       if [ "$OPTARG" = "-" ]; then
+                           echo "  Long options are NOT double-dash prefixed"
+                       else
+                           echo "  Option does not exist : $OPTARG"
+                       fi
+                       usage
+                       exit 1
+                       ;;
 
   esac    # --- end of case ---
 done


### PR DESCRIPTION
- We still support long options, though they are only prefixed with a single dash.
- Testcase.
