### PR TITLE
Fix when using upstream tags

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1217,6 +1217,7 @@ __git_clone_and_checkout() {
             git remote add upstream "$_SALTSTACK_REPO_URL" || return 1
             echodebug "Fetching upstream(SaltStack's Salt repository) git tags"
             git fetch --tags upstream || return 1
+            GIT_REV="upstream/$GIT_REV"
         fi
 
         if [ "$__SHALLOW_CLONE" -eq "${BS_FALSE}" ]; then

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1217,7 +1217,7 @@ __git_clone_and_checkout() {
             git remote add upstream "$_SALTSTACK_REPO_URL" || return 1
             echodebug "Fetching upstream(SaltStack's Salt repository) git tags"
             git fetch --tags upstream || return 1
-            GIT_REV="upstream/$GIT_REV"
+            GIT_REV="origin/$GIT_REV"
         fi
 
         if [ "$__SHALLOW_CLONE" -eq "${BS_FALSE}" ]; then


### PR DESCRIPTION
When the need arises for upstream tag fetching, the branch can only be checked out using `upstream/<tag>`.

This is the actual error FreeBSD runs into in #550.
This is on Ubuntu 14.04, git version 1.9.1:

```
 *  INFO: Adding SaltStack's Salt repository as a remote
+ git remote add upstream https://github.com/saltstack/salt.git
+ echodebug Fetching upstream(SaltStack's Salt repository) git tags
+ [ 1 -eq 1 ]
+ printf \033[1;34m * DEBUG\033[0m: %s\n Fetching upstream(SaltStack's Salt repository) git tags
 * DEBUG: Fetching upstream(SaltStack's Salt repository) git tags
+ git fetch --tags upstream
From https://github.com/saltstack/salt
 * [new branch]      0.11       -> upstream/0.11
 * [new branch]      0.12       -> upstream/0.12
 * [new branch]      0.13       -> upstream/0.13
 * [new branch]      0.14       -> upstream/0.14
 * [new branch]      0.15       -> upstream/0.15
 * [new branch]      0.16       -> upstream/0.16
 * [new branch]      0.17       -> upstream/0.17
 * [new branch]      2014.1     -> upstream/2014.1
 * [new branch]      2014.7     -> upstream/2014.7
 * [new branch]      2015.2     -> upstream/2015.2
 * [new branch]      develop    -> upstream/develop
+ [ 0 -eq 0 ]
+ echodebug Checking out 2015.2
+ [ 1 -eq 1 ]
+ printf \033[1;34m * DEBUG\033[0m: %s\n Checking out 2015.2
 * DEBUG: Checking out 2015.2
+ git checkout 2015.2
error: pathspec '2015.2' did not match any file(s) known to git.
+ return 1
+ return 1
+ [ 1 -ne 0 ]
+ echoerror Failed to run install_ubuntu_git_deps()!!!
+ printf \033[1;31m * ERROR\033[0m: %s\n Failed to run install_ubuntu_git_deps()!!!
 * ERROR: Failed to run install_ubuntu_git_deps()!!!
+ exit 1
```
