### PR TITLE
RHEL7: Fixes EPEL repository package location

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2495,7 +2495,7 @@ __install_epel_repository() {
     elif [ "$DISTRO_MAJOR_VERSION" -eq 6 ]; then
         rpm -Uvh --force "http://download.fedoraproject.org/pub/epel/6/${EPEL_ARCH}/epel-release-6-8.noarch.rpm" || return 1
     elif [ "$DISTRO_MAJOR_VERSION" -eq 7 ]; then
-        rpm -Uvh --force "http://download.fedoraproject.org/pub/epel/7/${EPEL_ARCH}/epel-release-7-1.noarch.rpm" || return 1
+        rpm -Uvh --force "http://download.fedoraproject.org/pub/epel/7/${EPEL_ARCH}/e/epel-release-7-1.noarch.rpm" || return 1
     else
         echoerror "Failed add EPEL repository support."
         return 1


### PR DESCRIPTION
`salt-bootstrap` tries to install the `epel-release-7-1.noarch.rpm` from the url `http://download.fedoraproject.org/pub/epel/7/${EPEL_ARCH}/epel-release-7-1.noarch.rpm`, which is 404'ing: [ppc64](http://download.fedoraproject.org/pub/epel/7/ppc64/epel-release-7-1.noarch.rpm), [x86_64](http://download.fedoraproject.org/pub/epel/7/x86_64/epel-release-7-1.noarch.rpm).

The correct one is: `http://download.fedoraproject.org/pub/epel/7/${EPEL_ARCH}/e/epel-release-7-1.noarch.rpm`: [ppc64](http://download.fedoraproject.org/pub/epel/7/ppc64/e/epel-release-7-1.noarch.rpm), [x86_64](http://download.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-1.noarch.rpm).

This pull request fixes the regression from PR #453.
