### PR TITLE
Fix Debian Squeeze backports mirror

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2040,7 +2040,7 @@ _eof
 
     # Debian Backports
     if [ "$(grep -R 'squeeze-backports' /etc/apt | grep -v "^#")" = "" ]; then
-        echo "deb http://http.debian.net/debian-backports squeeze-backports main" >> \
+        echo "deb http://ftp.de.debian.org/debian-backports squeeze-backports main" >> \
             /etc/apt/sources.list.d/backports.list
     fi
 


### PR DESCRIPTION
http://http.debian.net/debian-backports is not available anymore
