### PR TITLE
Fix install on Debian Docker images (fix runlevel problem #479)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+/.idea/
 /.project
 *.swp

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -208,6 +208,7 @@ _SALT_MINION_ID="null"
 # __SIMPLIFY_VERSION is mostly used in Solaris based distributions
 __SIMPLIFY_VERSION=$BS_TRUE
 _LIBCLOUD_MIN_VERSION="0.14.0"
+_PY_REQUESTS_MIN_VERSION="2.4.3"
 _EXTRA_PACKAGES=""
 _HTTP_PROXY=""
 __SALT_GIT_CHECKOUT_DIR=${BS_SALT_GIT_CHECKOUT_DIR:-/tmp/git/salt}
@@ -1132,6 +1133,34 @@ __function_defined() {
 
 
 #---  FUNCTION  -------------------------------------------------------------------------------------------------------
+#          NAME:  __version_gte
+#   DESCRIPTION:  Compares 2 version numbers to see if the first is >= the second
+#                 Note: This uses Python to do the number crunching; DO NOT use it until after Python is installed.
+#    PARAMETERS:  Two (2) version numbers
+#       RETURNS:  0 if $1 >= $2; 1 if $1 < $2
+#----------------------------------------------------------------------------------------------------------------------
+__version_gte() {
+
+    v1="$1"
+    v2="$2"
+
+    result=$(python -c "
+from distutils.version import LooseVersion
+if LooseVersion('$v1') >= LooseVersion('$v2'):
+    print '0'
+else:
+    print '1'
+")
+
+    # If python failed for some reason then this is absolutely not the result we expected,
+    # and we should not rely on $result
+    [ x$? = x0 ] || { echo "ERROR: __version_gte received unexpected result" 1>&2; exit 1; }
+
+    return $result
+}
+
+
+#---  FUNCTION  -------------------------------------------------------------------------------------------------------
 #          NAME:  __git_clone_and_checkout
 #   DESCRIPTION:  (DRY) Helper function to clone and checkout salt to a
 #                 specific revision.
@@ -1723,8 +1752,7 @@ install_ubuntu_deps() {
     else
         check_pip_allowed "You need to allow pip based installations (-P) in order to install the python package 'requests'"
         __apt_get_install_noinput python-setuptools python-pip
-        __PIP_PACKAGES="requests"
-        pip install requests
+        __PIP_PACKAGES="'requests>=$_PY_REQUESTS_MIN_VERSION'"
     fi
 
     # Additionally install procps and pciutils which allows for Docker boostraps. See 366#issuecomment-39666813
@@ -1956,7 +1984,7 @@ install_debian_deps() {
         check_pip_allowed "You need to allow pip based installations (-P) in order to install the python 'requests' package"
         # Additionally install procps and pciutils which allows for Docker boostraps. See 366#issuecomment-39666813
         __PACKAGES="${__PACKAGES} python-pip"
-        __PIP_PACKAGES="${__PIP_PACKAGES} requests"
+        __PIP_PACKAGES="${__PIP_PACKAGES} 'requests>=$_PY_REQUESTS_MIN_VERSION'"
     else
         __PACKAGES="${__PACKAGES} python-requests"
     fi
@@ -2133,6 +2161,15 @@ _eof
         __PACKAGES="${__PACKAGES} procps pciutils"
         # shellcheck disable=SC2086
         __apt_get_install_noinput ${__PACKAGES} || return 1
+
+        # Check to see what version of python-requests was installed
+        # On wheezy for example there is a REALLY old version and we must upgrade it via pip
+        version=$(pip freeze 2> /dev/null | awk -F== '$1 == "requests" {print $2}')
+        # if ! $version >= $_PY_REQUESTS_MIN_VERSION
+        if ! __version_gte "$version" "$_PY_REQUESTS_MIN_VERSION"; then
+            echodebug "Debian ports installed an old python-ports (version $version); upgrading via pip"
+            pip install -U "requests>=$_PY_REQUESTS_MIN_VERSION"
+        fi
     else
         apt-get update || return 1
         __PACKAGES="python-zmq python-requests python-apt"

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1559,13 +1559,23 @@ __check_services_debian() {
     servicename=$1
     echodebug "Checking if service ${servicename} is enabled"
 
-    # shellcheck disable=SC2086,SC2046,SC2144
-    if [ -f /etc/rc$(runlevel | awk '{ print $2 }').d/S*${servicename} ]; then
-        echodebug "Service ${servicename} is enabled"
+    if [ "$(runlevel)" = "unknown" ]; then
+        # We're running in a Docker image that doesn't know the runlevel.
+        # In this event none of the /etc/init.d scripts will run anyway,
+        # which is the intended behavior.
+
+        # We don't need to check that ${servicename} is enabled.
+        echodebug "Skipping service ${servicename} enabled check (runlevel unknown)"
         return 0
     else
-        echodebug "Service ${servicename} is NOT enabled"
-        return 1
+        # shellcheck disable=SC2086,SC2046,SC2144
+        if [ -f /etc/rc$(runlevel | awk '{ print $2 }').d/S*${servicename} ]; then
+            echodebug "Service ${servicename} is enabled"
+            return 0
+        else
+            echodebug "Service ${servicename} is NOT enabled"
+            return 1
+        fi
     fi
 }   # ----------  end of function __check_services_debian  ----------
 


### PR DESCRIPTION
An alternate approach to fixing the runlevel problem https://github.com/saltstack/salt-bootstrap/issues/479 as compared to PR https://github.com/saltstack/salt-bootstrap/pull/480 (though that also looks like it works).

In this approach:
- No changes for most users
- In Debian Docker images (and perhaps other environments) when `runlevel` == "unknown":
  - DO NOT check that the services will start at boot.
  - DO NOT exit with a fatal error caused by not being able to check that the services will start at the current runlevel.

In Docker the startup scripts don't get run so this is a pointless check in that event anyway, and without this fix Salt cannot be installed.
