### PR TITLE
Update Vagrantfile to autoprovision

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.project
 *.swp
+.vagrant

--- a/README.rst
+++ b/README.rst
@@ -385,8 +385,6 @@ Ubuntu box. First, install Vagrant, then::
 
     $ vagrant up
     $ vagrant ssh
-    <vm> $ cd /salt_bootstrap
-    <vm> $ sudo sh salt-bootstrap.sh
 
 
 .. _Vagrant: http://www.vagrantup.com

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,7 +10,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # please see the online documentation at vagrantup.com.
 
   # Every Vagrant virtual environment requires a box to build off of.
-  config.vm.box = "precise64"
+  config.vm.box = "ubuntu/precise64"
 
   # The url from where the 'config.vm.box' box will be fetched if it
   # doesn't already exist on the user's system.
@@ -40,6 +40,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # argument is a set of non-required options.
   config.vm.synced_folder ".", "/salt_bootstrap"
 
+  config.vm.provision "shell", path: "bootstrap-salt.sh"
   # Provider-specific configuration so you can fine-tune various
   # backing providers for Vagrant. These expose provider-specific options.
   # Example for VirtualBox:


### PR DESCRIPTION
This updates the Vagrantfile to:
- use Ubuntu's precise64 box (Vagrant will download the box if not already present on the system).
- automatically run the salt-bootstrap.sh script on startup, removing the need to ssh into the VM and run it manually. All output is printed to the terminal.
- Removes instructions in the README for Vagrant usage.
- Gitignore `.vagrant`, which is Vagrant's scratch folder.

Sorry for the completely unsolicited PR, I'm brand new to Salt but love Vagrant, so I thought I'd help out.
