### PR TITLE
Fixes error finding python-jinja2 in RHEL 7

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -3189,7 +3189,7 @@ __test_rhel_optionals_packages() {
     yum list installed yum-utils > /dev/null 2>&1 || yum -y install yum-utils --enablerepo=${_EPEL_REPO} || return 1
 
     if [ "$DISTRO_MAJOR_VERSION" -ge 7 ]; then
-        yum-config-manager --enable \*server-optional || return 1
+        yum-config-manager --enable \*server-optional-rpms || return 1
     fi
 
     if [ "$DISTRO_MAJOR_VERSION" -ge 6 ]; then


### PR DESCRIPTION
The installer prints the following on RHEL 7 when the server optional package is not enabled:

```
 *  INFO: Testing if packages usually on the optionals repository are available:
 *  INFO:   - python-jinja2
 * ERROR: Failed to find an installable 'python-jinja2' package. The optional repository or its subscription might be missing.
 *  INFO: Sleeping 10 seconds while waiting for the optional repository subscription to be externally configured
```

This change fixes the name of the server-optional repo to be the correct name.

The command `sudo subscription-manager repos --list` displays all available repos and their names.
