### PR TITLE
only use the first number of the distro for centos

### DIFF
--- a/bootstrap-salt-minion.sh
+++ b/bootstrap-salt-minion.sh
@@ -449,9 +449,11 @@ echo
 
 # Simplify version naming on functions
 if [ "x${DISTRO_VERSION}" = "x" ]; then
+    DISTRO_MAJOR_VERSION=""
     DISTRO_VERSION_NO_DOTS=""
     PREFIXED_DISTRO_VERSION_NO_DOTS=""
 else
+    DISTRO_MAJOR_VERSION="$(echo $DISTRO_VERSION | sed 's/^\([0-9]*\).*/\1/g')"
     DISTRO_VERSION_NO_DOTS="$(echo $DISTRO_VERSION | tr -d '.')"
     PREFIXED_DISTRO_VERSION_NO_DOTS="_${DISTRO_VERSION_NO_DOTS}"
 fi
@@ -812,9 +814,9 @@ install_centos_stable_deps() {
     else
         EPEL_ARCH=$CPU_ARCH_L
     fi
-    if [ ${DISTRO_VERSION_NO_DOTS:0:1} -gt 4 ] && [ ${DISTRO_VERSION_NO_DOTS:0:1} -lt 6 ]; then
+    if [ $DISTRO_MAJOR_VERSION -eq 5 ]; then
         rpm -Uvh --force http://mirrors.kernel.org/fedora-epel/5/${EPEL_ARCH}/epel-release-5-4.noarch.rpm
-    elif [ ${DISTRO_VERSION_NO_DOTS:0:1} -gt 5 ] && [ ${DISTRO_VERSION_NO_DOTS:0:1} -lt 7 ]; then
+    elif [ $DISTRO_MAJOR_VERSION -eq 6 ]; then
         rpm -Uvh --force http://mirrors.kernel.org/fedora-epel/6/${EPEL_ARCH}/epel-release-6-8.noarch.rpm
     fi
     yum -y update

--- a/bootstrap-salt-minion.sh
+++ b/bootstrap-salt-minion.sh
@@ -812,9 +812,9 @@ install_centos_stable_deps() {
     else
         EPEL_ARCH=$CPU_ARCH_L
     fi
-    if [ $DISTRO_VERSION_NO_DOTS -gt 4 ] && [ $DISTRO_VERSION_NO_DOTS -lt 6 ]; then
+    if [ ${DISTRO_VERSION_NO_DOTS:0:1} -gt 4 ] && [ ${DISTRO_VERSION_NO_DOTS:0:1} -lt 6 ]; then
         rpm -Uvh --force http://mirrors.kernel.org/fedora-epel/5/${EPEL_ARCH}/epel-release-5-4.noarch.rpm
-    elif [ $DISTRO_VERSION_NO_DOTS -gt 5 ] && [ $DISTRO_VERSION_NO_DOTS -lt 7 ]; then
+    elif [ ${DISTRO_VERSION_NO_DOTS:0:1} -gt 5 ] && [ ${DISTRO_VERSION_NO_DOTS:0:1} -lt 7 ]; then
         rpm -Uvh --force http://mirrors.kernel.org/fedora-epel/6/${EPEL_ARCH}/epel-release-6-8.noarch.rpm
     fi
     yum -y update


### PR DESCRIPTION
https://github.com/saltstack/salt-bootstrap/commit/c2d641bdde06d89ddcd15f980542af540aeb786a removed the _63_ functions, which had fixed centos. this pull request makes it so that the epel can be downloaded properly.
