### PR TITLE
fix config and etc path on SmartOS

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -4229,7 +4229,7 @@ install_smartos_stable() {
 install_smartos_git() {
     # Use setuptools in order to also install dependencies
     # lets force our config path on the setup for now, since salt/syspaths.py only  got fixed in 2015.5.0
-    USE_SETUPTOOLS=1 /opt/local/bin/python setup.py install --salt-config-dir="$_SALT_ETC_DIR" || return 1
++++ USE_SETUPTOOLS=1 /opt/local/bin/python setup.py install --salt-config-dir="$_SALT_ETC_DIR" || USE_SETUPTOOLS=1 /opt/local/bin/python setup.py --salt-config-dir="$_SALT_ETC_DIR" install || return 1
     return 0
 }
 

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -4154,6 +4154,11 @@ install_freebsd_restart_daemons() {
 install_smartos_deps() {
     pkgin -y install zeromq py27-m2crypto py27-crypto py27-msgpack py27-yaml py27-jinja2 py27-zmq py27-requests || return 1
 
+    # Set _SALT_ETC_DIR to SmartOS default if they didn't specify
+    _SALT_ETC_DIR=${BS_SALT_ETC_DIR:-/opt/local/etc/salt}
+    # We also need to redefine the PKI directory
+    _PKI_DIR=${_SALT_ETC_DIR}/pki
+
     # Let's trigger config_salt()
     if [ "$_TEMP_CONFIG_DIR" = "null" ]; then
         # Let's set the configuration directory to /tmp
@@ -4223,7 +4228,8 @@ install_smartos_stable() {
 
 install_smartos_git() {
     # Use setuptools in order to also install dependencies
-    USE_SETUPTOOLS=1 /opt/local/bin/python setup.py install || return 1
+    # lets force our config path on the setup for now, since salt/syspaths.py only  got fixed in 2015.5.0
+    USE_SETUPTOOLS=1 /opt/local/bin/python setup.py install --salt-config-dir="$_SALT_ETC_DIR" || return 1
     return 0
 }
 


### PR DESCRIPTION
Issue: On SmartOS, if BS_SALT_ETC_DIR is not given, `bootstrap-salt.sh` [uses wrong etc path](https://github.com/saltstack/salt-bootstrap/blob/develop/bootstrap-salt.sh#L194)

Fixes https://github.com/saltstack/salt-bootstrap/issues/615

Background:
Salt-bootstrap hardcodes all OS's to /etc/salt unless they have their own manually later in the script (like freebsd), or the BS_SALT_ETC_DIR environment variable is given at runtime. SmartOS uses /opt/local/etc so lets set that to default for it.

This is killing two issues on SmartOS that this script presents with default etc path.
1. First is we just need to set the proper default [like freebsd does.](https://github.com/saltstack/salt-bootstrap/blob/develop/bootstrap-salt.sh#L3976)
2. Next, We've reciently fixed salt's syspaths.py for SmartOS since 2015.5.0, but that doesn't help anyone using this bootstrap to install 2014.x etc. which will still put parts of salt in the wrong place, so unlike how [fedora falls back to syspath.py](https://github.com/saltstack/salt-bootstrap/blob/develop/bootstrap-salt.sh#L2677-L2684) I think we should still prefer our new default unless we have a environment variable override.
