### PR TITLE
Check services without using runlevel (fixes #479)

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1544,7 +1544,7 @@ __check_services_debian() {
     echodebug "Checking if service ${servicename} is enabled"
 
     # shellcheck disable=SC2086,SC2046
-    if [ -f /etc/rc$(runlevel | awk '{ print $2 }').d/S*${servicename} ]; then
+    if [ $(ls /etc/rc[2345].d/S*${servicename} | wc -l) -eq 4 ]; then
         echodebug "Service ${servicename} is enabled"
         return 0
     else


### PR DESCRIPTION
The bootstrap script should not rely on the "runlevel" utility as it
reports "unknown" when used in a systemd OS. One use case is a Debian
system inside of a ArchLinux chroot.
