### PR TITLE
Install stable version with the insecure example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -149,7 +149,7 @@ Installing the latest develop branch of Salt:
 
 .. code:: console
 
-  curl -L https://bootstrap.saltstack.com | sudo sh -s -- git develop
+  curl -L https://bootstrap.saltstack.com | sudo sh -s -- stable
 
 Any of the example above which use two-lines can be made to run in a single-line
 configuration with minor modifications.


### PR DESCRIPTION
For anyone who does copy & paste the insecure one-liner, they probably should get the stable version rather than development.
