### PR TITLE
openSUSE and Arch fixes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -11,6 +11,7 @@ Version 1.5.5:
 		* FreeBSD no longer ignores $SALT_ETC_DIR. Thanks Geoff Garside!
 		* SunOS (Make use of XPG4 binaries on SunOS). Thanks Matthieu Guegan!
 		* openSUSE (Don't fail if only one of the repositories failed to update)
+		* Arch (Fixed the GPG issues for git installations)
 
 
 Version 1.5.4:

--- a/ChangeLog
+++ b/ChangeLog
@@ -10,6 +10,7 @@ Version 1.5.5:
 		* SmartOS no longer ignores $SALT_ETC_DIR. Matthieu Guegan!
 		* FreeBSD no longer ignores $SALT_ETC_DIR. Thanks Geoff Garside!
 		* SunOS (Make use of XPG4 binaries on SunOS). Thanks Matthieu Guegan!
+		* openSUSE (Don't fail if only one of the repositories failed to update)
 
 
 Version 1.5.4:

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1903,9 +1903,7 @@ SigLevel = Optional TrustAll
 }
 
 install_arch_linux_git_deps() {
-    grep '\[salt\]' /etc/pacman.conf >/dev/null 2>&1 || echo '[salt]
-Server = http://intothesaltmine.org/archlinux
-' >> /etc/pacman.conf
+    install_arch_linux_stable_deps
 
     pacman -Sy --noconfirm pacman || return 1
     pacman -Sy --noconfirm git python2-crypto python2-distribute \

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -864,7 +864,7 @@ __git_clone_and_checkout() {
             git pull --rebase || return 1
         fi
     else
-        git clone https://github.com/saltstack/salt.git salt || return 1
+        git clone git://github.com/saltstack/salt.git || return 1
         cd $SALT_GIT_CHECKOUT_DIR
         git checkout $GIT_REV || return 1
     fi
@@ -2297,8 +2297,7 @@ install_opensuse_stable_deps() {
 
 install_opensuse_git_deps() {
     install_opensuse_stable_deps || return 1
-    zypper --non-interactive install --auto-agree-with-licenses \
-        ca-certificates-mozilla git || return 1
+    zypper --non-interactive install --auto-agree-with-licenses git || return 1
 
     __git_clone_and_checkout || return 1
 

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2282,7 +2282,13 @@ install_opensuse_stable_deps() {
             http://download.opensuse.org/repositories/devel:/languages:/python/${DISTRO_REPO}/devel:languages:python.repo || return 1
     fi
 
-    zypper --gpg-auto-import-keys --non-interactive refresh || return 1
+    zypper --gpg-auto-import-keys --non-interactive refresh
+    exitcode=$?
+    if [ $? -ne 0 ] && [ $? -ne 4 ]; then
+        # If the exit code is not 0, and it's not 4(failed to update a
+        # repository) return a failure. Otherwise continue.
+        return 1
+    fi
     zypper --non-interactive install --auto-agree-with-licenses libzmq3 python \
         python-Jinja2 python-M2Crypto python-PyYAML python-msgpack-python \
         python-pycrypto python-pyzmq || return 1

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2297,7 +2297,8 @@ install_opensuse_stable_deps() {
 
 install_opensuse_git_deps() {
     install_opensuse_stable_deps || return 1
-    zypper --non-interactive install --auto-agree-with-licenses git || return 1
+    zypper --non-interactive install --auto-agree-with-licenses \
+        ca-certificates-mozilla git || return 1
 
     __git_clone_and_checkout || return 1
 


### PR DESCRIPTION
- Don't fail if only one of the openSUSE repositories failed to update.
- Clone using the git protocol instead of HTTPS to avoid SSL errors.
- Since Arch's stable deps function just sets up the repository, call that instead of duplicating code.
