### PR TITLE
Added INSTALL_DEBIAN_INIT_SCRIPT test.

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -869,7 +869,7 @@ install_ubuntu_git_post() {
         [ $fname = "master" ] && [ $INSTALL_MASTER -eq $BS_FALSE ] && continue
         [ $fname = "syndic" ] && [ $INSTALL_SYNDIC -eq $BS_FALSE ] && continue
 
-        if [ -f /sbin/initctl ]; then
+        if [ -z ${INSTALL_DEBIAN_INIT_SCRIPT} ] && [ -f /sbin/initctl ]; then
             # We have upstart support
             /sbin/initctl status salt-$fname > /dev/null 2>&1
             if [ $? -eq 1 ]; then


### PR DESCRIPTION
This checks for the INSTALL_DEBIAN_INIT_SCRIPT environment variable and
will skip trying to install upstart.  This is a method of installing the
salt-minion init script on an Ubuntu LXC because upstart wasn't working.
The method for bootstrapping salt in the LXC is like so:

```
lxc_bootstrap_salt:
  cmd.run:
    - name: INSTALL_DEBIAN_INIT_SCRIPT=1 lxc-unshare -s MOUNT -- chroot "{{ container['rootfs'] }}" sh {{ bootstrap_salt }} git develop
    - unless: test -e {{ container['rootfs'] }}/usr/bin/salt
    - require:
      - file: {{ container['rootfs'] }}{{ bootstrap_salt }}
```
