### PR TITLE
Debian: don't run update-rc.d with no init script

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2223,9 +2223,9 @@ install_debian_git_post() {
 
         if [ -f "${SALT_GIT_CHECKOUT_DIR}/debian/salt-$fname.init" ]; then
             copyfile "${SALT_GIT_CHECKOUT_DIR}/debian/salt-$fname.init" "/etc/init.d/salt-$fname"
+            chmod +x "/etc/init.d/salt-$fname"
+            update-rc.d "salt-$fname" defaults
         fi
-        chmod +x "/etc/init.d/salt-$fname"
-        update-rc.d "salt-$fname" defaults
     done
 }
 


### PR DESCRIPTION
On Debian, it seems that chmod and update-rc.d run unconditionally on init files; even when there is in fact not init file (e.g. for salt-api), which causes an error. 

This proposed change fixes this. 
