### PR TITLE
Removed '&' symbol from the start function for CentOS. Fixes Issue 61.

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1194,7 +1194,7 @@ install_centos_restart_daemons() {
         if [ -f /etc/init.d/salt-$fname ]; then
             # Still in SysV init!?
             /etc/init.d/salt-$fname stop > /dev/null 2>&1
-            /etc/init.d/salt-$fname start &
+            /etc/init.d/salt-$fname start
         fi
     done
 }


### PR DESCRIPTION
I took a look at the script and modified the script for the restart daemons function. Simply removing the & to force to the background lets the script work as expected.
