### PR TITLE
Modify bootstrap-salt.sh unbound error with CONFIG_PROTECT_MASK for Gentoo

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -4788,7 +4788,7 @@ __gentoo_config_protection() {
     # this point, manually merge the changes using etc-update/dispatch-conf/
     # cfg-update and then restart the bootstrapping script, so instead we allow
     # at this point to modify certain config files directly
-    export CONFIG_PROTECT_MASK="$CONFIG_PROTECT_MASK /etc/portage/package.keywords /etc/portage/package.unmask /etc/portage/package.use /etc/portage/package.license"
+    export CONFIG_PROTECT_MASK=: "${CONFIG_PROTECT_MASK:=/etc/portage/package.keywords /etc/portage/package.unmask /etc/portage/package.use /etc/portage/package.license}"
 }
 
 __gentoo_pre_dep() {


### PR DESCRIPTION
Currently, bootstrap-salt.sh will fail on Gentoo targets complaining of an unbound variable referring to CONFIG_PROTECT_MASK.  These changes allow this to resume.
