### PR TITLE
\| grouping doesn't work in POSIX sed

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1211,7 +1211,7 @@ __git_clone_and_checkout() {
             cd "${__SALT_GIT_CHECKOUT_DIR}"
         fi
 
-        if $(echo "$_SALT_REPO_URL" | grep -q -e '\(\(git\|https\)://github\.com/\|git@github\.com:\)saltstack/salt\.git'); then
+        if [ $(echo "$_SALT_REPO_URL" | grep -c -e '\(\(git\|https\)://github\.com/\|git@github\.com:\)saltstack/salt\.git') == 0 ]; then
             # We need to add the saltstack repository as a remote and fetch tags for proper versioning
             echoinfo "Adding SaltStack's Salt repository as a remote"
             git remote add upstream "$_SALTSTACK_REPO_URL" || return 1

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1211,7 +1211,7 @@ __git_clone_and_checkout() {
             cd "${__SALT_GIT_CHECKOUT_DIR}"
         fi
 
-        if [ $(echo "$_SALT_REPO_URL" | grep -c -e '\(\(git\|https\)://github\.com/\|git@github\.com:\)saltstack/salt\.git') == 0 ]; then
+        if [ $(echo "$_SALT_REPO_URL" | grep -c -e '\(\(git\|https\)://github\.com/\|git@github\.com:\)saltstack/salt\.git') -eq 0 ]; then
             # We need to add the saltstack repository as a remote and fetch tags for proper versioning
             echoinfo "Adding SaltStack's Salt repository as a remote"
             git remote add upstream "$_SALTSTACK_REPO_URL" || return 1

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1211,7 +1211,7 @@ __git_clone_and_checkout() {
             cd "${__SALT_GIT_CHECKOUT_DIR}"
         fi
 
-        if [ "$(echo "$_SALT_REPO_URL" | sed 's/^\(\(git\|https\)\:\/\/github\.com\/saltstack\/salt\.git\|git@github.com\:saltstack\/salt\.git\)$/MATCH/')" != "MATCH" ]; then
+        if $(echo "$_SALT_REPO_URL" | grep -q -e '\(\(git\|https\)://github\.com/\|git@github\.com:\)saltstack/salt\.git'); then
             # We need to add the saltstack repository as a remote and fetch tags for proper versioning
             echoinfo "Adding SaltStack's Salt repository as a remote"
             git remote add upstream "$_SALTSTACK_REPO_URL" || return 1

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1211,7 +1211,7 @@ __git_clone_and_checkout() {
             cd "${__SALT_GIT_CHECKOUT_DIR}"
         fi
 
-        if [ $(echo "$_SALT_REPO_URL" | grep -c -e '\(\(git\|https\)://github\.com/\|git@github\.com:\)saltstack/salt\.git') -eq 0 ]; then
+        if [ "$(echo "$_SALT_REPO_URL" | grep -c -e '\(\(git\|https\)://github\.com/\|git@github\.com:\)saltstack/salt\.git')" -eq 0 ]; then
             # We need to add the saltstack repository as a remote and fetch tags for proper versioning
             echoinfo "Adding SaltStack's Salt repository as a remote"
             git remote add upstream "$_SALTSTACK_REPO_URL" || return 1


### PR DESCRIPTION
As part of #550, the reason FreeBSD falls on tags at all (fixed in #564) is because the REPO_URL sed substition line doesn't work in non-Linux sed. 

This fix replaces it with an equivalent POSIX compliant filter so it works on FreeBSD (and probably Solaris, Nexenta, etc.).

This was the only place in the script I could find where this occurs.

Together with #564 this closes #550.
