### PR TITLE
Export https_proxy too

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -20,6 +20,7 @@ Elias Probst                eliasp
 Erik Johnson                terminalmage           erik@saltstack.com
 Forrest Alvarez             gravyboat
 Geoff Garside               geoffgarside           geoff@geoffgarside.co.uk
+Giuseppe Iannello           giannello              giuseppe.iannello@brokenloop.net
 Guillaume Derval            GuillaumeDerval        guillaume@guillaumederval.be
                             gweis
 Henrik Holmboe              holmboe

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -418,6 +418,7 @@ fi
 # Export the http_proxy configuration to our current environment
 if [ "x${_HTTP_PROXY}" != "x" ]; then
     export http_proxy="$_HTTP_PROXY"
+    export https_proxy="$_HTTP_PROXY"
 fi
 
 # Let's discover how we're being called


### PR DESCRIPTION
On some platforms repositories can also be accessed via HTTPS, like Ubuntu PPAs. We need to export the HTTPS proxy too.
