### PR TITLE
Fix tornado installation on ubuntu

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1874,7 +1874,7 @@ install_ubuntu_git_deps() {
             if [ "$(which pip)" = "" ]; then
                 __apt_get_install_noinput python-setuptools python-pip
             fi
-            pip install -U "'${__REQUIRED_TORNADO}'"
+            pip install -U "${__REQUIRED_TORNADO}"
         fi
     fi
 


### PR DESCRIPTION
I got error from `/tmp/bootstrap-salt.log` on Ubuntu 14.04.

```
Exception:
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/pip/basecommand.py", line 122, in main
    status = self.run(options, args)
  File "/usr/lib/python2.7/dist-packages/pip/commands/install.py", line 257, in run
    InstallRequirement.from_line(name, None))
  File "/usr/lib/python2.7/dist-packages/pip/req.py", line 172, in from_line
    return cls(req, comes_from, url=url, prereleases=prereleases)
  File "/usr/lib/python2.7/dist-packages/pip/req.py", line 70, in __init__
    req = pkg_resources.Requirement.parse(req)
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 2667, in parse
    reqs = list(parse_requirements(s))
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 2593, in parse_requirements
    raise ValueError("Missing distribution spec", line)
ValueError: ('Missing distribution spec', "'tornado >= 4.0'")
...
 *  INFO: Running daemons_running()
 * ERROR: salt-minion was not found running
 * ERROR: salt-master was not found running
 * ERROR: Failed to run daemons_running()!!!
 * ERROR: salt-minion was not found running. Pass '-D' to bootstrap-salt.sh when bootstrapping for additional debugging information...
 * ERROR: salt-master was not found running. Pass '-D' to bootstrap-salt.sh when bootstrapping for additional debugging information...
```

salt-minion error:

```
$ salt-minion
Traceback (most recent call last):
  File "/usr/bin/salt-minion", line 26, in <module>
    salt_minion()
  File "/usr/lib/python2.7/dist-packages/salt/scripts.py", line 106, in salt_minion
    import salt.cli.daemons
  File "/usr/lib/python2.7/dist-packages/salt/cli/daemons.py", line 46, in <module>
    from salt.utils import parsers, ip_bracket
  File "/usr/lib/python2.7/dist-packages/salt/utils/parsers.py", line 26, in <module>
    import salt.config as config
  File "/usr/lib/python2.7/dist-packages/salt/config.py", line 39, in <module>
    import salt.utils.sdb
  File "/usr/lib/python2.7/dist-packages/salt/utils/sdb.py", line 9, in <module>
    import salt.loader
  File "/usr/lib/python2.7/dist-packages/salt/loader.py", line 27, in <module>
    import salt.utils.event
  File "/usr/lib/python2.7/dist-packages/salt/utils/event.py", line 80, in <module>
    import salt.payload
  File "/usr/lib/python2.7/dist-packages/salt/payload.py", line 17, in <module>
    import salt.crypt
  File "/usr/lib/python2.7/dist-packages/salt/crypt.py", line 36, in <module>
    import salt.transport.client
  File "/usr/lib/python2.7/dist-packages/salt/transport/client.py", line 12, in <module>
    from salt.utils.async import SyncWrapper
  File "/usr/lib/python2.7/dist-packages/salt/utils/async.py", line 8, in <module>
    import tornado.ioloop
ImportError: No module named tornado.ioloop
```

This patch fix tornado installaion.
