### PR TITLE
SLES 11 SP3 Fixes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -12,6 +12,9 @@ Version 2014.xx.xx:
 		* CentOS 7 now uses systemd and the script now properly handles it
 		* systemd in openSUSE 12.2 complains if service does not contain `.service``
 		* Properly detect openSUSE using `lsb_release
+		* SLES 11 SP3 ships with both python-M2Crypto-0.22.* and python-m2crypto-0.21 and we will 
+		be asked which we want to install, even with --non-interactive. Let's try to install the 
+		higher version first and then the lower one in case of failure.
 
 
 Version 2014.06.30:

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2696,7 +2696,7 @@ __test_rhel_optionals_packages() {
                 yum --config "${__YUM_CONF_FILE}" install -y ${package} --enablerepo=${_EPEL_REPO} >/dev/null 2>&1
             fi
             if [ $? -ne 0 ]; then
-                echoerror "Failed to install '${package}'. The optional repository or it's subscription might be missing."
+                echoerror "Failed to find an installable '${package}' package. The optional repository or it's subscription might be missing."
                 rm -rf "${__YUM_CONF_DIR}"
                 return 1
             fi

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -3902,7 +3902,7 @@ install_suse_11_stable_deps() {
     # Salt needs python-zypp installed in order to use the zypper module
     __PACKAGES="python-zypp"
     # shellcheck disable=SC2089
-    __PACKAGES="${__PACKAGES} libzmq3 python python-Jinja2 'python-M2Crypto>=0.21' python-msgpack-python"
+    __PACKAGES="${__PACKAGES} libzmq3 python python-Jinja2 python-msgpack-python"
     __PACKAGES="${__PACKAGES} python-pycrypto python-pyzmq python-pip python-xml python-requests"
 
     if [ "$SUSE_PATCHLEVEL" -eq 1 ]; then
@@ -3916,6 +3916,11 @@ install_suse_11_stable_deps() {
         __PACKAGES="${__PACKAGES} python-apache-libcloud"
     fi
 
+    # SLES 11 SP3 ships with both python-M2Crypto-0.22.* and python-m2crypto-0.21 and we will be asked which
+    # we want to install, even with --non-interactive.
+    # Let's try to install the higher version first and then the lower one in case of failure
+    zypper --non-interactive install --auto-agree-with-licenses 'python-M2Crypto>=0.22' || \
+        zypper --non-interactive install --auto-agree-with-licenses 'python-M2Crypto>=0.21' || return 1
     # shellcheck disable=SC2086,SC2090
     zypper --non-interactive install --auto-agree-with-licenses ${__PACKAGES} || return 1
 


### PR DESCRIPTION
SLES 11 SP3 ships with both python-M2Crypto-0.22.\* and python-m2crypto-0.21 and we will be asked which we want to install, even with --non-interactive.
Let's try to install the higher version first and then the lower one in case of failure.
