### PR TITLE
FreeBSD 9.1 support + start daemons

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1310,17 +1310,17 @@ __freebsd_get_packagesite() {
         BSD_ARCH="x86:32"
     fi
 
-    PACKAGESITE=${PACKAGESITE:="http://pkgbeta.freebsd.org/freebsd:9:${BSD_ARCH}/latest"}
+    BS_PACKAGESITE=${PACKAGESITE:-"http://pkgbeta.freebsd.org/freebsd:9:${BSD_ARCH}/latest"}
 }
 
 install_freebsd_9x_stable_deps() {
     __freebsd_get_packagesite
 
-    fetch "${PACKAGESITE}/Latest/pkg.txz"
+    fetch "${BS_PACKAGESITE}/Latest/pkg.txz"
     tar xf ./pkg.txz -s ",/.*/,,g" "*/pkg-static"
     ./pkg-static add ./pkg.txz
     /usr/local/sbin/pkg2ng
-    echo "PACKAGESITE: ${PACKAGESITE}" > /usr/local/etc/pkg.conf
+    echo "PACKAGESITE: ${BS_PACKAGESITE}" > /usr/local/etc/pkg.conf
 
     /usr/local/sbin/pkg install -y swig
 }
@@ -1336,11 +1336,11 @@ install_freebsd_91_stable_deps() {
 install_freebsd_git_deps() {
     __freebsd_get_packagesite
 
-    fetch "${PACKAGESITE}/Latest/pkg.txz"
+    fetch "${BS_PACKAGESITE}/Latest/pkg.txz"
     tar xf ./pkg.txz -s ",/.*/,,g" "*/pkg-static"
     ./pkg-static add ./pkg.txz
     /usr/local/sbin/pkg2ng
-    echo "PACKAGESITE: ${PACKAGESITE}" > /usr/local/etc/pkg.conf
+    echo "PACKAGESITE: ${BS_PACKAGESITE}" > /usr/local/etc/pkg.conf
 
     /usr/local/sbin/pkg install -y swig
 

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1299,7 +1299,7 @@ install_arch_start_daemons() {
 #
 #   FreeBSD Install Functions
 #
-install_freebsd_90_stable_deps() {
+install_freebsd_9x_stable_deps() {
     if [ $CPU_ARCH_L = "amd64" ]; then
         BSD_ARCH="x86:64"
     elif [ $CPU_ARCH_L = "x86_64" ]; then
@@ -1317,6 +1317,14 @@ install_freebsd_90_stable_deps() {
     echo "PACKAGESITE: http://pkgbeta.freebsd.org/freebsd:9:${BSD_ARCH}/latest" > /usr/local/etc/pkg.conf
 
     /usr/local/sbin/pkg install -y swig
+}
+
+install_freebsd_90_stable_deps() {
+    install_freebsd_9x_stable_deps
+}
+
+install_freebsd_91_stable_deps() {
+    install_freebsd_9x_stable_deps
 }
 
 install_freebsd_git_deps() {
@@ -1346,8 +1354,16 @@ install_freebsd_git_deps() {
     fi
 }
 
-install_freebsd_90_stable() {
+install_freebsd_9x_stable() {
     /usr/local/sbin/pkg install -y salt
+}
+
+install_freebsd_90_stable() {
+    install_freebsd_9x_stable
+}
+
+install_freebsd_91_stable() {
+    install_freebsd_9x_stable
 }
 
 install_freebsd_git() {
@@ -1378,6 +1394,23 @@ install_freebsd_start_daemons() {
         salt-$fname -d &
     done
 }
+
+install_freebsd_9x_stable_post() {
+    salt-minion -d &
+}
+
+install_freebsd_90_stable_post() {
+    install_freebsd_9x_stable_post
+}
+
+install_freebsd_91_stable_post() {
+    install_freebsd_9x_stable_post
+}
+
+install_freebsd_git_post() {
+    salt-minion -d &
+}
+
 #
 #   Ended FreeBSD Install Functions
 #

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1379,10 +1379,12 @@ install_freebsd_9x_stable_post() {
         [ $fname = "master" ] && [ $INSTALL_MASTER -eq $BS_FALSE ] && continue
         [ $fname = "syndic" ] && [ $INSTALL_SYNDIC -eq $BS_FALSE ] && continue
 
-        # XXX: Should we cp /usr/local/etc/salt/master.sample /usr/local/etc/salt/master and same for minion?
         enable_string="salt_${fname}_enable=\"YES\""
         grep "$enable_string" /etc/rc.conf >/dev/null 2>&1
         [ $? -eq 1 ] && echo "$enable_string" >> /etc/rc.conf
+
+        [ $fname = "minion" ] && cp /usr/local/etc/salt/${fname}.sample /usr/local/etc/salt/${fname}
+        [ $fname = "master" ] && cp /usr/local/etc/salt/${fname}.sample /usr/local/etc/salt/${fname}
 
         if [ $fname = "minion" ] ; then
             grep "salt_minion_paths" /etc/rc.conf >/dev/null 2>&1
@@ -1408,10 +1410,12 @@ install_freebsd_git_post() {
         [ $fname = "master" ] && [ $INSTALL_MASTER -eq $BS_FALSE ] && continue
         [ $fname = "syndic" ] && [ $INSTALL_SYNDIC -eq $BS_FALSE ] && continue
 
-        # XXX: Should we cp /usr/local/etc/salt/master.sample /usr/local/etc/salt/master and same for minion?
         enable_string="salt_${fname}_enable=\"YES\""
         grep "$enable_string" /etc/rc.conf >/dev/null 2>&1
         [ $? -eq 1 ] && echo "$enable_string" >> /etc/rc.conf
+
+        [ $fname = "minion" ] && cp /usr/local/etc/salt/${fname}.sample /usr/local/etc/salt/${fname}
+        [ $fname = "master" ] && cp /usr/local/etc/salt/${fname}.sample /usr/local/etc/salt/${fname}
 
         if [ $fname = "minion" ] ; then
             grep "salt_minion_paths" /etc/rc.conf >/dev/null 2>&1

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -517,7 +517,7 @@ else
     PREFIXED_DISTRO_VERSION_NO_DOTS="_${DISTRO_VERSION_NO_DOTS}"
 fi
 # Simplify distro name naming on functions
-DISTRO_NAME_L=$(echo $DISTRO_NAME | tr '[:upper:]' '[:lower:]' | sed 's/[^a-zA-Z0-9_ ]//g' | sed -re 's/[[:space:]]+/_/g')
+DISTRO_NAME_L=$(echo $DISTRO_NAME | tr '[:upper:]' '[:lower:]' | sed 's/[^a-zA-Z0-9_ ]//g' | sed -re 's/([[:space:]])+/_/g')
 
 
 # Only Ubuntu has daily packages, let's let users know about that

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1373,17 +1373,7 @@ install_freebsd_git() {
     /usr/local/bin/python setup.py install
 }
 
-install_freebsd_90_stable_post__() {
-    # XXX: What needs to be done for init.d support on FreeBSD
-    echo
-}
-
-install_freebsd_git_post__() {
-    # XXX: What needs to be done for init.d support on FreeBSD
-    echo
-}
-
-install_freebsd_start_daemons() {
+install_freebsd_9x_stable_post() {
     for fname in minion master syndic; do
 
         # Skip if not meant to be installed
@@ -1391,12 +1381,14 @@ install_freebsd_start_daemons() {
         [ $fname = "master" ] && [ $INSTALL_MASTER -eq $BS_FALSE ] && continue
         [ $fname = "syndic" ] && [ $INSTALL_SYNDIC -eq $BS_FALSE ] && continue
 
-        salt-$fname -d &
-    done
-}
+        # XXX: Should we cp /usr/local/etc/salt/master.sample /usr/local/etc/salt/master and same for minion?
+        echo "salt_${fname}_enable=\"YES\"" >> /etc/rc.conf
 
-install_freebsd_9x_stable_post() {
-    salt-minion -d &
+        if [ $fname = "minion" ] ; then
+            echo "salt_minion_paths=\"/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin\"" >> /etc/rc.conf
+        fi
+
+    done
 }
 
 install_freebsd_90_stable_post() {
@@ -1408,9 +1400,35 @@ install_freebsd_91_stable_post() {
 }
 
 install_freebsd_git_post() {
-    salt-minion -d &
+    for fname in minion master syndic; do
+
+        # Skip if not meant to be installed
+        [ $fname = "minion" ] && [ $INSTALL_MINION -eq $BS_FALSE ] && continue
+        [ $fname = "master" ] && [ $INSTALL_MASTER -eq $BS_FALSE ] && continue
+        [ $fname = "syndic" ] && [ $INSTALL_SYNDIC -eq $BS_FALSE ] && continue
+
+        # XXX: Should we cp /usr/local/etc/salt/master.sample /usr/local/etc/salt/master and same for minion?
+        echo "salt_${fname}_enable=\"YES\"" >> /etc/rc.conf
+
+        if [ $fname = "minion" ] ; then
+            echo "salt_minion_paths=\"/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin\"" >> /etc/rc.conf
+        fi
+
+    done
 }
 
+install_freebsd_start_daemons() {
+    for fname in minion master syndic; do
+
+        # Skip if not meant to be installed
+        [ $fname = "minion" ] && [ $INSTALL_MINION -eq $BS_FALSE ] && continue
+        [ $fname = "master" ] && [ $INSTALL_MASTER -eq $BS_FALSE ] && continue
+        [ $fname = "syndic" ] && [ $INSTALL_SYNDIC -eq $BS_FALSE ] && continue
+
+        service salt_$fname start &
+
+    done
+}
 #
 #   Ended FreeBSD Install Functions
 #

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1383,8 +1383,8 @@ install_freebsd_9x_stable_post() {
         grep "$enable_string" /etc/rc.conf >/dev/null 2>&1
         [ $? -eq 1 ] && echo "$enable_string" >> /etc/rc.conf
 
-        [ $fname = "minion" ] && cp /usr/local/etc/salt/${fname}.sample /usr/local/etc/salt/${fname}
-        [ $fname = "master" ] && cp /usr/local/etc/salt/${fname}.sample /usr/local/etc/salt/${fname}
+        [ $fname = "minion" ] && [ -f /usr/local/etc/salt/${fname}.sample ] && cp /usr/local/etc/salt/${fname}.sample /usr/local/etc/salt/${fname}
+        [ $fname = "master" ] && [ -f /usr/local/etc/salt/${fname}.sample ] && cp /usr/local/etc/salt/${fname}.sample /usr/local/etc/salt/${fname}
 
         if [ $fname = "minion" ] ; then
             grep "salt_minion_paths" /etc/rc.conf >/dev/null 2>&1
@@ -1414,8 +1414,8 @@ install_freebsd_git_post() {
         grep "$enable_string" /etc/rc.conf >/dev/null 2>&1
         [ $? -eq 1 ] && echo "$enable_string" >> /etc/rc.conf
 
-        [ $fname = "minion" ] && cp /usr/local/etc/salt/${fname}.sample /usr/local/etc/salt/${fname}
-        [ $fname = "master" ] && cp /usr/local/etc/salt/${fname}.sample /usr/local/etc/salt/${fname}
+        [ $fname = "minion" ] && [ -f /usr/local/etc/salt/${fname}.sample ] && cp /usr/local/etc/salt/${fname}.sample /usr/local/etc/salt/${fname}
+        [ $fname = "master" ] && [ -f /usr/local/etc/salt/${fname}.sample ] && cp /usr/local/etc/salt/${fname}.sample /usr/local/etc/salt/${fname}
 
         if [ $fname = "minion" ] ; then
             grep "salt_minion_paths" /etc/rc.conf >/dev/null 2>&1

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1355,7 +1355,7 @@ install_freebsd_git_deps() {
 }
 
 install_freebsd_9x_stable() {
-    /usr/local/sbin/pkg install -y salt
+    /usr/local/sbin/pkg install -y sysutils/py-salt
 }
 
 install_freebsd_90_stable() {
@@ -1367,8 +1367,8 @@ install_freebsd_91_stable() {
 }
 
 install_freebsd_git() {
-    /usr/local/sbin/pkg install -y git salt
-    /usr/local/sbin/pkg delete -y salt
+    /usr/local/sbin/pkg install -y git sysutils/py-salt
+    /usr/local/sbin/pkg delete -y sysutils/py-salt
 
     /usr/local/bin/python setup.py install
 }

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -10,6 +10,7 @@
 #          BUGS: https://github.com/saltstack/salty-vagrant/issues
 #        AUTHOR: Pedro Algarvio (s0undt3ch), pedro@algarvio.me
 #                Alec Koumjian (akoumjian), akoumjian@gmail.com
+#                Geoff Garside (geoffgarside), geoff@geoffgarside.co.uk
 #       LICENSE: Apache 2.0
 #  ORGANIZATION: Salt Stack (saltstack.org)
 #       CREATED: 10/15/2012 09:49:37 PM WEST

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1382,10 +1382,13 @@ install_freebsd_9x_stable_post() {
         [ $fname = "syndic" ] && [ $INSTALL_SYNDIC -eq $BS_FALSE ] && continue
 
         # XXX: Should we cp /usr/local/etc/salt/master.sample /usr/local/etc/salt/master and same for minion?
-        echo "salt_${fname}_enable=\"YES\"" >> /etc/rc.conf
+        enable_string="salt_${fname}_enable=\"YES\""
+        grep "$enable_string" /etc/rc.conf >/dev/null 2>&1
+        [ $? -eq 1 ] && echo "$enable_string" >> /etc/rc.conf
 
         if [ $fname = "minion" ] ; then
-            echo "salt_minion_paths=\"/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin\"" >> /etc/rc.conf
+            grep "salt_minion_paths" /etc/rc.conf >/dev/null 2>&1
+            [ $? -eq 1 ] && echo "salt_minion_paths=\"/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin\"" >> /etc/rc.conf
         fi
 
     done
@@ -1408,10 +1411,13 @@ install_freebsd_git_post() {
         [ $fname = "syndic" ] && [ $INSTALL_SYNDIC -eq $BS_FALSE ] && continue
 
         # XXX: Should we cp /usr/local/etc/salt/master.sample /usr/local/etc/salt/master and same for minion?
-        echo "salt_${fname}_enable=\"YES\"" >> /etc/rc.conf
+        enable_string="salt_${fname}_enable=\"YES\""
+        grep "$enable_string" /etc/rc.conf >/dev/null 2>&1
+        [ $? -eq 1 ] && echo "$enable_string" >> /etc/rc.conf
 
         if [ $fname = "minion" ] ; then
-            echo "salt_minion_paths=\"/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin\"" >> /etc/rc.conf
+            grep "salt_minion_paths" /etc/rc.conf >/dev/null 2>&1
+            [ $? -eq 1 ] && echo "salt_minion_paths=\"/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin\"" >> /etc/rc.conf
         fi
 
     done

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1384,7 +1384,6 @@ install_freebsd_9x_stable_post() {
         [ $? -eq 1 ] && echo "$enable_string" >> /etc/rc.conf
 
         [ -f /usr/local/etc/salt/${fname}.sample ] && cp /usr/local/etc/salt/${fname}.sample /usr/local/etc/salt/${fname}
-        [ -f /usr/local/etc/salt/${fname}.sample ] && cp /usr/local/etc/salt/${fname}.sample /usr/local/etc/salt/${fname}
 
         if [ $fname = "minion" ] ; then
             grep "salt_minion_paths" /etc/rc.conf >/dev/null 2>&1
@@ -1414,7 +1413,6 @@ install_freebsd_git_post() {
         grep "$enable_string" /etc/rc.conf >/dev/null 2>&1
         [ $? -eq 1 ] && echo "$enable_string" >> /etc/rc.conf
 
-        [ -f /usr/local/etc/salt/${fname}.sample ] && cp /usr/local/etc/salt/${fname}.sample /usr/local/etc/salt/${fname}
         [ -f /usr/local/etc/salt/${fname}.sample ] && cp /usr/local/etc/salt/${fname}.sample /usr/local/etc/salt/${fname}
 
         if [ $fname = "minion" ] ; then

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1383,8 +1383,8 @@ install_freebsd_9x_stable_post() {
         grep "$enable_string" /etc/rc.conf >/dev/null 2>&1
         [ $? -eq 1 ] && echo "$enable_string" >> /etc/rc.conf
 
-        [ $fname = "minion" ] && [ -f /usr/local/etc/salt/${fname}.sample ] && cp /usr/local/etc/salt/${fname}.sample /usr/local/etc/salt/${fname}
-        [ $fname = "master" ] && [ -f /usr/local/etc/salt/${fname}.sample ] && cp /usr/local/etc/salt/${fname}.sample /usr/local/etc/salt/${fname}
+        [ -f /usr/local/etc/salt/${fname}.sample ] && cp /usr/local/etc/salt/${fname}.sample /usr/local/etc/salt/${fname}
+        [ -f /usr/local/etc/salt/${fname}.sample ] && cp /usr/local/etc/salt/${fname}.sample /usr/local/etc/salt/${fname}
 
         if [ $fname = "minion" ] ; then
             grep "salt_minion_paths" /etc/rc.conf >/dev/null 2>&1
@@ -1414,8 +1414,8 @@ install_freebsd_git_post() {
         grep "$enable_string" /etc/rc.conf >/dev/null 2>&1
         [ $? -eq 1 ] && echo "$enable_string" >> /etc/rc.conf
 
-        [ $fname = "minion" ] && [ -f /usr/local/etc/salt/${fname}.sample ] && cp /usr/local/etc/salt/${fname}.sample /usr/local/etc/salt/${fname}
-        [ $fname = "master" ] && [ -f /usr/local/etc/salt/${fname}.sample ] && cp /usr/local/etc/salt/${fname}.sample /usr/local/etc/salt/${fname}
+        [ -f /usr/local/etc/salt/${fname}.sample ] && cp /usr/local/etc/salt/${fname}.sample /usr/local/etc/salt/${fname}
+        [ -f /usr/local/etc/salt/${fname}.sample ] && cp /usr/local/etc/salt/${fname}.sample /usr/local/etc/salt/${fname}
 
         if [ $fname = "minion" ] ; then
             grep "salt_minion_paths" /etc/rc.conf >/dev/null 2>&1

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -517,7 +517,7 @@ else
     PREFIXED_DISTRO_VERSION_NO_DOTS="_${DISTRO_VERSION_NO_DOTS}"
 fi
 # Simplify distro name naming on functions
-DISTRO_NAME_L=$(echo $DISTRO_NAME | tr '[:upper:]' '[:lower:]' | sed 's/[^a-zA-Z0-9_ ]//g' | sed -re 's/(\s)+/_/g')
+DISTRO_NAME_L=$(echo $DISTRO_NAME | tr '[:upper:]' '[:lower:]' | sed 's/[^a-zA-Z0-9_ ]//g' | sed -re 's/[[:space:]]+/_/g')
 
 
 # Only Ubuntu has daily packages, let's let users know about that

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1299,7 +1299,7 @@ install_arch_start_daemons() {
 #
 #   FreeBSD Install Functions
 #
-install_freebsd_9x_stable_deps() {
+__freebsd_get_packagesite() {
     if [ $CPU_ARCH_L = "amd64" ]; then
         BSD_ARCH="x86:64"
     elif [ $CPU_ARCH_L = "x86_64" ]; then
@@ -1310,11 +1310,17 @@ install_freebsd_9x_stable_deps() {
         BSD_ARCH="x86:32"
     fi
 
-    fetch http://pkgbeta.freebsd.org/freebsd:9:${BSD_ARCH}/latest/Latest/pkg.txz
+    PACKAGESITE=${PACKAGESITE:="http://pkgbeta.freebsd.org/freebsd:9:${BSD_ARCH}/latest"}
+}
+
+install_freebsd_9x_stable_deps() {
+    __freebsd_get_packagesite
+
+    fetch "${PACKAGESITE}/Latest/pkg.txz"
     tar xf ./pkg.txz -s ",/.*/,,g" "*/pkg-static"
     ./pkg-static add ./pkg.txz
     /usr/local/sbin/pkg2ng
-    echo "PACKAGESITE: http://pkgbeta.freebsd.org/freebsd:9:${BSD_ARCH}/latest" > /usr/local/etc/pkg.conf
+    echo "PACKAGESITE: ${PACKAGESITE}" > /usr/local/etc/pkg.conf
 
     /usr/local/sbin/pkg install -y swig
 }
@@ -1328,21 +1334,13 @@ install_freebsd_91_stable_deps() {
 }
 
 install_freebsd_git_deps() {
-    if [ $CPU_ARCH_L = "amd64" ]; then
-        BSD_ARCH="x86:64"
-    elif [ $CPU_ARCH_L = "x86_64" ]; then
-        BSD_ARCH="x86:64"
-    elif [ $CPU_ARCH_L = "i386" ]; then
-        BSD_ARCH="x86:32"
-    elif [ $CPU_ARCH_L = "i686" ]; then
-        BSD_ARCH="x86:32"
-    fi
+    __freebsd_get_packagesite
 
-    fetch http://pkgbeta.freebsd.org/freebsd:9:${BSD_ARCH}/latest/Latest/pkg.txz
+    fetch "${PACKAGESITE}/Latest/pkg.txz"
     tar xf ./pkg.txz -s ",/.*/,,g" "*/pkg-static"
     ./pkg-static add ./pkg.txz
     /usr/local/sbin/pkg2ng
-    echo "PACKAGESITE: http://pkgbeta.freebsd.org/freebsd:9:${BSD_ARCH}/latest" > /usr/local/etc/pkg.conf
+    echo "PACKAGESITE: ${PACKAGESITE}" > /usr/local/etc/pkg.conf
 
     /usr/local/sbin/pkg install -y swig
 

--- a/tests/bootstrap/__init__.py
+++ b/tests/bootstrap/__init__.py
@@ -75,7 +75,7 @@ class NonBlockingPopen(subprocess.Popen):
                 self.obuff += obuff
                 sys.stdout.write(obuff)
             except IOError, err:
-                if err.errno != 11:
+                if err.errno not in (11, 35):
                     # We only handle Resource not ready properly, any other
                     # raise the exception
                     raise
@@ -85,7 +85,7 @@ class NonBlockingPopen(subprocess.Popen):
                 self.ebuff += ebuff
                 sys.stderr.write(ebuff)
             except IOError, err:
-                if err.errno != 11:
+                if err.errno not in (11, 35):
                     # We only handle Resource not ready properly, any other
                     # raise the exception
                     raise
@@ -179,14 +179,17 @@ class BootstrapTestCase(TestCase):
                 # process already terminated
                 pass
 
-    def assert_script_result(self, fail_msg, expected_rc, process_details):
+    def assert_script_result(self, fail_msg, expected_rcs, process_details):
+        if not isinstance(expected_rcs, (tuple, list)):
+            expected_rcs = (expected_rcs,)
+
         rc, out, err = process_details
-        if rc != expected_rc:
+        if rc not in expected_rcs:
             err_msg = '{0}:\n'.format(fail_msg)
             if out:
                 err_msg = '{0}STDOUT:\n{1}\n'.format(err_msg, '\n'.join(out))
             if err:
                 err_msg = '{0}STDERR:\n{1}\n'.format(err_msg, '\n'.join(err))
             if not err and not out:
-                err_msg = '{0} No std{out,err} captured.'.format(err_msg)
+                err_msg = '{0} No stdout nor stderr captured.'.format(err_msg)
             raise AssertionError(err_msg.rstrip())

--- a/tests/bootstrap/ext/os_data.py
+++ b/tests/bootstrap/ext/os_data.py
@@ -175,7 +175,11 @@ def os_data():
     #    grains.update(_bsd_cpudata(grains))
     else:
         grains['os'] = grains['kernel']
-    #if grains['kernel'] in ('FreeBSD', 'OpenBSD'):
+    if grains['kernel'] in ('FreeBSD', 'OpenBSD'):
+        grains['os'] = grains['kernel']
+        grains['os_family'] = grains['os']
+        grains['osfullname'] = "{0} {1}".format(grains['kernel'], grains['kernelrelease'])
+        grains['osrelease'] = grains['kernelrelease']
     #    grains.update(_bsd_cpudata(grains))
     if not grains['os']:
         grains['os'] = 'Unknown {0}'.format(grains['kernel'])

--- a/tests/bootstrap/test_install.py
+++ b/tests/bootstrap/test_install.py
@@ -47,7 +47,11 @@ class InstallationTestCase(BootstrapTestCase):
             print 'Running cleanup command {0!r}'.format(cleanup)
             self.assert_script_result(
                 'Failed to execute cleanup command {0!r}'.format(cleanup),
-                0,
+                (
+                    0,
+                    65  # FreeBSD throws this error code when the packages being
+                        # un-installed were not installed in the first place
+                ),
                 self.run_script(
                     script=None,
                     args=cleanup.split(),

--- a/tests/bootstrap/test_install.py
+++ b/tests/bootstrap/test_install.py
@@ -24,7 +24,7 @@ CLEANUP_COMMANDS_BY_OS_FAMILY = {
         'yum -y remove salt-minion salt-master'
     ],
     'FreeBSD': [
-        'pkg delete -y sysutils/py-salt',
+        'pkg delete -y swig sysutils/py-salt',
         'pkg autoremove -y'
     ]
 }

--- a/tests/bootstrap/test_install.py
+++ b/tests/bootstrap/test_install.py
@@ -22,6 +22,10 @@ CLEANUP_COMMANDS_BY_OS_FAMILY = {
     ],
     'RedHat': [
         'yum -y remove salt-minion salt-master'
+    ],
+    'FreeBSD': [
+        'pkg delete -y sysutils/py-salt',
+        'pkg autoremove -y'
     ]
 }
 


### PR DESCRIPTION
The following commits add FreeBSD 9.1 support along side FreeBSD 9.0. They are both pretty much the same, all they do is provide the `_freebsd_90_` and `_freebsd_91_` methods which call a `_freebsd_9x_` function.

I've also added /etc/rc.conf enabling of the daemons as per the [FreeBSD Installation Instructions](http://docs.saltstack.org/en/latest/topics/installation/freebsd.html).

Another pass has been made on the DISTRO_NAME_L setting, FreeBSD doesn't seem to like the `sed -re 's/(\s)+/_/g'` method either though `sed -re 's/[[:space:]]+/_/g'` does seem to be working in both FreeBSD and Ubuntu for me.

I've changed the name of the "salt" FreeBSD package to "sysutils/py-salt" to reflect the new package name. You could also use "py27-salt" but the fully qualified port name has the advantage of supporting any future python version defaults used in the package repository.

As a potential fix for #20 I've added the ability for the pkgng PACKAGESITE variable to be set by the environment, I'm not too sure if the `VAR=${VAR:="default"}` syntax is plain POSIX or not though.

Apologies for this being a rather disjointed set of commits, if you'd like me to break them up a bit into more logical chunks I'll happily do so.
