### PR TITLE
Copy files instead of moving is asked for. Fixes #182.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,8 @@ Version 1.5.6:
 	proper place while moving the minion configuration file.
 	* Gentoo bootstraps can now use a bin host to provide binary packages, just set the 
 	`BS_GENTOO_USE_BINHOST` environment variable.
+	* If `BS_KEEP_TEMP_FILES=1` is found on the environment, the script will copy the files instead 
+	of moving them.
 	* Distro Support Fixed:
 		* Arch now upgrades it's system package properly as suggested on their mailing list.
 		* Arch now moves back any configuration files provided by the user renamed by pacman on the 

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -26,6 +26,7 @@ ScriptName="bootstrap-salt.sh"
 #   * BS_PIP_ALLOWED:     If 1 enable pip based installations(if needed)
 #   * BS_ECHO_DEBUG:      If 1 enable debug echo which can also be set by -D
 #   * BS_SALT_ETC_DIR:    Defaults to /etc/salt
+#   * BS_KEEP_TEMP_FILES: If 1, don't move temporary files, instead copy them
 #   * BS_FORCE_OVERWRITE: Force overriding copied files(config, init.d, etc)
 #   * BS_GENTOO_USE_BINHOST: If 1 add `--getbinpkg` to gentoo's emerge
 #===============================================================================
@@ -217,6 +218,7 @@ __check_config_dir() {
 #-----------------------------------------------------------------------
 #  Handle command line arguments
 #-----------------------------------------------------------------------
+KEEP_TEMP_FILES=${BS_KEEP_TEMP_FILES:-$BS_FALSE}
 TEMP_CONFIG_DIR="null"
 TEMP_KEYS_DIR="null"
 INSTALL_MASTER=$BS_FALSE
@@ -959,6 +961,13 @@ movefile() {
         echoerror "Wrong number of arguments for movefile()"
         echoinfo "USAGE: movefile <source> <dest>  OR  movefile <source> <dest> <overwrite>"
         exit 1
+    fi
+
+    if [ $BS_KEEP_TEMP_FILES -eq $BS_TRUE ]; then
+        # We're being told not to move files, instead copy them so we can keep
+        # them around
+        echodebug "Since BS_KEEP_TEMP_FILES=1 we're copying files instead of moving them"
+        return copyfile "$sfile" "$dfile" $overwrite
     fi
 
     # Does the source file exist?

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -963,7 +963,7 @@ movefile() {
         exit 1
     fi
 
-    if [ $BS_KEEP_TEMP_FILES -eq $BS_TRUE ]; then
+    if [ $KEEP_TEMP_FILES -eq $BS_TRUE ]; then
         # We're being told not to move files, instead copy them so we can keep
         # them around
         echodebug "Since BS_KEEP_TEMP_FILES=1 we're copying files instead of moving them"


### PR DESCRIPTION
If `BS_KEEP_TEMP_FILES=1` is found on the environment, the script will copy the files instead of moving them.
