### PR TITLE
updated FreeBSD PACKAGESITE to use freebsd.saltstack.com

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2118,7 +2118,7 @@ __freebsd_get_packagesite() {
         echowarn "The environment variable PACKAGESITE is not set."
         echowarn "The installation will, most likely fail since pkgbeta.freebsd.org does not yet contain any packages"
     fi
-    BS_PACKAGESITE=${PACKAGESITE:-"http://pkgbeta.freebsd.org/freebsd:${DISTRO_MAJOR_VERSION}:${BSD_ARCH}/latest"}
+    BS_PACKAGESITE=${PACKAGESITE:-"http://freebsd.saltstack.com/${ABI}/"}
 
     # Treat unset variables as errors once more
     set -o nounset


### PR DESCRIPTION
I have generated and published FreeBSD salt packages at freebsd.saltstack.com. This request updates the bootstrap to use this infrastructure.
