### PR TITLE
Changing errors to warning and removing return statements. Why return?

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2542,11 +2542,9 @@ install_red_hat_linux_stable_deps() {
     fi
     if [ $DISTRO_MAJOR_VERSION -eq 6 ]; then
       if rhn-channel -b >/dev/null 2>&1 && case "X$(rhn-channel -l | grep optional)" in Xrhel-${OPTIONAL_ARCH}-server-optional-${DISTRO_MAJOR_VERSION}* ) false ;; * ) true ;; esac ; then
-        echoerror "Failed to find RHN optional repo, please enable it using the GUI or rhn-channel command."
-        return 1
+        echowarn "Failed to find RHN optional repo, please enable it using the GUI or rhn-channel command."
       elif ! (yum repolist | grep -s -q server-optional-rpms); then
-        echoerror "Failed to find server-optional-rpms repo, please enable it using yum-config-manager."
-        return 1
+        echowarn "Failed to find server-optional-rpms repo, please enable it using yum-config-manager."
       fi
     fi
     install_centos_stable_deps || return 1


### PR DESCRIPTION
There's no need to return. Instead just display a warning message to users and continue execution. This solves the problem where the instance creation using cloud module fails giving the following error:

```
test-master:
----------
          ID: test.minion
    Function: cloud.present
      Result: False
     Comment: An exception occurred in this state: Traceback (most recent call last):
                File "/usr/lib/python2.6/site-packages/salt/state.py", line 1492, in call
                  **cdata['kwargs'])
                File "/usr/lib/python2.6/site-packages/salt/states/cloud.py", line 106, in present
                  info = __salt__['cloud.create'](cloud_provider, name, **kwargs)
                File "/usr/lib/python2.6/site-packages/salt/modules/cloud.py", line 202, in create
                  info = client.create(provider, names, **kwargs)
                File "/usr/lib/python2.6/site-packages/salt/cloud/__init__.py", line 362, in create
                  mapper.create(vm_))
                File "/usr/lib/python2.6/site-packages/salt/cloud/__init__.py", line 1162, in create
                  output = self.clouds[func](vm_)
                File "/usr/lib/python2.6/site-packages/salt/cloud/clouds/openstack.py", line 773, in create
                  ret = salt.utils.cloud.bootstrap(vm_, __opts__)
                File "/usr/lib/python2.6/site-packages/salt/utils/cloud.py", line 418, in bootstrap
                  deployed = deploy_script(**deploy_kwargs)
                File "/usr/lib/python2.6/site-packages/salt/utils/cloud.py", line 1204, in deploy_script
                  deploy_command
              SaltCloudSystemExit: Executing the command '/tmp/.saltcloud/deploy.sh -c /tmp/.saltcloud' failed
     Started: 14:41:56.077120
     Duration: 867 ms
     Changes:   

Summary
------------
Succeeded: 0
Failed:    1
------------
Total states run:     1
```
