### PR TITLE
updating bootstrap script for freebsd 10

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2427,6 +2427,10 @@ install_freebsd_9_stable_deps() {
     return 0
 }
 
+install_freebsd_10_stable_deps() {
+    install_freebsd_9_stable_deps
+}
+
 config_freebsd_salt() {
     # Set _SALT_ETC_DIR to ports default
     _SALT_ETC_DIR=${BS_SALT_ETC_DIR:-/usr/local/etc/salt}
@@ -2485,6 +2489,10 @@ install_freebsd_git_deps() {
 install_freebsd_9_stable() {
     /usr/local/sbin/pkg install ${SALT_PKG_FLAGS} -y sysutils/py-salt || return 1
     return 0
+}
+
+install_freebsd_10_stable() {
+    install_freebsd_9_stable
 }
 
 install_freebsd_git() {
@@ -2546,6 +2554,10 @@ install_freebsd_9_stable_post() {
         fi
 
     done
+}
+
+install_freebsd_10_stable_post() {
+    install_freebsd_9_stable_post
 }
 
 install_freebsd_git_post() {


### PR DESCRIPTION
Here are the updates for FreeBSD 10

I've tested this on a stock freebsd 10 system:

```
root@fbsd-qa:~ # sh bootstrap.saltstack.org
 *  INFO: sh bootstrap.saltstack.org -- Version 1.5.11

 *  INFO: System Information:
 *  INFO:   CPU:          AMD Opteron(TM) Processor 6220
 *  INFO:   CPU Arch:     amd64
 *  INFO:   OS Name:      FreeBSD
 *  INFO:   OS Version:   10.0-RELEASE
 *  INFO:   Distribution: FreeBSD 10.0

 *  INFO: Installing minion
 *  INFO: Found function install_freebsd_10_stable_deps
 *  INFO: Found function install_freebsd_10_stable
 *  INFO: Found function install_freebsd_10_stable_post
 *  INFO: Found function install_freebsd_restart_daemons
 *  INFO: Found function daemons_running
 *  INFO: Running install_freebsd_10_stable_deps()
Updating repository catalogue
The following 1 packages will be installed:

        Installing swig: 2.0.11

The installation will require 14 MB more space

3 MB to be downloaded
swig-2.0.11.txz                     100% 3319KB   3.2MB/s   3.2MB/s   00:01
Checking integrity... done
[1/1] Installing swig-2.0.11... done
 *  INFO: Running install_freebsd_10_stable()
Updating repository catalogue
The following 14 packages will be installed:

        Installing sshpass: 1.05
        Installing gmp: 5.1.3
        Installing py27-m2crypto: 0.21.1_1
        Installing py27-yaml: 3.10
        Installing libzmq4: 4.0.3
        Installing py27-msgpack: 0.4.0
        Installing py27-setuptools: 2.0.1
        Installing py27-pytz: 2013.9_1,1
        Installing py27-pycrypto: 2.6.1
        Installing py27-pyzmq: 14.0.1
        Installing py27-MarkupSafe: 0.18
        Installing py27-Babel: 1.3_1
        Installing py27-Jinja2: 2.7.1
        Installing py27-salt: 0.17.4

The installation will require 32 MB more space

6 MB to be downloaded
sshpass-1.05.txz                    100%   15KB  15.2KB/s  15.2KB/s   00:00
gmp-5.1.3.txz                       100%  421KB 420.8KB/s 420.8KB/s   00:00
py27-m2crypto-0.21.1_1.txz          100%  202KB 202.0KB/s 202.0KB/s   00:00
py27-yaml-3.10.txz                  100%   79KB  78.5KB/s  78.5KB/s   00:00
libzmq4-4.0.3.txz                   100%  309KB 308.7KB/s 308.7KB/s   00:01
py27-msgpack-0.4.0.txz              100%   56KB  56.1KB/s  56.1KB/s   00:00
py27-setuptools-2.0.1.txz           100%  304KB 304.4KB/s 304.4KB/s   00:00
py27-pytz-2013.9_1,1.txz            100%  136KB 136.3KB/s 136.3KB/s   00:00
py27-pycrypto-2.6.1.txz             100%  331KB 330.6KB/s 330.6KB/s   00:00
py27-pyzmq-14.0.1.txz               100%  253KB 253.1KB/s 253.1KB/s   00:00
py27-MarkupSafe-0.18.txz            100%   21KB  21.4KB/s  21.4KB/s   00:00
py27-Babel-1.3_1.txz                100% 2092KB   2.0MB/s   2.0MB/s   00:00
py27-Jinja2-2.7.1.txz               100%  269KB 269.0KB/s 269.0KB/s   00:00
py27-salt-0.17.4.txz                100% 1568KB   1.5MB/s   1.5MB/s   00:01
Checking integrity... done
[1/14] Installing sshpass-1.05... done
[2/14] Installing gmp-5.1.3... done
[3/14] Installing py27-m2crypto-0.21.1_1... done
[4/14] Installing py27-yaml-3.10... done
[5/14] Installing libzmq4-4.0.3... done
[6/14] Installing py27-msgpack-0.4.0... done
[7/14] Installing py27-setuptools-2.0.1... done
[8/14] Installing py27-pytz-2013.9_1,1... done
[9/14] Installing py27-pycrypto-2.6.1... done
[10/14] Installing py27-pyzmq-14.0.1... done
[11/14] Installing py27-MarkupSafe-0.18...185
230
 done
[12/14] Installing py27-Babel-1.3_1...230
252
 done
[13/14] Installing py27-Jinja2-2.7.1...252
277
 done
[14/14] Installing py27-salt-0.17.4... done
===================================================================================================

To configure a Salt Master, do the following:

  o Copy /usr/local/etc/salt/master.sample to /usr/local/etc/salt/master
  o Update to meet your needs
  o Set salt_master_enable="YES" in rc.conf

---------------------------------------------------------------------------------------------------

To configure a Salt Minion, do the following:

  o Copy /usr/local/etc/salt/minion.sample to /usr/local/etc/salt/minion
  o Update 'master: salt' to point to your Salt Master's hostname or IP
  o Set salt_minion_enable="YES" in rc.conf
  o Set salt_minion_paths="/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin" in rc.conf

===================================================================================================
 *  INFO: Running install_freebsd_10_stable_post()
 *  INFO: Running install_freebsd_restart_daemons()
Starting salt_minion.
 *  INFO: Running daemons_running()
 *  INFO: Salt installed!
```
