### PR TITLE
Properly refresh branches.

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -730,6 +730,7 @@ __git_clone_and_checkout() {
     if [ -d $SALT_GIT_CHECKOUT_DIR ]; then
         cd $SALT_GIT_CHECKOUT_DIR
         git fetch
+        git fetch --tags
         git checkout $GIT_REV
 
         # Just calling `git reset --hard $GIT_REV` on a branch name that has
@@ -749,8 +750,6 @@ __git_clone_and_checkout() {
         cd $SALT_GIT_CHECKOUT_DIR
         git checkout $GIT_REV
     fi
-    # Tags are needed because of salt's versioning, also fetch that
-    git fetch --tags
 }
 
 

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -738,7 +738,7 @@ __git_clone_and_checkout() {
         # if it is a branch name, check out the branch, and pull in the
         # changes.
         git branch -a | grep -q ${GIT_REV}
-        if [ "$?" == "0" ]; then
+        if [ $? -eq 0 ]; then
             git pull --rebase
         fi;
     else

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -731,7 +731,7 @@ __git_clone_and_checkout() {
         cd $SALT_GIT_CHECKOUT_DIR
         git fetch
         git fetch --tags
-        git checkout $GIT_REV
+        git reset --hard $GIT_REV
 
         # Just calling `git reset --hard $GIT_REV` on a branch name that has
         # already been checked out will not update that branch to the upstream

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -737,8 +737,11 @@ __git_clone_and_checkout() {
         # HEAD; instead it will simply reset to itself.  Check the ref to see
         # if it is a branch name, check out the branch, and pull in the
         # changes.
+        set +e
         git branch -a | grep -q ${GIT_REV}
-        if [ $? -eq 0 ]; then
+        status=$?
+        set -e
+        if [ $status -eq 0 ]; then
             git pull --rebase
         fi;
     else

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -730,7 +730,17 @@ __git_clone_and_checkout() {
     if [ -d $SALT_GIT_CHECKOUT_DIR ]; then
         cd $SALT_GIT_CHECKOUT_DIR
         git fetch
-        git reset --hard $GIT_REV
+        git checkout $GIT_REV
+
+        # Just calling `git reset --hard $GIT_REV` on a branch name that has
+        # already been checked out will not update that branch to the upstream
+        # HEAD; instead it will simply reset to itself.  Check the ref to see
+        # if it is a branch name, check out the branch, and pull in the
+        # changes.
+        git branch -a | grep -q ${GIT_REV}
+        if [ "$?" == "0" ]; then
+            git pull --rebase
+        fi;
     else
         git clone https://github.com/saltstack/salt.git salt
         cd $SALT_GIT_CHECKOUT_DIR


### PR DESCRIPTION
Just calling `git reset --hard` on a branch name doesn't pull in
upstream changes.
