### PR TITLE
Add missing urllib3 dependency for Ubuntu (hotfix)

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1771,9 +1771,11 @@ install_ubuntu_deps() {
         # Above Ubuntu 11.04 add a -y flag
         add-apt-repository -y "ppa:chris-lea/python-requests" || return 1
         add-apt-repository -y "ppa:chris-lea/python-chardet" || return 1
+        add-apt-repository -y "ppa:chris-lea/python-urllib3" || return 1
     else
         add-apt-repository "ppa:chris-lea/python-requests" || return 1
         add-apt-repository "ppa:chris-lea/python-chardet" || return 1
+        add-apt-repository "ppa:chris-lea/python-urllib3" || return 1
     fi
 
     __PACKAGES="${__PACKAGES} python-requests"


### PR DESCRIPTION
Vagrant installs using the bootstrap from `stable`, and currently this branch does not include the `python-urllib3` PPA dependency that newer versions of the bootstrap install on Ubuntu versions greater than 11.

Even though this change already exists in develop, I think it's important to get it to stable ASAP so users on Ubuntu 12+ can use Vagrant's salt provisioner.

This causes issue https://github.com/saltstack/salt-bootstrap/issues/637, and still requires the [workaround mentioned in the comments there](https://github.com/saltstack/salt-bootstrap/issues/637#issuecomment-124862874) until upstream fixes https://github.com/mitchellh/vagrant/issues/6029.

To test:
1. Update Vagrant's `/embedded/gems/gems/vagrant-1.7.4/plugins/provisioners/salt/bootstrap-salt.sh` in the vagrant installation directory (`/opt/vagrant` for me on OS X) to use this PR's bootstrap file. [Here's a gist](https://gist.github.com/johntron/d981f23f6a6075637847).
2. Update your Vagrantfile to use the `-P` flag (see [comment](https://github.com/saltstack/salt-bootstrap/issues/637#issuecomment-124862874)).
2. Create a fresh VM with salt provisioning.
