### PR TITLE
Fix #189: Don't call yum update

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1593,7 +1593,7 @@ install_centos_stable_deps() {
         return 1
     fi
 
-    yum -y update || return 1
+    yum -y makecache || return 1
 
     if [ $DISTRO_MAJOR_VERSION -eq 5 ]; then
         yum -y install PyYAML python26-m2crypto m2crypto python26 \

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1593,8 +1593,6 @@ install_centos_stable_deps() {
         return 1
     fi
 
-    yum -y makecache || return 1
-
     if [ $DISTRO_MAJOR_VERSION -eq 5 ]; then
         yum -y install PyYAML python26-m2crypto m2crypto python26 \
             python26-crypto python26-msgpack python26-zmq \
@@ -1839,7 +1837,6 @@ install_amazon_linux_ami_deps() {
         EPEL_ARCH=$CPU_ARCH_L
     fi
     rpm -Uvh --force http://mirrors.kernel.org/fedora-epel/6/${EPEL_ARCH}/epel-release-6-8.noarch.rpm || return 1
-    yum -y update || return 1
     yum -y install PyYAML m2crypto python-crypto python-msgpack python-zmq \
         python-ordereddict python-jinja2 --enablerepo=epel || return 1
 }


### PR DESCRIPTION
This addresses the issues raised in Issue #189. 

`yum update` automatically upgrades all packages that can be updated, which is either annoying or catastrophic if it breaks running software. All Yum commands automatically refresh the cache before running, so this shouldn't be necessary.

Tested on Centos64 and found no issues.
