### PR TITLE
scmgit package outdated in pkgin, use git instead

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -4170,7 +4170,7 @@ install_smartos_git_deps() {
     install_smartos_deps || return 1
 
     if [ "$(which git)" = "" ]; then
-        pkgin -y install scmgit || return 1
+        pkgin -y install git || return 1
     fi
 
     if [ -f "${__SALT_GIT_CHECKOUT_DIR}/requirements/base.txt" ]; then


### PR DESCRIPTION
Since SmartOS pkgin 2013Q3 release, `scmgit` is depreciated. We're "strongly advised" to use `git` instead. For now, both yield same result.

More info: https://github.com/joyent/pkgsrc-joyent/blob/master/scmgit/DESCR
