### PR TITLE
moving install_centos_stable_deps before __test_rhel_optionals_pacakg…

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -3186,6 +3186,8 @@ __test_rhel_optionals_packages() {
 
 
 install_red_hat_linux_stable_deps() {
+    install_centos_stable_deps || return 1
+
     if [ "${DISTRO_MAJOR_VERSION}" -ge 6 ]; then
         # Wait at most 60 seconds for the repository subscriptions to register
         __ATTEMPTS=6
@@ -3207,7 +3209,6 @@ install_red_hat_linux_stable_deps() {
          __test_rhel_optionals_packages || return 1
     fi
 
-    install_centos_stable_deps || return 1
     return 0
 }
 


### PR DESCRIPTION
…es call in install_red_hat_linux_stable_deps to verify that yum-config-manager is available (it is installed in install_centos_stable_deps) for use (called in __test_rhel_optionals_packages)

resolves #622 

There could be a reason the code was originally ordered this way, I couldn't see a reason while looking at the problem...

Tested on RHEL7.1 and RHEL6.6 to bootstrap new minions
