### PR TITLE
opensuse 13.2: fix installation

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -697,7 +697,6 @@ __gather_linux_system_info() {
         elif [ "${DISTRO_NAME}" = "openSUSE project" ]; then
             # lsb_release -si returns "openSUSE project" on openSUSE 12.3
             DISTRO_NAME="opensuse"
-            install_opensuse_zypper_vars
         elif [ "${DISTRO_NAME}" = "SUSE LINUX" ]; then
             if [ "$(lsb_release -sd | grep -i opensuse)" != "" ]; then
                 # openSUSE 12.2 reports SUSE LINUX on lsb_release -si
@@ -706,7 +705,6 @@ __gather_linux_system_info() {
                 # lsb_release -si returns "SUSE LINUX" on SLES 11 SP3
                 DISTRO_NAME="suse"
             fi
-            install_opensuse_zypper_vars
         elif [ "${DISTRO_NAME}" = "EnterpriseEnterpriseServer" ]; then
             # This the Oracle Linux Enterprise ID before ORACLE LINUX 5 UPDATE 3
             DISTRO_NAME="Oracle Linux"
@@ -3954,6 +3952,7 @@ install_opensuse_zypper_vars() {
 }
 
 install_opensuse_stable_deps() {
+    install_opensuse_zypper_vars
     DISTRO_REPO="openSUSE_${DISTRO_MAJOR_VERSION}.${DISTRO_MINOR_VERSION}"
 
     # Is the repository already known
@@ -4002,6 +4001,7 @@ install_opensuse_stable_deps() {
 }
 
 install_opensuse_git_deps() {
+    install_opensuse_zypper_vars
     install_opensuse_stable_deps || return 1
     $ZYPPER_INSTALL git || return 1
 
@@ -4023,6 +4023,7 @@ install_opensuse_git_deps() {
 }
 
 install_opensuse_stable() {
+    install_opensuse_zypper_vars
     __PACKAGES=""
     if [ "$_INSTALL_MINION" -eq $BS_TRUE ]; then
         __PACKAGES="${__PACKAGES} salt-minion"
@@ -4144,6 +4145,7 @@ install_opensuse_check_services() {
 #    SuSE Install Functions.
 #
 install_suse_11_stable_deps() {
+    install_opensuse_zypper_vars
     SUSE_PATCHLEVEL=$(awk '/PATCHLEVEL/ {print $3}' /etc/SuSE-release )
     if [ "${SUSE_PATCHLEVEL}" != "" ]; then
         DISTRO_PATCHLEVEL="_SP${SUSE_PATCHLEVEL}"
@@ -4232,6 +4234,7 @@ install_suse_11_stable_deps() {
 }
 
 install_suse_11_git_deps() {
+    install_opensuse_zypper_vars
     install_suse_11_stable_deps || return 1
     $ZYPPER_INSTALL git || return 1
 


### PR DESCRIPTION
zypper in openSUSE 13.2 now checks for file conflicts. When you install a package that replaces files from other (already installed) package it warns you and asks what to do. It breaks bootstrap script because `python-pyzmq` conflicts with `libzmq3` (I don't know why).

I've fixed this by specifying additional argument that forces file overwrite. Also I put all `zypper` arguments into two variables to follow DRY and make code more readable and maintainable.

I'm not an expert in bootstrap script, so I didn't know where to put variables definition. If there is a better way, please fix it. Probably you would like to change version checking too (to `sed` for example). In my opinion this way is the cleanest, moreover openSUSE and SUSE always used GNU version of `sort`, so it's not a problem.
