### PR TITLE
Increase default sleep period to avoid stepping on upstart.

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -45,7 +45,7 @@ BS_TRUE=1
 BS_FALSE=0
 
 # Default sleep time used when waiting for daemons to start, restart and checking for these running
-__DEFAULT_SLEEP=3
+__DEFAULT_SLEEP=10
 
 #---  FUNCTION  -------------------------------------------------------------------------------------------------------
 #          NAME:  __detect_color_support


### PR DESCRIPTION
The default sleep period would cause a race condition with upstart
wherein the package installation would call an upstart start and before
it could complete, bootstrap would call another. The result was _two_
copies of salt running which ended up causing a most stubborn bug that's
documented in saltstack/salt#12248
