### PR TITLE
Adding contrib and non-free

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1990,7 +1990,7 @@ _eof
 
     # Debian Backports
     if [ "$(grep -R 'backports.debian.org' /etc/apt)" = "" ]; then
-        echo "deb http://backports.debian.org/debian-backports squeeze-backports main" >> \
+        echo "deb http://backports.debian.org/debian-backports squeeze-backports main contrib non-free" >> \
             /etc/apt/sources.list.d/backports.list
 
         # Add the backports key


### PR DESCRIPTION
According to the [Debian installation guide in the Salt documentation](http://docs.saltstack.com/en/latest/topics/installation/debian.html) the `contrib` and `non-free` components should be added to the backport list as well.
