### PR TITLE
Any configuration files renamed by pacman on the installation process gets renamed back. Fixes #163.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,8 @@
 Version 1.5.6:
 	* Distro Support Fixed:
 		* Arch now upgrades it's system package properly as suggested on their mailing list.
+		* Arch now moves back any configuration files provided by the user renamed by pacman on the 
+		installation process.
 		* Fixed SmartOS detection(was being detected as Solaris) and bootstrapping. Fixed SmartOS 
 		different gcc package names for different package sets.
 		* Fixed FreeBSD git based installations(no rc.d scripts were available).

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1967,12 +1967,21 @@ install_arch_linux_git() {
 }
 
 install_arch_linux_post() {
+
     for fname in minion master syndic; do
 
         # Skip if not meant to be installed
         [ $fname = "minion" ] && [ $INSTALL_MINION -eq $BS_FALSE ] && continue
         [ $fname = "master" ] && [ $INSTALL_MASTER -eq $BS_FALSE ] && continue
         [ $fname = "syndic" ] && [ $INSTALL_SYNDIC -eq $BS_FALSE ] && continue
+
+        # Since Arch's pacman renames configuration files
+        if [ "$TEMP_CONFIG_DIR" != "null" ] && [ -f $SALT_ETC_DIR/$fname.pacorig ]; then
+            # Since a configuration directory was provided, it also means that any
+            # configuration file copied was renamed by Arch, see:
+            #   https://wiki.archlinux.org/index.php/Pacnew_and_Pacsave_Files#.pacorig
+            copyfile $SALT_ETC_DIR/$fname.pacorig $SALT_ETC_DIR/$fname $BS_TRUE
+        fi
 
         if [ -f /usr/bin/systemctl ]; then
             # Using systemd


### PR DESCRIPTION
Any configuration files renamed by pacman on the installation process gets renamed back. Fixes #163.
