### PR TITLE
Remove reference to curl with --insecure option on README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,7 @@ If you have certificate issues using ``curl``, try the following:
 
 .. code:: console 
 
-  curl -L https://bootstrap.saltstack.com -o install_salt.sh
+  curl --insecure -L https://bootstrap.saltstack.com -o install_salt.sh
   sudo sh install_salt.sh git develop
 
 

--- a/README.rst
+++ b/README.rst
@@ -47,14 +47,6 @@ Using ``curl`` to install latest git:
   sudo sh install_salt.sh git develop
 
 
-If you have certificate issues using ``curl``, try the following:
-
-.. code:: console 
-
-  curl --insecure -L https://bootstrap.saltstack.com -o install_salt.sh
-  sudo sh install_salt.sh git develop
-
-
 Using ``wget`` to install your distribution's stable packages:
 
 .. code:: console


### PR DESCRIPTION
Hi,

This is a minor change, I've added the `--insecure` option of `curl`, maybe it was removed unintentionally on be5e5bf5aad141286b58c63560397ce3d0eb82ec. Or maybe that paragraph makes no more sense and can be removed.
