### PR TITLE
lsb_release distronames for openSUSE 12.3 didn't work

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -723,6 +723,11 @@ if ([ "${DISTRO_NAME_L}" != "ubuntu" ] && [ $ITYPE = "daily" ]) && \
     echoerror "${DISTRO_NAME} does not have daily packages support"
     exit 1
 fi
+ 
+#lsb_release -si returns "openSUSE project" on openSUSE 12.3
+if [ "${DISTRO_NAME_L}" == "opensuse_project" ]; then
+    DISTRO_NAME_L="opensuse"
+fi
 
 
 #---  FUNCTION  ----------------------------------------------------------------

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -725,7 +725,7 @@ if ([ "${DISTRO_NAME_L}" != "ubuntu" ] && [ $ITYPE = "daily" ]) && \
 fi
  
 #lsb_release -si returns "openSUSE project" on openSUSE 12.3
-if [ "${DISTRO_NAME_L}" == "opensuse_project" ]; then
+if [ "${DISTRO_NAME_L}" = "opensuse_project" ]; then
     DISTRO_NAME_L="opensuse"
 fi
 

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -477,6 +477,10 @@ __gather_linux_system_info() {
             # Let's convert CamelCase to Camel Case
             DISTRO_NAME=$(__camelcase_split "$DISTRO_NAME")
         fi
+        #lsb_release -si returns "openSUSE project" on openSUSE 12.3
+        if [ "${DISTRO_NAME}" = "openSUSE project" ]; then
+            DISTRO_NAME="opensuse"
+        fi
         rv=$(lsb_release -sr)
         [ "${rv}x" != "x" ] && DISTRO_VERSION=$(__parse_version_string "$rv")
     elif [ -f /etc/lsb-release ]; then
@@ -723,12 +727,6 @@ if ([ "${DISTRO_NAME_L}" != "ubuntu" ] && [ $ITYPE = "daily" ]) && \
     echoerror "${DISTRO_NAME} does not have daily packages support"
     exit 1
 fi
- 
-#lsb_release -si returns "openSUSE project" on openSUSE 12.3
-if [ "${DISTRO_NAME_L}" = "opensuse_project" ]; then
-    DISTRO_NAME_L="opensuse"
-fi
-
 
 #---  FUNCTION  ----------------------------------------------------------------
 #          NAME:  __function_defined


### PR DESCRIPTION
shorten distroname of openSUSE from 'opensuse_project' to 'opensuse' to match install function names
