### PR TITLE
Several fixes and improvements

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -334,11 +334,6 @@ exec 2>&-
 exec 2>$LOGPIPE
 
 
-# Any subsequent commands which fail and are not handled(catch), will cause the
-# shell script to exit immediately.
-set -e
-
-
 #---  FUNCTION  ----------------------------------------------------------------
 #          NAME:  __gather_hardware_info
 #   DESCRIPTION:  Discover hardware information
@@ -729,15 +724,16 @@ __git_clone_and_checkout() {
     cd /tmp/git
     if [ -d $SALT_GIT_CHECKOUT_DIR ]; then
         cd $SALT_GIT_CHECKOUT_DIR
-        git fetch
-        git reset --hard $GIT_REV
+        git fetch || return 1
+        git reset --hard $GIT_REV || return 1
     else
-        git clone https://github.com/saltstack/salt.git salt
+        git clone https://github.com/saltstack/salt.git salt || return 1
         cd $SALT_GIT_CHECKOUT_DIR
-        git checkout $GIT_REV
+        git checkout $GIT_REV || return 1
     fi
     # Tags are needed because of salt's versioning, also fetch that
-    git fetch --tags
+    git fetch --tags || return 1
+    return 0
 }
 
 
@@ -833,13 +829,15 @@ install_ubuntu_git_deps() {
     install_ubuntu_deps
     __apt_get_noinput git-core python-yaml python-m2crypto python-crypto msgpack-python python-zmq python-jinja2
 
-    __git_clone_and_checkout
+    __git_clone_and_checkout || return 1
 
     # Let's trigger config_salt()
     if [ "$TEMP_CONFIG_DIR" = "null" ]; then
         TEMP_CONFIG_DIR="${SALT_GIT_CHECKOUT_DIR}/conf/"
         CONFIG_SALT_FUNC="config_salt"
     fi
+
+    return 0
 }
 
 install_ubuntu_11_10_post() {
@@ -994,13 +992,15 @@ install_debian_git_deps() {
     __apt_get_noinput lsb-release python python-pkg-resources python-crypto \
         python-jinja2 python-m2crypto python-yaml msgpack-python python-pip git
 
-    __git_clone_and_checkout
+    __git_clone_and_checkout || return 1
 
     # Let's trigger config_salt()
     if [ "$TEMP_CONFIG_DIR" = "null" ]; then
         TEMP_CONFIG_DIR="${SALT_GIT_CHECKOUT_DIR}/conf/"
         CONFIG_SALT_FUNC="config_salt"
     fi
+
+    return 0
 }
 
 install_debian_6_0_git_deps() {
@@ -1099,13 +1099,15 @@ install_fedora_git_deps() {
     install_fedora_deps
     yum install -y git
 
-    __git_clone_and_checkout
+    __git_clone_and_checkout || return 1
 
     # Let's trigger config_salt()
     if [ "$TEMP_CONFIG_DIR" = "null" ]; then
         TEMP_CONFIG_DIR="${SALT_GIT_CHECKOUT_DIR}/conf/"
         CONFIG_SALT_FUNC="config_salt"
     fi
+
+    return 0
 }
 
 install_fedora_git() {
@@ -1204,7 +1206,7 @@ install_centos_git_deps() {
     install_centos_stable_deps
     yum -y install git --enablerepo=epel-testing
 
-    __git_clone_and_checkout
+    __git_clone_and_checkout || return 1
 
     # Let's trigger config_salt()
     if [ "$TEMP_CONFIG_DIR" = "null" ]; then
@@ -1212,6 +1214,7 @@ install_centos_git_deps() {
         CONFIG_SALT_FUNC="config_salt"
     fi
 
+    return 0
 }
 
 install_centos_git() {
@@ -1393,13 +1396,15 @@ install_amazon_linux_ami_git_deps() {
     install_amazon_linux_ami_deps
     yum -y install git --enablerepo=epel-testing
 
-    __git_clone_and_checkout
+    __git_clone_and_checkout || return 1
 
     # Let's trigger config_salt()
     if [ "$TEMP_CONFIG_DIR" = "null" ]; then
         TEMP_CONFIG_DIR="${SALT_GIT_CHECKOUT_DIR}/conf/"
         CONFIG_SALT_FUNC="config_salt"
     fi
+
+    return 0
 }
 
 install_amazon_linux_ami_stable() {
@@ -1445,13 +1450,15 @@ Server = http://intothesaltmine.org/archlinux
         python2-jinja  python2-m2crypto python2-markupsafe python2-msgpack \
         python2-psutil python2-pyzmq zeromq
 
-    __git_clone_and_checkout
+    __git_clone_and_checkout || return 1
 
     # Let's trigger config_salt()
     if [ "$TEMP_CONFIG_DIR" = "null" ]; then
         TEMP_CONFIG_DIR="${SALT_GIT_CHECKOUT_DIR}/conf/"
         CONFIG_SALT_FUNC="config_salt"
     fi
+
+    return 0
 }
 
 install_arch_linux_stable() {
@@ -1579,12 +1586,14 @@ install_freebsd_git_deps() {
 
     /usr/local/sbin/pkg install -y swig
 
-    __git_clone_and_checkout
+    __git_clone_and_checkout || return 1
     # Let's trigger config_salt()
     if [ "$TEMP_CONFIG_DIR" = "null" ]; then
         TEMP_CONFIG_DIR="${SALT_GIT_CHECKOUT_DIR}/conf/"
         CONFIG_SALT_FUNC="config_salt"
     fi
+
+    return 0
 }
 
 install_freebsd_9_stable() {
@@ -1684,12 +1693,14 @@ install_smartos_git_deps() {
     install_smartos_deps
     pkgin -y in scmgit
 
-    __git_clone_and_checkout
+    __git_clone_and_checkout || return 1
     # Let's trigger config_salt()
     if [ "$TEMP_CONFIG_DIR" = "null" ]; then
         TEMP_CONFIG_DIR="${SALT_GIT_CHECKOUT_DIR}/conf/"
         CONFIG_SALT_FUNC="config_salt"
     fi
+
+    return 0
 }
 
 install_smartos_stable() {
@@ -1760,13 +1771,15 @@ install_opensuse_git_deps() {
     install_opensuse_stable_deps
     zypper --non-interactive install --auto-agree-with-licenses git
 
-    __git_clone_and_checkout
+    __git_clone_and_checkout || return 1
 
     # Let's trigger config_salt()
     if [ "$TEMP_CONFIG_DIR" = "null" ]; then
         TEMP_CONFIG_DIR="${SALT_GIT_CHECKOUT_DIR}/conf/"
         CONFIG_SALT_FUNC="config_salt"
     fi
+
+    return 0
 }
 
 install_opensuse_stable() {
@@ -1886,13 +1899,15 @@ install_suse_11_git_deps() {
     install_suse_11_stable_deps
     zypper --non-interactive install --auto-agree-with-licenses git
 
-    __git_clone_and_checkout
+    __git_clone_and_checkout || return 1
 
     # Let's trigger config_salt()
     if [ "$TEMP_CONFIG_DIR" = "null" ]; then
         TEMP_CONFIG_DIR="${SALT_GIT_CHECKOUT_DIR}/conf/"
         CONFIG_SALT_FUNC="config_salt"
     fi
+
+    return 0
 }
 
 install_suse_11_stable() {

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -205,8 +205,8 @@ __check_unparsed_options() {
 
 # Check that we're actually installing one of minion/master/syndic
 if [ $INSTALL_MINION -eq $BS_FALSE ] && [ $INSTALL_MASTER -eq $BS_FALSE ] && [ $INSTALL_SYNDIC -eq $BS_FALSE ] && [ $CONFIG_ONLY -eq $BS_FALSE ]; then
-    echoerror "Nothing to install or configure"
-    exit 1
+    echowarn "Nothing to install or configure"
+    exit 0
 fi
 
 if [ $CONFIG_ONLY -eq $BS_TRUE ] && [ "$TEMP_CONFIG_DIR" = "null" ]; then
@@ -2021,8 +2021,8 @@ config_salt() {
     fi
 
     if [ $CONFIG_ONLY -eq $BS_TRUE ] && [ $CONFIGURED_ANYTHING -eq $BS_FALSE ]; then
-        echoerror "No configuration or keys were copied over. No configuration was done!"
-        exit 1
+        echowarn "No configuration or keys were copied over. No configuration was done!"
+        exit 0
     fi
 }
 #

--- a/tests/bootstrap/test_install.py
+++ b/tests/bootstrap/test_install.py
@@ -506,3 +506,72 @@ class InstallationTestCase(BootstrapTestCase):
                 stream_stds=True
             )
         )
+
+    def test_install_from_git_on_checked_out_repository(self):
+        '''
+        Check if the script properly updates an already checked out repository.
+        '''
+        if not os.path.isdir('/tmp/git'):
+            os.makedirs('/tmp/git')
+
+        # Clone salt from git
+        self.assert_script_result(
+            'Failed to clone salt\'s git repository',
+            0,
+            self.run_script(
+                script=None,
+                args=('git', 'clone', 'https://github.com/saltstack/salt.git'),
+                cwd='/tmp/git',
+                timeout=15 * 60,
+                stream_stds=True
+            )
+        )
+
+        # Check-out a specific revision
+        self.assert_script_result(
+            'Failed to checkout v0.12.1 from salt\'s cloned git repository',
+            0,
+            self.run_script(
+                script=None,
+                args=('git', 'checkout', 'v0.12.1'),
+                cwd='/tmp/git',
+                timeout=15 * 60,
+                stream_stds=True
+            )
+        )
+
+        # Now run the bootstrap script over an existing git checkout and see
+        # if it properly updates.
+        args = []
+        if GRAINS['os'] in OS_REQUIRES_PIP_ALLOWED:
+            args.append('-P')
+
+        args.extend(['git', 'v0.13.1'])
+
+        self.assert_script_result(
+            'Failed to install using specific git tag',
+            0,
+            self.run_script(
+                args=args,
+                timeout=15 * 60,
+                stream_stds=True
+            )
+        )
+
+        # Get the version from the salt binary just installed
+        # Do it as a two step so we can check the returning output.
+        rc, out, err = self.run_script(
+            script=None,
+            args=('salt', '--version'),
+            timeout=15 * 60,
+            stream_stds=True
+        )
+
+        self.assert_script_result(
+            'Failed to get the salt version',
+            0, (rc, out, err)
+        )
+
+        # Make sure the installation updated the git repository to the proper
+        # git tag before installing.
+        self.assertIn('v0.13.1', out)

--- a/tests/bootstrap/test_install.py
+++ b/tests/bootstrap/test_install.py
@@ -574,4 +574,4 @@ class InstallationTestCase(BootstrapTestCase):
 
         # Make sure the installation updated the git repository to the proper
         # git tag before installing.
-        self.assertIn('v0.13.1', out)
+        self.assertIn('0.13.1', '\n'.join(out))

--- a/tests/bootstrap/test_install.py
+++ b/tests/bootstrap/test_install.py
@@ -407,11 +407,19 @@ class InstallationTestCase(BootstrapTestCase):
         Test running in configuration mode only without actually configuring
         anything fails.
         '''
+        rc, out, err = self.run_script(
+            args=('-C', '-n', '-c', '/tmp'),
+        )
+
         self.assert_script_result(
-            'The script successfully executed even though no configuration '
+            'The script did not show a warning even though no configuration '
             'was done.',
-            1,
-            self.run_script(args=('-C', '-c', '/tmp'))
+            0, (rc, out, err)
+        )
+        self.assertIn(
+            'WARN: No configuration or keys were copied over. No '
+            'configuration was done!',
+            '\n'.join(out)
         )
 
     def test_install_salt_master(self):

--- a/tests/bootstrap/test_install.py
+++ b/tests/bootstrap/test_install.py
@@ -534,7 +534,7 @@ class InstallationTestCase(BootstrapTestCase):
             self.run_script(
                 script=None,
                 args=('git', 'checkout', 'v0.12.1'),
-                cwd='/tmp/git',
+                cwd='/tmp/git/salt',
                 timeout=15 * 60,
                 stream_stds=True
             )

--- a/tests/bootstrap/test_usage.py
+++ b/tests/bootstrap/test_usage.py
@@ -11,13 +11,18 @@ from bootstrap.unittesting import *
 
 
 class UsageTestCase(BootstrapTestCase):
-    def test_no_daemon_install_fails(self):
+    def test_no_daemon_install_shows_warning(self):
         '''
         Passing '-N'(no minion) without passing '-M'(install master) or
-        '-S'(install syndic) fails.
+        '-S'(install syndic) shows a warning.
         '''
-        self.assert_script_result(
-            'Not installing any daemons did not throw any error',
-            1,
-            self.run_script(args=('-N',))
+        rc, out, err = self.run_script(
+            args=('-N', '-n'),
         )
+
+        self.assert_script_result(
+            'Not installing any daemons nor configuring did not throw any '
+            'warning',
+            0, (rc, out, err)
+        )
+        self.assertIn(' *  WARN: Nothing to install or configure', out)

--- a/tests/bootstrap/unittesting.py
+++ b/tests/bootstrap/unittesting.py
@@ -98,21 +98,22 @@ class NonBlockingPopen(subprocess.Popen):
             # Not done yet
             return poll
 
-        # Allow the same attribute access even though not streaming to stds
-        try:
-            self.obuff = self.stdout.read()
-        except IOError, err:
-            if err.errno not in (11, 35):
-                # We only handle Resource not ready properly, any other
-                # raise the exception
-                raise
-        try:
-            self.ebuff = self.stderr.read()
-        except IOError, err:
-            if err.errno not in (11, 35):
-                # We only handle Resource not ready properly, any other
-                # raise the exception
-                raise
+        if not self.stream_stds:
+            # Allow the same attribute access even though not streaming to stds
+            try:
+                self.obuff = self.stdout.read()
+            except IOError, err:
+                if err.errno not in (11, 35):
+                    # We only handle Resource not ready properly, any other
+                    # raise the exception
+                    raise
+            try:
+                self.ebuff = self.stderr.read()
+            except IOError, err:
+                if err.errno not in (11, 35):
+                    # We only handle Resource not ready properly, any other
+                    # raise the exception
+                    raise
         return poll
 
 

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -65,7 +65,10 @@ def run_suite(opts, path, display_name, suffix='[!_]*.py'):
     Execute a unit test suite
     '''
     loader = TestLoader()
-    tests = loader.discover(path, suffix, TEST_DIR)
+    if opts.name:
+        tests = tests = loader.loadTestsFromName(display_name)
+    else:
+        tests = loader.discover(path, suffix, TEST_DIR)
 
     header = '{0} Tests'.format(display_name)
     print_header('Starting {0}'.format(header))
@@ -118,6 +121,12 @@ def main():
         action='store_true',
         help='Run Installation tests'
     )
+    test_selection_group.add_option(
+        '-n', '--name',
+        action='append',
+        default=[],
+        help='Specific test to run'
+    )
     parser.add_option_group(test_selection_group)
 
     output_options_group = optparse.OptionGroup(parser, "Output Options")
@@ -161,7 +170,7 @@ def main():
             )
         )
 
-    if not any((options.lint, options.usage, options.install)):
+    if not any((options.lint, options.usage, options.install, options.name)):
         options.lint = True
         options.usage = True
         options.install = True
@@ -174,6 +183,10 @@ def main():
 
     overall_status = []
 
+    if options.name:
+        for name in options.name:
+            results = run_suite(options, '', name)
+            overall_status.append(results)
     if options.lint:
         status = run_integration_suite(options, 'Lint', "*lint.py")
         overall_status.append(status)


### PR DESCRIPTION
- Added an additional setup to the bootstrap script which hecks if the installed daemons are running or not. They should.
-  Added a test case which require the cloned git repository to be updated before installing salt.
- Warn the users when nothing is going to be installed and `exit 0`. Warn the users when nothing was configured and it was supposed to configure, then `exit 0`. This simplifies other applications using the script, namely [salty-vagrant](https://github.com/saltstack/salty-vagrant).
- Add support for running a specific test case(by name).
