### PR TITLE
Ubuntu alternate ppas

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -421,7 +421,7 @@ elif [ "$ITYPE" = "stable" ]; then
     else
         __check_unparsed_options "$*"
         if [ "$(echo "$1" | egrep '^(latest|1\.6|1\.7|2014\.1|2014\.7|2015\.2)$')" = "" ]; then
-          echo "Unknown stable version: $1 (valid: 1.6, 1.7, 2014.1, 2014.7, 2015.2, latest)"
+          echo "Unknown stable version: $1 (valid: 1.6, 1.7, 2014.1, 2014.7, 2015.5, latest)"
           exit 1
         else
           STABLE_REV="$1"

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1122,7 +1122,7 @@ if ([ "${DISTRO_NAME_L}" != "ubuntu" ] && [ "$ITYPE" = "daily" ]); then
     echoerror "${DISTRO_NAME} does not have daily packages support"
     exit 1
 elif ([ "${DISTRO_NAME_L}" != "ubuntu" ] && [ "$STABLE_REV" != "latest" ]); then
-    echoerror "${DISTRO_NAME} does have major version pegged packages support"
+    echoerror "${DISTRO_NAME} does not have major version pegged packages support"
     exit 1
 fi
 

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -420,12 +420,12 @@ elif [ "$ITYPE" = "stable" ]; then
         STABLE_REV="latest"
     else
         __check_unparsed_options "$*"
-        if [ "$(echo "$1" | egrep '(latest|1\.6|1\.7|2014\.1|2014\.7|2015\.2)')" = "" ]; then
-          STABLE_REV="$1"
-          shift
-        else
+        if [ "$(echo "$1" | egrep '^(latest|1\.6|1\.7|2014\.1|2014\.7|2015\.2)$')" = "" ]; then
           echo "Unknown stable version: $1 (valid: 1.6, 1.7, 2014.1, 2014.7, 2015.2, latest)"
           exit 1
+        else
+          STABLE_REV="$1"
+          shift
         fi
     fi
 fi
@@ -1772,12 +1772,13 @@ install_ubuntu_deps() {
 install_ubuntu_stable_deps() {
     install_ubuntu_deps || return 1
 
-    STABLE_PPA="saltstack/salt"
     # Alternate PPAs: salt16, salt17, salt2014-1, salt2014-7
-    if [ "$(echo "$STABLE_REV" | egrep '(1\.6|1\.7))')" = "" ]; then
-      STABLE_PPA="$STABLE_PPA$(echo "$STABLE_REV" | tr -d .)"
-    elif [ "$(echo "$STABLE_REV" | egrep '(2014\.1|2014\.7|2015\.2)')" = "" ]; then
-      STABLE_PPA="$STABLE_PPA$(echo "$1" | tr . -)"
+    if [ ! "$(echo "$STABLE_REV" | egrep '^(1\.6|1\.7)$')" = "" ]; then
+      STABLE_PPA="saltstack/salt$(echo "$STABLE_REV" | tr -d .)"
+    elif [ ! "$(echo "$STABLE_REV" | egrep '^(2014\.1|2014\.7|2015\.2)$')" = "" ]; then
+      STABLE_PPA="saltstack/salt$(echo "$STABLE_REV" | tr . -)"
+    else
+      STABLE_PPA="saltstack/salt"
     fi
 
     if [ "$DISTRO_MAJOR_VERSION" -gt 11 ] || ([ "$DISTRO_MAJOR_VERSION" -eq 11 ] && [ "$DISTRO_MINOR_VERSION" -gt 04 ]); then

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -226,6 +226,7 @@ usage() {
     - stable (default)
     - stable [version] (ubuntu specific)
     - daily  (ubuntu specific)
+    - testing (redhat specific)
     - git
 
   Examples:
@@ -233,6 +234,7 @@ usage() {
     - ${__ScriptName} stable
     - ${__ScriptName} stable 2014.7
     - ${__ScriptName} daily
+    - ${__ScriptName} testing
     - ${__ScriptName} git
     - ${__ScriptName} git develop
     - ${__ScriptName} git v0.17.0


### PR DESCRIPTION
Fixes #543.

Adds additional 'stable' install type under Ubuntu:
bootstrap-salt.sh stable [version]

With no version specified acts same as default ('saltstack/salt' PPA) but with a version specified it uses the alternate PPAs which won't force major version shifts automatically, but do get backported fixes.

bootstrap-salt.sh stable 0.16 (ppa:saltstack/salt16)
bootstrap-salt.sh stable 0.17 (ppa:saltstack/salt17)
bootstrap-salt.sh stable 2014.1 (ppa:saltstack/salt2014-1)
bootstrap-salt.sh stable 2014.7 (ppa:saltstack/salt2014-7)
bootstrap-salt.sh stable latest (ppa:saltstack/salt)

It also includes the PPA for the upcoming 2015.2 release, available when 2015.2 RCs become stable:
bootstrap-salt.sh stable 2015.2 (ppa:saltstack/salt2015-2)

Bonus: Documents the 'testing' type available on Redhat distros.
