### PR TITLE
Properly detect OmniOS. Refs #144

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -710,7 +710,7 @@ __gather_sunos_system_info() {
                     ;;
                 *OmniOS*)
                     DISTRO_NAME="OmniOS"
-                    DISTRO_VERSION=$(echo "$line" | awk '{print $3}'
+                    DISTRO_VERSION=$(echo "$line" | awk '{print $3}')
                     __SIMPLIFY_VERSION=$BS_FALSE
                     break
                     ;;

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -226,6 +226,8 @@ CONFIG_ONLY=$BS_FALSE
 PIP_ALLOWED=${BS_PIP_ALLOWED:-$BS_FALSE}
 SALT_ETC_DIR=${BS_SALT_ETC_DIR:-/etc/salt}
 FORCE_OVERWRITE=${BS_FORCE_OVERWRITE:-$BS_FALSE}
+# __SIMPLIFY_VERSION is mostly used in Solaris based distributions
+__SIMPLIFY_VERSION=$BS_TRUE
 
 while getopts ":hvnDc:k:MSNCPF" opt
 do
@@ -706,6 +708,12 @@ __gather_sunos_system_info() {
                     DISTRO_NAME="SmartOS"
                     break
                     ;;
+                *OmniOS*)
+                    DISTRO_NAME="OmniOS"
+                    DISTRO_VERSION=$(echo "$line" | awk '{print $3}'
+                    __SIMPLIFY_VERSION=$BS_FALSE
+                    break
+                    ;;
             esac
         done < /etc/release
     fi
@@ -799,7 +807,7 @@ if [ $INSTALL_SYNDIC -eq $BS_TRUE ]; then
 fi
 
 # Simplify version naming on functions
-if [ "x${DISTRO_VERSION}" = "x" ]; then
+if [ "x${DISTRO_VERSION}" = "x" ] || [ $__SIMPLIFY_VERSION -eq $BS_FALSE ]; then
     DISTRO_MAJOR_VERSION=""
     DISTRO_MINOR_VERSION=""
     PREFIXED_DISTRO_MAJOR_VERSION=""


### PR DESCRIPTION
```
 *  INFO: sh bs.sh -- Version 1.5.5
 *  WARN: Running the unstable version of bootstrap-salt.sh

 *  INFO: System Information:
 *  INFO:   CPU:          GenuineIntel
 *  INFO:   CPU Arch:     i86pc
 *  INFO:   OS Name:      SunOS
 *  INFO:   OS Version:   5.11
 *  INFO:   Distribution: OmniOS r151006

 *  INFO: Installing minion
 * DEBUG: install_omnios_stable_deps not found....
 * DEBUG: install_omnios_deps not found....
 * DEBUG: install_omnios_stable not found....
 * DEBUG: install_omnios_stable_post not found....
 * DEBUG: install_omnios_post not found....
 * DEBUG: install_omnios_stable_restart_daemons not found....
 * DEBUG: install_omnios_restart_daemons not found....
 * DEBUG: daemons_running_omnios_stable not found....
 * DEBUG: daemons_running_omnios not found....
 *  INFO: Found function daemons_running
 * ERROR: No dependencies installation function found. Exiting...
 * DEBUG: Removing the logging pipe /tmp/bootstrap-salt.logpipe
```

All we need now is someone to add the install functions :)

_hint hint_ @robinsmidsrod.... :smiley: 
