### PR TITLE
Update to install_red_hat_linux_stable_deps function to resolve issue 198.

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1795,6 +1795,7 @@ install_red_hat_linux_stable_deps() {
     if [ $(rhn-channel -l | grep optional) != "rhel-${OPTIONAL_ARCH}-server-optional-${DISTRO_MAJOR_VERSION}" ]; then 
       echoerror "Failed to find RHN optional repo, please enable it."
       return 1
+    fi
     if [ $DISTRO_MAJOR_VERSION -eq 5 ]; then
         rpm -Uvh --force http://mirrors.kernel.org/fedora-epel/5/${EPEL_ARCH}/epel-release-5-4.noarch.rpm || return 1
     elif [ $DISTRO_MAJOR_VERSION -eq 6 ]; then

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1796,27 +1796,7 @@ install_red_hat_linux_stable_deps() {
       echoerror "Failed to find RHN optional repo, please enable it using the GUI or rhn-channel command."
       return 1
     fi
-    if [ $DISTRO_MAJOR_VERSION -eq 5 ]; then
-        rpm -Uvh --force http://mirrors.kernel.org/fedora-epel/5/${EPEL_ARCH}/epel-release-5-4.noarch.rpm || return 1
-    elif [ $DISTRO_MAJOR_VERSION -eq 6 ]; then
-        rpm -Uvh --force http://mirrors.kernel.org/fedora-epel/6/${EPEL_ARCH}/epel-release-6-8.noarch.rpm || return 1
-    else
-        echoerror "Failed add EPEL repository support."
-        return 1
-    fi
-
-    if [ $UPGRADE_SYS -eq $BS_TRUE ]; then
-        yum -y update || return 1
-    fi
-
-    if [ $DISTRO_MAJOR_VERSION -eq 5 ]; then
-        yum -y install python26-PyYAML python26-m2crypto m2crypto python26 \
-            python26-crypto python26-msgpack python26-zmq \
-            python26-jinja2 --enablerepo=${BS_EPEL_REPO} || return 1
-    else
-        yum -y install PyYAML m2crypto python-crypto python-msgpack \
-            python-zmq python-jinja2 --enablerepo=${BS_EPEL_REPO} || return 1
-    fi
+    install_centos_stable_deps || return 1
     return 0
 }
 

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1793,7 +1793,7 @@ install_red_hat_linux_stable_deps() {
         OPTIONAL_ARCH=$CPU_ARCH_L
     fi
     if [ $(rhn-channel -l | grep optional) != "rhel-${OPTIONAL_ARCH}-server-optional-${DISTRO_MAJOR_VERSION}" ]; then 
-      echoerror "Failed to find RHN optional repo, please enable it."
+      echoerror "Failed to find RHN optional repo, please enable it using the GUI or rhn-channel command."
       return 1
     fi
     if [ $DISTRO_MAJOR_VERSION -eq 5 ]; then

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1787,7 +1787,35 @@ install_centos_restart_daemons() {
 #   RedHat Install Functions
 #
 install_red_hat_linux_stable_deps() {
-    install_centos_stable_deps || return 1
+    if [ $CPU_ARCH_L = "i686" ]; then
+        OPTIONAL_ARCH="i386"
+    else
+        OPTIONAL_ARCH=$CPU_ARCH_L
+    fi
+    if [ $(rhn-channel -l | grep optional) != "rhel-${OPTIONAL_ARCH}-server-optional-${DISTRO_MAJOR_VERSION}" ]; then 
+      echoerror "Failed to find RHN optional repo, please enable it."
+      return 1
+    if [ $DISTRO_MAJOR_VERSION -eq 5 ]; then
+        rpm -Uvh --force http://mirrors.kernel.org/fedora-epel/5/${EPEL_ARCH}/epel-release-5-4.noarch.rpm || return 1
+    elif [ $DISTRO_MAJOR_VERSION -eq 6 ]; then
+        rpm -Uvh --force http://mirrors.kernel.org/fedora-epel/6/${EPEL_ARCH}/epel-release-6-8.noarch.rpm || return 1
+    else
+        echoerror "Failed add EPEL repository support."
+        return 1
+    fi
+
+    if [ $UPGRADE_SYS -eq $BS_TRUE ]; then
+        yum -y update || return 1
+    fi
+
+    if [ $DISTRO_MAJOR_VERSION -eq 5 ]; then
+        yum -y install python26-PyYAML python26-m2crypto m2crypto python26 \
+            python26-crypto python26-msgpack python26-zmq \
+            python26-jinja2 --enablerepo=${BS_EPEL_REPO} || return 1
+    else
+        yum -y install PyYAML m2crypto python-crypto python-msgpack \
+            python-zmq python-jinja2 --enablerepo=${BS_EPEL_REPO} || return 1
+    fi
     return 0
 }
 

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1792,7 +1792,7 @@ install_red_hat_linux_stable_deps() {
     else
         OPTIONAL_ARCH=$CPU_ARCH_L
     fi
-    if [ $(rhn-channel -l | grep optional) != "rhel-${OPTIONAL_ARCH}-server-optional-${DISTRO_MAJOR_VERSION}" ]; then 
+    if [ $DISTRO_MAJOR_VERSION -eq 6 ] && [ $(rhn-channel -l | grep optional) != "rhel-${OPTIONAL_ARCH}-server-optional-${DISTRO_MAJOR_VERSION}" ]; then
       echoerror "Failed to find RHN optional repo, please enable it using the GUI or rhn-channel command."
       return 1
     fi


### PR DESCRIPTION
This pull addresses concerns I raised in [issue 198](https://github.com/saltstack/salt-bootstrap/issues/198) regarding how the bootstrap errors out without a useful message for redhat users. Due to the way that the rhn-channel command operates (requiring a user/password to join to a channel) I've simply added in an error explaining that users need to enable the optional repo. At some point it might be good to expand on this, but I don't see a good way to do it right now.
