### PR TITLE
Allow overriding existing init.d script in CentOS

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -11,6 +11,7 @@ Version 1.5.12:
 		* FreeBSD `fetch` now has a notion of insecure certificates. Handle this properly. Thank 
 		You Mike Carlson(m87carlson).
 		* Arch, openSUSE and SuSE are now upgradable when the `-U` flag is passed.
+		* Force overwrites now works for existing init.d scripts on CentOS git installations. #259
 	* Distro Support Added:
 		* FreeBSD 10 is now also supported. Thank You Mike Carlson(m87carlson).
 		* Red Had Enterprise Workstation is now supported.

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2028,7 +2028,7 @@ install_centos_git_post() {
                 copyfile ${SALT_GIT_CHECKOUT_DIR}/pkg/salt-$fname.upstart /etc/init/salt-$fname.conf
             fi
         # Still in SysV init?!
-        elif [ ! -f /etc/init.d/salt-$fname ]; then
+        elif [ ! -f /etc/init.d/salt-$fname ] || ([ -f /etc/init.d/salt-$fname ] && [ $_FORCE_OVERWRITE -eq $BS_TRUE ]); then
             copyfile ${SALT_GIT_CHECKOUT_DIR}/pkg/rpm/salt-${fname} /etc/init.d/
             chmod +x /etc/init.d/salt-${fname}
             /sbin/chkconfig salt-${fname} on


### PR DESCRIPTION
Fixes #259
