### PR TITLE
Fix "STABLE_REV: unbound variable"

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1147,7 +1147,7 @@ fi
 if ([ "${DISTRO_NAME_L}" != "ubuntu" ] && [ "$ITYPE" = "daily" ]); then
     echoerror "${DISTRO_NAME} does not have daily packages support"
     exit 1
-elif ([ "${DISTRO_NAME_L}" != "ubuntu" ] && [ "$STABLE_REV" != "latest" ]); then
+elif ([ "${DISTRO_NAME_L}" != "ubuntu" ] && [ "$ITYPE" = "stable" ] && [ "$STABLE_REV" != "latest" ]); then
     echoerror "${DISTRO_NAME} does not have major version pegged packages support"
     exit 1
 fi


### PR DESCRIPTION
On non Ubuntu systems, installing from a git reference (such as a branch name) failed with the following error 'line 1150: STABLE_REV: unbound variable'

Fixes #599
