### PR TITLE
Add support for Linux Mint

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -226,6 +226,7 @@ Supported Operating Systems
 - Fedora 17/18
 - FreeBSD 9.1
 - Gentoo
+- Linux Mint 13/14
 - OpenSUSE 12.x
 - Red Hat 5/6
 - Red Hat Enterprise 5/6

--- a/tests/bootstrap/test_install.py
+++ b/tests/bootstrap/test_install.py
@@ -271,7 +271,7 @@ class InstallationTestCase(BootstrapTestCase):
         rc, out, err = self.run_script(
             args=args, timeout=15 * 60, stream_stds=True
         )
-        if GRAINS['os'] in ('Ubuntu', 'Trisquel'):
+        if GRAINS['os'] in ('Ubuntu', 'Trisquel', 'Mint'):
             self.assert_script_result(
                 'Failed to install daily',
                 0, (rc, out, err)


### PR DESCRIPTION
Add support for Linux Mint and re-use Ubuntu install functions for derivatives.

Tested on Mint 13/14, Trisquel 6, Ubuntu 10.04/12.04/12.10/13.04, and Debian 7

==> debian-7.log <==
OK (total=15, skipped=1, passed=14, failures=0, errors=0) 
============================  Overall Tests Report  ============================

==> mint-13.log <==
OK (total=15, skipped=1, passed=14, failures=0, errors=0) 
============================  Overall Tests Report  ============================

==> mint-14.log <==
OK (total=15, skipped=1, passed=14, failures=0, errors=0) 
============================  Overall Tests Report  ============================

==> trisquel-6.log <==
OK (total=15, skipped=1, passed=14, failures=0, errors=0) 
============================  Overall Tests Report  ============================

==> ubuntu-10.04.log <==
OK (total=15, skipped=1, passed=14, failures=0, errors=0) 
============================  Overall Tests Report  ============================

==> ubuntu-12.04.log <==
OK (total=15, skipped=1, passed=14, failures=0, errors=0) 
============================  Overall Tests Report  ============================

==> ubuntu-12.10.log <==
OK (total=15, skipped=1, passed=14, failures=0, errors=0) 
============================  Overall Tests Report  ============================

==> ubuntu-13.04.log <==
OK (total=15, skipped=1, passed=14, failures=0, errors=0) 
============================  Overall Tests Report  ============================
