### PR TITLE
Address amazon linux not being found

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -703,7 +703,7 @@ __gather_linux_system_info() {
 
     # shellcheck disable=SC2086
     for rsource in $(__sort_release_files "$(
-            cd /etc && /bin/ls ./*[_-]release ./*[_-]version 2>/dev/null | env -i sort | \
+            cd /etc && /bin/ls *[_-]release *[_-]version 2>/dev/null | env -i sort | \
             sed -e '/^redhat-release$/d' -e '/^lsb-release$/d'; \
             echo redhat-release lsb-release
             )"); do


### PR DESCRIPTION
the `./` prevent the script from recognizing the Amazon Linux release #418

``` diff
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -703,7 +703,7 @@ __gather_linux_system_info() {

     # shellcheck disable=SC2086
     for rsource in $(__sort_release_files "$(
-            cd /etc && /bin/ls ./*[_-]release ./*[_-]version 2>/dev/null | env -i sort | \
+            cd /etc && /bin/ls *[_-]release *[_-]version 2>/dev/null | env -i sort | \
             sed -e '/^redhat-release$/d' -e '/^lsb-release$/d'; \
             echo redhat-release lsb-release
             )"); do
```

```
+ n=./system
++ sed -e q
++ grep '[0-9]'
++ grep VERSION /etc/./system-release
++ cat /etc/./system-release
+ rv='Amazon Linux AMI release 2014.03'
+ '[' 'Amazon Linux AMI release 2014.03' = '' ']'
++ __parse_version_string 'Amazon Linux AMI release 2014.03'
++ VERSION_STRING='Amazon Linux AMI release 2014.03'
+++ echo 'Amazon Linux AMI release 2014.03'
+++ sed -e 's/^/#/' -e
's/^#[^0-9]*\([0-9][0-9]*\.[0-9][0-9]*\)\(\.[0-9][0-9]*\).*$/\1/' -e
's/^#[^0-9]*\([0-9][0-9]*\.[0-9][0-9]*\).*$/\1/' -e
's/^#[^0-9]*\([0-9][0-9]*\).*$/\1/' -e 's/^#.*$//'
++ PARSED_VERSION=2014.03
++ echo 2014.03
+ v=2014.03
+ case $(echo "${n}" | tr '[:upper:]' '[:lower:]') in
++ echo ./system
++ tr '[:upper:]' '[:lower:]'
+ n=./system
+ DISTRO_NAME=./system
+ DISTRO_VERSION=2014.03
```
