### PR TITLE
Update bootstrap-salt.sh

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -778,6 +778,8 @@ __gather_linux_system_info() {
         elif [ "${DISTRO_NAME}" = "Arch" ]; then
             DISTRO_NAME="Arch Linux"
             return
+        elif [ "${DISTRO_NAME}" = "Raspbian" ]; then
+           DISTRO_NAME="Debian"
         fi
         rv=$(lsb_release -sr)
         [ "${rv}" != "" ] && DISTRO_VERSION=$(__parse_version_string "$rv")


### PR DESCRIPTION
Resolves: Bootstrap fails on Raspbian #539 

Add alias of Raspbian to match the debian family. Tested working on Raspbian jessie (released 2015-09-24)
