### PR TITLE
Install a `pyzmq` package compiled against `libzmq3`. Fixes #57.

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -922,6 +922,9 @@ install_debian_6_0_deps() {
     echowarn "PyZMQ will be installed from PyPi in order to compile it against ZMQ3"
     echowarn "This is required for long term stable minion connections to the master."
 
+    # No user interaction, libc6 restart services for example
+    export DEBIAN_FRONTEND=noninteractive
+
     if [ "x$(grep -R 'backports.debian.org' /etc/apt)" = "x" ]; then
         echo "deb http://backports.debian.org/debian-backports squeeze-backports main" >> \
             /etc/apt/sources.list.d/backports.list
@@ -971,12 +974,12 @@ install_debian_git_deps() {
     echowarn "PyZMQ will be installed from PyPi in order to compile it against ZMQ3"
     echowarn "This is required for long term stable minion connections to the master."
 
+    # No user interaction, libc6 restart services for example
+    export DEBIAN_FRONTEND=noninteractive
+
     apt-get update
     __apt_get_noinput lsb-release python python-pkg-resources python-crypto \
         python-jinja2 python-m2crypto python-yaml msgpack-python git
-
-    # Building pyzmq from source to build it against libzmq3
-    pip install pyzmq
 
     __git_clone_and_checkout
 
@@ -1017,6 +1020,10 @@ install_debian_6_0() {
 
 install_debian_git() {
     python setup.py install --install-layout=deb
+
+    # Building pyzmq from source to build it against libzmq3.
+    # Should override current installation
+    pip install -U pyzmq
 }
 
 install_debian_6_0_git() {

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -937,8 +937,8 @@ Pin-Priority: 800
 _eof
 
     apt-get update
-    apt-get install -t experimental libzmq3 libzmq3-dev
-    apt-get install build-essential python-dev
+    __apt_get_noinput -t experimental libzmq3 libzmq3-dev
+    __apt_get_noinput build-essential python-dev
 }
 
 install_debian_git_deps() {

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -939,14 +939,15 @@ _eof
     apt-get update
     apt-get install -t experimental libzmq3 libzmq3-dev
     apt-get install build-essential python-dev
-    # Building pyzmq from source to build it against libzmq3
-    pip install pyzmq
 }
 
 install_debian_git_deps() {
     apt-get update
     __apt_get_noinput lsb-release python python-pkg-resources python-crypto \
         python-jinja2 python-m2crypto python-yaml msgpack-python git
+
+    # Building pyzmq from source to build it against libzmq3
+    pip install pyzmq
 
     __git_clone_and_checkout
 
@@ -974,6 +975,10 @@ install_debian_stable() {
         packages="${packages} salt-syndic"
     fi
     __apt_get_noinput ${packages}
+
+    # Building pyzmq from source to build it against libzmq3.
+    # Should override current installation
+    pip install -U pyzmq
 }
 
 

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -921,13 +921,32 @@ _eof
         wget -q http://debian.madduck.net/repo/gpg/archive.key -O - | apt-key add -
     fi
 
+    cat <<_eof > /etc/apt/sources.list.d/debian-experimental.list
+deb http://ftp.debian.org/debian experimental main
+deb-src http://ftp.debian.org/debian experimental main
+_eof
+
+    cat <<_eof > /etc/apt/preferences.d/libzmq3-debian-experimental.pref
+Package: libzmq3
+Pin: release a=experimental
+Pin-Priority: 800
+
+Package: libzmq3-dev
+Pin: release a=experimental
+Pin-Priority: 800
+_eof
+
     apt-get update
+    apt-get install -t experimental libzmq3 libzmq3-dev
+    apt-get install build-essential python-dev
+    # Building pyzmq from source to build it against libzmq3
+    pip install pyzmq
 }
 
 install_debian_git_deps() {
     apt-get update
     __apt_get_noinput lsb-release python python-pkg-resources python-crypto \
-        python-jinja2 python-m2crypto python-yaml msgpack-python git python-zmq
+        python-jinja2 python-m2crypto python-yaml msgpack-python git
 
     __git_clone_and_checkout
 

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -924,12 +924,13 @@ _eof
         wget -q http://debian.madduck.net/repo/gpg/archive.key -O - | apt-key add -
     fi
 
-    cat <<_eof > /etc/apt/sources.list.d/debian-experimental.list
+    if [ ! -f /etc/apt/sources.list.d/debian-experimental.list ]; then
+        cat <<_eof > /etc/apt/sources.list.d/debian-experimental.list
 deb http://ftp.debian.org/debian experimental main
 deb-src http://ftp.debian.org/debian experimental main
 _eof
 
-    cat <<_eof > /etc/apt/preferences.d/libzmq3-debian-experimental.pref
+        cat <<_eof > /etc/apt/preferences.d/libzmq3-debian-experimental.pref
 Package: libzmq3
 Pin: release a=experimental
 Pin-Priority: 800
@@ -938,6 +939,7 @@ Package: libzmq3-dev
 Pin: release a=experimental
 Pin-Priority: 800
 _eof
+    fi
 
     apt-get update
     __apt_get_noinput -t experimental libzmq3 libzmq3-dev

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -899,6 +899,7 @@ install_debian_deps() {
 }
 
 install_debian_6_0_deps() {
+    [ $PIP_ALLOWED -eq $BS_FALSE ] && pip_not_allowed
     echowarn "PyZMQ will be installed from PyPi in order to compile it against ZMQ3"
     echowarn "This is required for long term stable minion connections to the master."
 
@@ -947,6 +948,7 @@ _eof
 }
 
 install_debian_git_deps() {
+    [ $PIP_ALLOWED -eq $BS_FALSE ] && pip_not_allowed
     echowarn "PyZMQ will be installed from PyPi in order to compile it against ZMQ3"
     echowarn "This is required for long term stable minion connections to the master."
 

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -899,6 +899,9 @@ install_debian_deps() {
 }
 
 install_debian_6_0_deps() {
+    echowarn "PyZMQ will be installed from PyPi in order to compile it against ZMQ3"
+    echowarn "This is required for long term stable minion connections to the master."
+
     if [ "x$(grep -R 'backports.debian.org' /etc/apt)" = "x" ]; then
         echo "deb http://backports.debian.org/debian-backports squeeze-backports main" >> \
             /etc/apt/sources.list.d/backports.list
@@ -942,6 +945,9 @@ _eof
 }
 
 install_debian_git_deps() {
+    echowarn "PyZMQ will be installed from PyPi in order to compile it against ZMQ3"
+    echowarn "This is required for long term stable minion connections to the master."
+
     apt-get update
     __apt_get_noinput lsb-release python python-pkg-resources python-crypto \
         python-jinja2 python-m2crypto python-yaml msgpack-python git

--- a/tests/bootstrap/test_install.py
+++ b/tests/bootstrap/test_install.py
@@ -448,6 +448,12 @@ class InstallationTestCase(BootstrapTestCase):
         '''
         Test if installing a salt-syndic works
         '''
+        if GRAINS['os'] == 'Debian':
+            self.skipTest(
+                'Currently the debian stable package will have the syndic '
+                'waiting for a connection to a master.'
+            )
+
         args = []
         if GRAINS['os'] in OS_REQUIRES_PIP_ALLOWED:
             args.append('-P')

--- a/tests/bootstrap/test_install.py
+++ b/tests/bootstrap/test_install.py
@@ -66,6 +66,15 @@ CLEANUP_COMMANDS_BY_OS_FAMILY = {
     ]
 }
 
+OS_REQUIRES_PIP_ALLOWED = (
+    # Some distributions can only install salt or some of its dependencies
+    # passing -P to the bootstrap script.
+    # The GRAINS['os'] which are in this list, requires that extra argument.
+    'Debian',
+    'SmartOS',
+    'Suse'  # Need to revisit openSUSE and SLES for the proper OS grain.
+)
+
 # SLES grains differ from openSUSE, let do a 1:1 direct mapping
 CLEANUP_COMMANDS_BY_OS_FAMILY['SUSE  Enterprise Server'] = CLEANUP_COMMANDS_BY_OS_FAMILY['Suse']
 
@@ -135,10 +144,15 @@ class InstallationTestCase(BootstrapTestCase):
         if not os.path.exists('/bin/bash'):
             self.skipTest('\'/bin/bash\' was not found on this system')
 
+        args = []
+        if GRAINS['os'] in OS_REQUIRES_PIP_ALLOWED:
+            args.append('-P')
+
         self.assert_script_result(
             'Failed to install using bash',
             0,
             self.run_script(
+                args=args,
                 executable='/bin/bash',
                 timeout=15 * 60,
                 stream_stds=True
@@ -147,7 +161,7 @@ class InstallationTestCase(BootstrapTestCase):
 
         # Try to get the versions report
         self.assert_script_result(
-            'Failed to the versions report',
+            'Failed to get the versions report (\'--versions-report\')',
             0,
             self.run_script(
                 script=None,
@@ -158,10 +172,15 @@ class InstallationTestCase(BootstrapTestCase):
         )
 
     def test_install_using_sh(self):
+        args = []
+        if GRAINS['os'] in OS_REQUIRES_PIP_ALLOWED:
+            args.append('-P')
+
         self.assert_script_result(
             'Failed to install using sh',
             0,
             self.run_script(
+                args=args,
                 timeout=15 * 60,
                 stream_stds=True
             )
@@ -169,7 +188,7 @@ class InstallationTestCase(BootstrapTestCase):
 
         # Try to get the versions report
         self.assert_script_result(
-            'Failed to the versions report',
+            'Failed to get the versions report (\'--versions-report\')',
             0,
             self.run_script(
                 script=None,
@@ -180,11 +199,17 @@ class InstallationTestCase(BootstrapTestCase):
         )
 
     def test_install_explicit_stable(self):
+        args = []
+        if GRAINS['os'] in OS_REQUIRES_PIP_ALLOWED:
+            args.append('-P')
+
+        args.append('stable')
+
         self.assert_script_result(
             'Failed to install explicit stable using sh',
             0,
             self.run_script(
-                args=('stable',),
+                args=args,
                 timeout=15 * 60,
                 stream_stds=True
             )
@@ -192,7 +217,7 @@ class InstallationTestCase(BootstrapTestCase):
 
         # Try to get the versions report
         self.assert_script_result(
-            'Failed to the versions report',
+            'Failed to get the versions report (\'--versions-report\')',
             0,
             self.run_script(
                 script=None,
@@ -203,8 +228,14 @@ class InstallationTestCase(BootstrapTestCase):
         )
 
     def test_install_daily(self):
+        args = []
+        if GRAINS['os'] in OS_REQUIRES_PIP_ALLOWED:
+            args.append('-P')
+
+        args.append('daily')
+
         rc, out, err = self.run_script(
-            args=('daily',), timeout=15 * 60, stream_stds=True
+            args=args, timeout=15 * 60, stream_stds=True
         )
         if GRAINS['os'] == 'Ubuntu':
             self.assert_script_result(
@@ -214,7 +245,7 @@ class InstallationTestCase(BootstrapTestCase):
 
             # Try to get the versions report
             self.assert_script_result(
-                'Failed to the versions report',
+                'Failed to get the versions report (\'--versions-report\')',
                 0,
                 self.run_script(
                     script=None,
@@ -230,12 +261,16 @@ class InstallationTestCase(BootstrapTestCase):
             )
 
     def test_install_stable_piped_through_sh(self):
+        args = 'cat {0} | sh '.format(BOOTSTRAP_SCRIPT_PATH).split()
+        if GRAINS['os'] in OS_REQUIRES_PIP_ALLOWED:
+            args.extend('-s -- -P'.split())
+
         self.assert_script_result(
             'Failed to install stable piped through sh',
             0,
             self.run_script(
                 script=None,
-                args='cat {0} | sh '.format(BOOTSTRAP_SCRIPT_PATH).split(),
+                args=args,
                 timeout=15 * 60,
                 stream_stds=True
             )
@@ -243,7 +278,7 @@ class InstallationTestCase(BootstrapTestCase):
 
         # Try to get the versions report
         self.assert_script_result(
-            'Failed to the versions report',
+            'Failed to get the versions report (\'--versions-report\')',
             0,
             self.run_script(
                 script=None,
@@ -254,11 +289,17 @@ class InstallationTestCase(BootstrapTestCase):
         )
 
     def test_install_latest_from_git_develop(self):
+        args = []
+        if GRAINS['os'] in OS_REQUIRES_PIP_ALLOWED:
+            args.append('-P')
+
+        args.extend(['git', 'develop'])
+
         self.assert_script_result(
             'Failed to install using latest git develop',
             0,
             self.run_script(
-                args=('git', 'develop'),
+                args=args,
                 timeout=15 * 60,
                 stream_stds=True
             )
@@ -266,7 +307,7 @@ class InstallationTestCase(BootstrapTestCase):
 
         # Try to get the versions report
         self.assert_script_result(
-            'Failed to the versions report',
+            'Failed to get the versions report (\'--versions-report\')',
             0,
             self.run_script(
                 script=None,
@@ -277,11 +318,17 @@ class InstallationTestCase(BootstrapTestCase):
         )
 
     def test_install_specific_git_tag(self):
+        args = []
+        if GRAINS['os'] in OS_REQUIRES_PIP_ALLOWED:
+            args.append('-P')
+
+        args.extend(['git', 'v0.13.1'])
+
         self.assert_script_result(
             'Failed to install using specific git tag',
             0,
             self.run_script(
-                args=('git', 'v0.13.1'),
+                args=args,
                 timeout=15 * 60,
                 stream_stds=True
             )
@@ -289,7 +336,7 @@ class InstallationTestCase(BootstrapTestCase):
 
         # Try to get the versions report
         self.assert_script_result(
-            'Failed to the versions report',
+            'Failed to get the versions report (\'--versions-report\')',
             0,
             self.run_script(
                 script=None,
@@ -300,11 +347,17 @@ class InstallationTestCase(BootstrapTestCase):
         )
 
     def test_install_specific_git_sha(self):
+        args = []
+        if GRAINS['os'] in OS_REQUIRES_PIP_ALLOWED:
+            args.append('-P')
+
+        args.extend(['git', '2b6264de62bf2ea221bb2c0b8af36dfcfaafe7cf'])
+
         self.assert_script_result(
             'Failed to install using specific git sha',
             0,
             self.run_script(
-                args=('git', '2b6264de62bf2ea221bb2c0b8af36dfcfaafe7cf'),
+                args=args,
                 timeout=15 * 60,
                 stream_stds=True
             )
@@ -312,7 +365,7 @@ class InstallationTestCase(BootstrapTestCase):
 
         # Try to get the versions report
         self.assert_script_result(
-            'Failed to the versions report',
+            'Failed to get the versions report (\'--versions-report\')',
             0,
             self.run_script(
                 script=None,
@@ -363,11 +416,17 @@ class InstallationTestCase(BootstrapTestCase):
         '''
         Test if installing a salt-master works
         '''
+        args = []
+        if GRAINS['os'] in OS_REQUIRES_PIP_ALLOWED:
+            args.append('-P')
+
+        args.extend(['-N', '-M'])
+
         self.assert_script_result(
             'Failed to install salt-master',
             0,
             self.run_script(
-                args=('-N', '-M'),
+                args=args,
                 timeout=15 * 60,
                 stream_stds=True
             )
@@ -389,11 +448,17 @@ class InstallationTestCase(BootstrapTestCase):
         '''
         Test if installing a salt-syndic works
         '''
+        args = []
+        if GRAINS['os'] in OS_REQUIRES_PIP_ALLOWED:
+            args.append('-P')
+
+        args.extend(['-N', '-S'])
+
         self.assert_script_result(
             'Failed to install salt-syndic',
             0,
             self.run_script(
-                args=('-N', '-S'),
+                args=args,
                 timeout=15 * 60,
                 stream_stds=True
             )
@@ -406,6 +471,29 @@ class InstallationTestCase(BootstrapTestCase):
             self.run_script(
                 script=None,
                 args=('salt-syndic', '--versions-report'),
+                timeout=15 * 60,
+                stream_stds=True
+            )
+        )
+
+    def test_install_pip_not_allowed(self):
+        '''
+        Check if distributions which require `-P` to allow pip to install
+        packages, fail if that flag is not passed.
+        '''
+        if GRAINS['os'] not in OS_REQUIRES_PIP_ALLOWED:
+            self.skipTest(
+                'Distribution {0} does not require the extra `-P` flag'.format(
+                    GRAINS['os']
+                )
+            )
+
+        self.assert_script_result(
+            'Even though {0} is flagged as requiring the extra `-P` flag to '
+            'allow packages to be installed by pip, it did not fail when we '
+            'did not pass it'.format(GRAINS['os']),
+            1,
+            self.run_script(
                 timeout=15 * 60,
                 stream_stds=True
             )

--- a/tests/bootstrap/unittesting.py
+++ b/tests/bootstrap/unittesting.py
@@ -54,6 +54,7 @@ BOOTSTRAP_SCRIPT_PATH = os.path.join(PARENT_DIR, 'bootstrap-salt.sh')
 
 
 class NonBlockingPopen(subprocess.Popen):
+
     def __init__(self, *args, **kwargs):
         self.stream_stds = kwargs.pop('stream_stds', False)
         super(NonBlockingPopen, self).__init__(*args, **kwargs)

--- a/tests/install-testsuite-deps.py
+++ b/tests/install-testsuite-deps.py
@@ -61,7 +61,7 @@ elif GRAINS['os_family'] == 'Debian':
     COMMANDS.extend([
         'apt-get install -y -o Dpkg::Options::="--force-confdef" '
         '-o Dpkg::Options::="--force-confold" git python-pip',
-        'sudo pip install unittest2'
+        'pip install unittest2'
     ])
 else:
     print(

--- a/tests/install-testsuite-deps.py
+++ b/tests/install-testsuite-deps.py
@@ -59,7 +59,7 @@ elif GRAINS['osfullname'].startswith('SUSE Linux Enterprise Server'):
     ])
 elif GRAINS['os_family'] == 'Debian':
     COMMANDS.extend([
-        'sudo apt-get install -y -o Dpkg::Options::="--force-confdef" '
+        'apt-get install -y -o Dpkg::Options::="--force-confdef" '
         '-o Dpkg::Options::="--force-confold" git python-pip',
         'sudo pip install unittest2'
     ])

--- a/tests/install-testsuite-deps.py
+++ b/tests/install-testsuite-deps.py
@@ -57,6 +57,12 @@ elif GRAINS['osfullname'].startswith('SUSE Linux Enterprise Server'):
         'zypper --non-interactive install --auto-agree-with-licenses git python-pip',
         'pip install unittest2'
     ])
+elif GRAINS['os_family'] == 'Debian':
+    COMMANDS.extend([
+        'sudo apt-get install -y -o Dpkg::Options::="--force-confdef" '
+        '-o Dpkg::Options::="--force-confold" git python-pip',
+        'sudo pip install unittest2'
+    ])
 else:
     print(
         'Failed gather the proper commands to allow the tests suite to be '


### PR DESCRIPTION
Although Debian experimental has `libzmq3`, it does not have `pyzmq` compiled against it. We install `pyzmq` from `pip` having `libzmq3` already installed.

**Should we really do this?**
**Even the stable builds are installing `pyzmq` from pip.**
