### PR TITLE
Disable auto exit for service status

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -890,8 +890,11 @@ install_ubuntu_git_post() {
 
         if [ -f /sbin/initctl ]; then
             # We have upstart support
+            set +e
             /sbin/initctl status salt-$fname > /dev/null 2>&1
-            if [ $? -eq 1 ]; then
+            status=$?
+            set -e
+            if [ $status -eq 1 ]; then
                 # upstart does not know about our service, let's copy the proper file
                 cp ${SALT_GIT_CHECKOUT_DIR}/pkg/salt-$fname.upstart /etc/init/salt-$fname.conf
             fi

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -912,6 +912,8 @@ install_ubuntu_restart_daemons() {
         [ $fname = "master" ] && [ $INSTALL_MASTER -eq $BS_FALSE ] && continue
         [ $fname = "syndic" ] && [ $INSTALL_SYNDIC -eq $BS_FALSE ] && continue
 
+        # disable auto-exit, trying to stop a stopped service will fail
+        set +e
         if [ -f /sbin/initctl ]; then
             # We have upstart support
             /sbin/initctl status salt-$fname > /dev/null 2>&1
@@ -927,6 +929,7 @@ install_ubuntu_restart_daemons() {
         fi
         /etc/init.d/salt-$fname stop > /dev/null 2>&1
         /etc/init.d/salt-$fname start
+        set -e
     done
 }
 #


### PR DESCRIPTION
With `set -e`, testing for the init script by calling `status` will cause the bootstrap script to exit.  Similarly, so will trying to stop a stopped service, which has happened to me when I restore a VM snapshot, but do not clear out the key on the salt master.
