### PR TITLE
Fixes #578, set env DEBIAN_FRONTEND=noninteractive

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1704,6 +1704,8 @@ install_ubuntu_deps() {
     if [ $_START_DAEMONS -eq $BS_FALSE ]; then
         echowarn "Not starting daemons on Debian based distributions is not working mostly because starting them is the default behaviour."
     fi
+    # No user interaction, libc6 restart services for example
+    export DEBIAN_FRONTEND=noninteractive
 
     apt-get update
 


### PR DESCRIPTION
Some packages ignore the dpkg options --force-confold and --force-confdef (see issue #578 for an example) 

Setting the DEBIAN_FRONTEND to noninteractive guarantees that an interactive prompt won't come up during the package upgrade process.
