### PR TITLE
Make -U work for FreeBSD

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -3623,6 +3623,10 @@ install_freebsd_9_stable_deps() {
         /usr/local/sbin/pkg install ${SALT_PKG_FLAGS} -y ${_EXTRA_PACKAGES} || return 1
     fi
 
+    if [ "$_UPGRADE_SYS" -eq $BS_TRUE ]; then
+        pkg upgrade -y || return 1
+    fi
+
     return 0
 }
 


### PR DESCRIPTION
When using http://files.wunki.org/freebsd-9.2-amd64-wunki.box or
http://files.wunki.org/freebsd-10.0-amd64-wunki.box with Vagrant,
bootstrap would succeed, but a number of states would fail without
a package upgrade prior to running highstate. The -U switch currently
does not trigger an upgrade when bootstraping FreeBSD. This patch adds
a package upgrade to the end of the FreeBSD dependency install
function.
