### PR TITLE
Set the FreeBSD /etc/salt dir to PREFIX/etc/salt

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1976,6 +1976,12 @@ install_freebsd_9_stable_deps() {
     echo "PACKAGESITE: ${BS_PACKAGESITE}" > /usr/local/etc/pkg.conf
 
     /usr/local/sbin/pkg install -y swig || return 1
+
+    # Lets set SALT_ETC_DIR to ports default
+    if [ "$TEMP_CONFIG_DIR" != "null" ]; then
+        SALT_ETC_DIR="/usr/local/${SALT_ETC_DIR}"
+    fi
+
     return 0
 }
 

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1978,9 +1978,7 @@ install_freebsd_9_stable_deps() {
     /usr/local/sbin/pkg install -y swig || return 1
 
     # Lets set SALT_ETC_DIR to ports default
-    if [ "$TEMP_CONFIG_DIR" != "null" ]; then
-        SALT_ETC_DIR="/usr/local/${SALT_ETC_DIR}"
-    fi
+    SALT_ETC_DIR=${BS_SALT_ETC_DIR:-/usr/local/etc/salt}
 
     return 0
 }


### PR DESCRIPTION
The FreeBSD port version of saltstack uses /usr/local/etc/salt rather
than /etc/salt for its configuration. This change fixes the use of a configuration directory when bootstrapping FreeBSD.
