### PR TITLE
Added fetch & reset to refresh existing repo.

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -722,9 +722,16 @@ __git_clone_and_checkout() {
     SALT_GIT_CHECKOUT_DIR=/tmp/git/salt
     [ -d /tmp/git ] || mkdir /tmp/git
     cd /tmp/git
-    [ -d $SALT_GIT_CHECKOUT_DIR ] || git clone git://github.com/saltstack/salt.git salt
-    cd salt
-    git checkout $GIT_REV
+    if [ -d $SALT_GIT_CHECKOUT_DIR ]; then
+        cd $SALT_GIT_CHECKOUT_DIR
+
+        git fetch
+        git reset --hard origin/$GIT_REV
+    else
+        git clone git://github.com/saltstack/salt.git salt
+        cd $SALT_GIT_CHECKOUT_DIR
+        git checkout $GIT_REV
+    fi
 }
 
 


### PR DESCRIPTION
When bootstrap is run more than once on a machine, the existing git
checkout is now refreshed instead of just used as is.
