### PR TITLE
Add mint 16 eqiuvalence to Ubuntu 13.10

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -810,6 +810,9 @@ __ubuntu_derivatives_translation() {
     #linuxmint_15_ubuntu_base="13.04"
     # Bug preventing add-apt-repository from working on Mint 15:
     # https://bugs.launchpad.net/linuxmint/+bug/1198751
+
+    linuxmint_16_ubuntu_base="13.10"
+
     linaro_12_ubuntu_base="12.04"
 
     # Translate Ubuntu derivatives to their base Ubuntu version


### PR DESCRIPTION
This adds linux mint 16 support by declaring that it's Ubuntu base is 13.10.

Tested with no switches.  Not tried installing git version or anything else.
