### PR TITLE
Infinite loop in install_red_hat_linux_stable_deps

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2721,6 +2721,8 @@ install_red_hat_linux_stable_deps() {
                 echoinfo "Sleeping 10 seconds while waiting for the optional repository subscription to be externally configured"
                 sleep 10
                 continue
+            else
+                break
             fi
         done
     else
@@ -2745,6 +2747,8 @@ install_red_hat_linux_git_deps() {
                 echoinfo "Sleeping 10 seconds while waiting for the optional repository subscription to be externally configured"
                 sleep 10
                 continue
+            else
+                break
             fi
         done
     else


### PR DESCRIPTION
Success installing the package(s) doesn't break out of the retry loop

Fixes: #438
Signed-off-by: Dan Mick dan.mick@inktank.com
