### PR TITLE
Fix for -C (_CONFIG_ONLY)

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -368,11 +368,6 @@ if [ "$_INSTALL_MINION" -eq $BS_FALSE ] && [ "$_INSTALL_MASTER" -eq $BS_FALSE ] 
     exit 0
 fi
 
-if [ "$_CONFIG_ONLY" -eq $BS_TRUE ] && [ "$_TEMP_CONFIG_DIR" = "null" ]; then
-    echoerror "In order to run the script in configuration only mode you also need to provide the configuration directory."
-    exit 1
-fi
-
 # Check that we're installing a minion if we're being passed a master address
 if [ "$_INSTALL_MINION" -eq $BS_FALSE ] && [ "$_SALT_MASTER_ADDRESS" != "null" ]; then
     echoerror "Don't pass a master address (-A) if no minion is going to be bootstrapped."

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -4472,7 +4472,7 @@ config_salt() {
         CONFIGURED_ANYTHING=$BS_TRUE
     fi
 
-    if [ "$_INSTALL_MINION" -eq $BS_TRUE ]; then
+    if [ "$_INSTALL_MINION" -eq $BS_TRUE ] || [ "$_CONFIG_ONLY" -eq $BS_TRUE ]; then
         # Create the PKI directory
         [ -d "$_PKI_DIR/minion" ] || (mkdir -p "$_PKI_DIR/minion" && chmod 700 "$_PKI_DIR/minion") || return 1
 
@@ -4496,7 +4496,7 @@ config_salt() {
     fi
 
 
-    if [ "$_INSTALL_MASTER" -eq $BS_TRUE ] || [ "$_INSTALL_SYNDIC" -eq $BS_TRUE ]; then
+    if [ "$_INSTALL_MASTER" -eq $BS_TRUE ] || [ "$_INSTALL_SYNDIC" -eq $BS_TRUE ] || [ "$_CONFIG_ONLY" -eq $BS_TRUE ]; then
         # Create the PKI directory
         [ -d "$_PKI_DIR/master" ] || (mkdir -p "$_PKI_DIR/master" && chmod 700 "$_PKI_DIR/master") || return 1
 


### PR DESCRIPTION
Since I pre seeded the machine image with salt-minion, all I needed the deploy process to do was setup the minion config and keys. However... The -C (_CONFIG_ONLY) flag for bootstrap-salt was effectively useless. It was never evaluated properly in config_salt() so it had no effect. There is also a requirement for_CONFIG_ONLY to require a tmp dir to be specified with the -c flag. This ends up being useless as the tmp dir created by the deployment process is dynamically generated under tmp so the tmp dir specified in the script_args does no reflect the actual temporary directory created on the target machine as indicated by the log:

`[DEBUG ] Uploading /tmp/.saltcloud-a27e1bfd-c6cb-4ea7-bbbb-5769e01ae1d6/deploy.sh to 10.0.0.233 (sfcp)`
...
`[DEBUG ] Using sudo to run command sudo /tmp/.saltcloud-a27e1bfd-c6cb-4ea7-bbbb-5769e01ae1d6/deploy.sh -c /tmp/.saltcloud-a27e1bfd-c6cb-4ea7-bbbb-5769e01ae1d6 -K -F -C`

The check for a tmp dir when specifying _CONFIG_ONLY appears superfluous as any configuration at all requires it be set, as it is done by the salt-master/cloud (from a second run):

`[DEBUG   ] Using sudo to run command sudo /tmp/.saltcloud-c7927dad-66cc-4176-99b1-b5b1fdade6de/deploy.sh -c /tmp/.saltcloud-c7927dad-66cc-4176-99b1-b5b1fdade6de -K -F -C -c /tmp`
