### PR TITLE
RHEL may be RHN, but that's not default as of 6.3; try RHSM too

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2496,9 +2496,14 @@ install_red_hat_linux_stable_deps() {
     else
         OPTIONAL_ARCH=$CPU_ARCH_L
     fi
-    if [ $DISTRO_MAJOR_VERSION -eq 6 ] && case "X$(rhn-channel -l | grep optional)" in Xrhel-${OPTIONAL_ARCH}-server-optional-${DISTRO_MAJOR_VERSION}* ) false ;; * ) true ;; esac ; then
-      echoerror "Failed to find RHN optional repo, please enable it using the GUI or rhn-channel command."
-      return 1
+    if [ $DISTRO_MAJOR_VERSION -eq 6 ]; then
+      if rhn-channel -b >/dev/null 2>&1 && case "X$(rhn-channel -l | grep optional)" in Xrhel-${OPTIONAL_ARCH}-server-optional-${DISTRO_MAJOR_VERSION}* ) false ;; * ) true ;; esac ; then
+        echoerror "Failed to find RHN optional repo, please enable it using the GUI or rhn-channel command."
+        return 1
+      elif ! (yum repolist | grep -s -q server-optional-rpms); then
+        echoerror "Failed to find server-optional-rpms repo, please enable it using yum-config-manager."
+        return 1
+      fi
     fi
     install_centos_stable_deps || return 1
     return 0


### PR DESCRIPTION
Code checked rhn-channel -l to find optional repo, but later RHEL
systems use the subscription-manager form of subscription, and rhn*
commands are not enabled.  Test first with rhn-channel -b, and if
that fails, check yum repolist instead (perhaps yum repolist would
work for RHN systems, too, but I don't have one of those).

Signed-off-by: Dan Mick dan.mick@inktank.com
