### PR TITLE
Don't use `&` to detach commands since it won't work when used in `salt-cloud` as a deploy script.

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -882,7 +882,7 @@ install_ubuntu_restart_daemons() {
             fi
         fi
         /etc/init.d/salt-$fname stop > /dev/null 2>&1
-        /etc/init.d/salt-$fname start &
+        /etc/init.d/salt-$fname start
     done
 }
 #
@@ -995,7 +995,7 @@ install_debian_restart_daemons() {
         [ $fname = "syndic" ] && [ $INSTALL_SYNDIC -eq $BS_FALSE ] && continue
 
         /etc/init.d/salt-$fname stop > /dev/null 2>&1
-        /etc/init.d/salt-$fname start &
+        /etc/init.d/salt-$fname start
     done
 }
 #
@@ -1449,7 +1449,7 @@ install_arch_linux_restart_daemons() {
             continue
         fi
         /etc/rc.d/salt-$fname stop > /dev/null 2>&1
-        /etc/rc.d/salt-$fname start &
+        /etc/rc.d/salt-$fname start
     done
 }
 #
@@ -1556,7 +1556,7 @@ install_freebsd_restart_daemons() {
         [ $fname = "syndic" ] && [ $INSTALL_SYNDIC -eq $BS_FALSE ] && continue
 
         service salt_$fname stop > /dev/null 2>&1
-        service salt_$fname start &
+        service salt_$fname start
     done
 }
 #


### PR DESCRIPTION
Don't use `&` to detach commands since it won't work when used in `salt-cloud` as a deploy script.
