### PR TITLE
Fix FreeBSD function detection

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -391,7 +391,7 @@ __camelcase_split() {
 #   DESCRIPTION:  Strip duplicate strings
 #-------------------------------------------------------------------------------
 __strip_duplicates() {
-    echo $@ | sed -r 's/[[:space:]]/\n/g' | awk '!x[$0]++'
+    echo $@ | tr -s '[:space:]' '\n' | awk '!x[$0]++'
 }
 
 #---  FUNCTION  ----------------------------------------------------------------


### PR DESCRIPTION
The addition of the `__strip_duplicates` function seems to have broken installation on FreeBSD as the `sed` call ends up replacing all of the spaces with 'n' which is obviously not the intended result.

I've replaced the use of `sed` with `tr` which can match the '[:space:]' character class and, seemingly more portably, replace it with a newline before piping the resulting output through `awk`.

I've run the tests and they pass on FreeBSD.
