### PR TITLE
SmartOS should install libcloud

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -4156,6 +4156,10 @@ install_smartos_deps() {
         fi
     fi
 
+    if [ "$_INSTALL_CLOUD" -eq $BS_TRUE  ]; then
+        pkgin -y install py27-apache-libcloud || return 1
+    fi
+
     if [ "${_EXTRA_PACKAGES}" != "" ]; then
         echoinfo "Installing the following extra packages as requested: ${_EXTRA_PACKAGES}"
         # shellcheck disable=SC2086


### PR DESCRIPTION
Based on https://github.com/saltstack/salt-bootstrap/issues/473 "problem 2", and my own experience across dozens of SmartOS boxes, `libcloud` should be installed on SmartOS via `pkgin` to get salt working. Previously, it was missing from SmartOS part of script.
