### PR TITLE
Fix daemons_running() on small window installations.

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2586,7 +2586,7 @@ daemons_running() {
                 echoerror "salt-$fname was not found running"
                 FAILED_DAEMONS=$(expr $FAILED_DAEMONS + 1)
             fi
-        elif [ "x$(ps aux | grep -v grep | grep salt-$fname)" = "x" ]; then
+        elif [ "x$(ps wwwaux | grep -v grep | grep salt-$fname)" = "x" ]; then
             echoerror "salt-$fname was not found running"
             FAILED_DAEMONS=$(expr $FAILED_DAEMONS + 1)
         fi


### PR DESCRIPTION
Handily ps(1) output is truncated to the size of the window, this causes the running check to fail on consoles with small windows as the salt-{minion,master,syndic} strings will not appear properly in the output which is passed to grep(1). The use of multiple -w passed to ps(1) prevents the truncation of the process lines.
