### PR TITLE
fix install_arch_linux_git_deps python2-setuptools is the correct package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/.project

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2052,7 +2052,7 @@ install_arch_linux_git_deps() {
     install_arch_linux_stable_deps
 
     pacman -Sy --noconfirm pacman || return 1
-    pacman -Sy --noconfirm git python2-crypto python2-distribute \
+    pacman -Sy --noconfirm git python2-crypto python2-setuptools \
         python2-jinja python2-m2crypto python2-markupsafe python2-msgpack \
         python2-psutil python2-yaml python2-pyzmq zeromq || return 1
 


### PR DESCRIPTION
This fixes jenkins.saltstack.com Project Salt 0.16 Rackspace Arch error

:: python2-setuptools and python2-distribute are in conflict
(setuptools). Remove python2-distribute? [y/N] error: unresolvable
package conflicts detected
error: failed to prepare transaction (conflicting dependencies)

:: python2-setuptools and python2-distribute are in conflict
