### PR TITLE
Fix issue where bootstrap script fails if a private epel repo has been configured

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2608,6 +2608,13 @@ __install_epel_repository() {
         return 0
     fi
 
+    # Check if epel repo is already enabled and flag it accordingly
+    yum repolist | grep -i "epel" > /dev/null 2>&1
+    if [ $? -eq 0 ]; then
+        __EPEL_REPOS_INSTALLED=${BS_TRUE}
+        return 0
+    fi
+
     # Check if epel-release is already installed and flag it accordingly
     rpm --nodigest --nosignature -q epel-release > /dev/null 2>&1
     if [ $? -eq 0 ]; then


### PR DESCRIPTION
Fix issue where bootstrap script fails if a private epel repo has been configured and if the server cannot access external network

Fixes #576

@s0undt3ch 
