### PR TITLE
Change to 'dnf' as package manager for Fedora 22->

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2629,14 +2629,14 @@ install_debian_check_services() {
 
 FEDORA_PACKAGE_MANAGER="yum"
 
-fedora_get_package_manager() {
+__fedora_get_package_manager() {
   if [ "$DISTRO_MAJOR_VERSION" -lt 22 ] || [ "$(which dnf)" != "" ]; then
     FEDORA_PACKAGE_MANAGER="dnf"
   fi
 }
 
 install_fedora_deps() {
-    fedora_get_package_manager
+    __fedora_get_package_manager
     if [ "$_ENABLE_EXTERNAL_ZMQ_REPOS" -eq $BS_TRUE ]; then
         __install_saltstack_copr_zeromq_repository || return 1
     fi
@@ -2666,7 +2666,7 @@ install_fedora_deps() {
 }
 
 install_fedora_stable() {
-    fedora_get_package_manager
+    __fedora_get_package_manager
     __PACKAGES=""
     if [ "$_INSTALL_MINION" -eq $BS_TRUE ]; then
         __PACKAGES="${__PACKAGES} salt-minion"
@@ -2697,7 +2697,7 @@ install_fedora_stable_post() {
 }
 
 install_fedora_git_deps() {
-    fedora_get_package_manager
+    __fedora_get_package_manager
     install_fedora_deps || return 1
 
     if [ "$(which git)" = "" ]; then

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2630,7 +2630,7 @@ install_debian_check_services() {
 FEDORA_PACKAGE_MANAGER="yum"
 
 __fedora_get_package_manager() {
-  if [ "$DISTRO_MAJOR_VERSION" -lt 22 ] || [ "$(which dnf)" != "" ]; then
+  if [ "$DISTRO_MAJOR_VERSION" -ge 22 ] || [ "$(which dnf)" != "" ]; then
     FEDORA_PACKAGE_MANAGER="dnf"
   fi
 }


### PR DESCRIPTION
If you are installing Saltstack on Fedora 22 onwards, the default package manager
is dnf (instead of yum).
This patch decide which package manager to use based on Fedora version and the
availability of dnf on the current system. If found, uses dnf to install packages
needed by saltstack.

Using this patch final user will not see yum deprecation warnings like:
Yum command has been deprecated, redirecting to '/usr/bin/dnf install -y yum-utils..
See 'man dnf' and 'man yum2dnf' for more information.
To transfer transaction metadata from yum to DNF, run:
'dnf install python-dnf-plugins-extras-migrate && dnf-2 migrate'
