### PR TITLE
Remove API from required installs for debian.

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2246,11 +2246,10 @@ install_debian_restart_daemons() {
 }
 
 install_debian_check_services() {
-    for fname in minion master syndic api; do
+    for fname in minion master syndic; do
         # Skip if not meant to be installed
         [ $fname = "minion" ] && [ "$_INSTALL_MINION" -eq $BS_FALSE ] && continue
         [ $fname = "master" ] && [ "$_INSTALL_MASTER" -eq $BS_FALSE ] && continue
-        [ $fname = "api" ] && [ "$_INSTALL_MASTER" -eq $BS_FALSE ] && continue
         [ $fname = "syndic" ] && [ "$_INSTALL_SYNDIC" -eq $BS_FALSE ] && continue
         __check_services_debian salt-$fname || return 1
     done


### PR DESCRIPTION
Debian doesn't appear to have salt-api installable, and when I try to install I see:

``` sh
 * INFO: Running install_debian_check_services()
 * DEBUG: Checking if service salt-minion is enabled
 * DEBUG: Service salt-minion is enabled
 * DEBUG: Checking if service salt-master is enabled
 * DEBUG: Service salt-master is enabled
 * DEBUG: Checking if service salt-api is enabled
 * DEBUG: Service salt-api is NOT enabled
 * ERROR: Failed to run install_debian_check_services()!!!
 * DEBUG: Removing the logging pipe /tmp/bootstrap-salt.logpipe
```
