### PR TITLE
Add support for pegged versions on YUM based OS'ses through repo.saltstack.com

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1875,7 +1875,7 @@ install_ubuntu_stable_deps() {
 
         # Saltstack's Stable Ubuntu repository
         if [ "$(grep -ER 'latest .+ main' /etc/apt)" = "" ]; then
-            echo "deb http://repo.saltstack.com/apt/ubuntu/$DISTRO_VERSION/$CPU_ARCH/$STABLE_REV $DISTRO_CODENAME main" >> \
+            echo "deb http://repo.saltstack.com/apt/ubuntu/$DISTRO_VERSION/$CPU_ARCH_L/$STABLE_REV $DISTRO_CODENAME main" >> \
                 /etc/apt/sources.list.d/saltstack.list
         fi
 
@@ -1884,7 +1884,7 @@ install_ubuntu_stable_deps() {
         __apt_get_install_noinput wget
 
         # shellcheck disable=SC2086
-        wget $_WGET_ARGS -q https://repo.saltstack.com/apt/ubuntu/$DISTRO_VERSION/$CPU_ARCH/$STABLE_REV/SALTSTACK-GPG-KEY.pub -O - | apt-key add - || return 1
+        wget $_WGET_ARGS -q https://repo.saltstack.com/apt/ubuntu/$DISTRO_VERSION/$CPU_ARCH_L/$STABLE_REV/SALTSTACK-GPG-KEY.pub -O - | apt-key add - || return 1
 
     else
         # Alternate PPAs: salt16, salt17, salt2014-1, salt2014-7

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2942,7 +2942,7 @@ enabled_metadata=1
 _eof
         if [ "$ITYPE" = "stable" -a "$STABLE_REV" != "latest" ]; then
             cat << _eof >> "/etc/yum.repos.d/repo-saltstack-el${DISTRO_MAJOR_VERSION}.repo"
-includepkgs=[0-9]:[!s][!a][!l][!t]* salt*${STABLE_REV}*
+includepkgs=?:[!s][!a][!l][!t]* salt*${STABLE_REV}*
 _eof
         fi
 
@@ -2967,7 +2967,7 @@ enabled_metadata=1
 _eof
         if [ "$ITYPE" = "stable" -a "$STABLE_REV" != "latest" ]; then
             cat << _eof >> "/etc/yum.repos.d/repo-saltstack-el${DISTRO_MAJOR_VERSION}.repo"
-includepkgs=[0-9]:[!s][!a][!l][!t]* salt*${STABLE_REV}*
+includepkgs=?:[!s][!a][!l][!t]* salt*${STABLE_REV}*
 _eof
         fi
 

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -3168,7 +3168,7 @@ install_centos_git() {
         _PYEXE=python2
     fi
     if [ -f "${__SALT_GIT_CHECKOUT_DIR}/salt/syspaths.py" ]; then
-        $_PYEXE setup.py --prefix=/usr --salt-config-dir="$_SALT_ETC_DIR" install || return 1
+        $_PYEXE setup.py install --prefix=/usr --salt-config-dir="$_SALT_ETC_DIR" || return 1
     else
         $_PYEXE setup.py install --prefix=/usr || return 1
     fi

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2925,10 +2925,12 @@ __install_saltstack_copr_zeromq_repository() {
 
 __install_saltstack_rhel_repository() {
     base_url="https://repo.saltstack.com/yum/redhat/\$releasever/\$basearch/${STABLE_REV}/"
+    fetch_url="https://repo.saltstack.com/yum/redhat/${DISTRO_MAJOR_VERSION}/${CPU_ARCH_L}/"
+
     if [ "${DISTRO_MAJOR_VERSION}" -eq 5 ]; then
-        gpg_url="${base_url}SALTSTACK-EL5-GPG-KEY.pub"
+        gpg_key="SALTSTACK-EL5-GPG-KEY.pub"
     else
-        gpg_url="${base_url}SALTSTACK-GPG-KEY.pub"
+        gpg_key="SALTSTACK-GPG-KEY.pub"
     fi
 
     repo_file="/etc/yum.repos.d/salt-${STABLE_REV}.repo"
@@ -2939,12 +2941,12 @@ name=SaltStack ${STABLE_REV} Release Channel for RHEL/CentOS \$releasever
 baseurl=$base_url
 skip_if_unavailable=True
 gpgcheck=1
-gpgkey=$gpg_url
+gpgkey=${base_url}${gpg_key}
 enabled=1
-enabled_metadata=1
+enabled_metadata=1gpg
 _eof
 
-        __fetch_url /tmp/repo-saltstack.pub "$gpg_url" || return 1
+        __fetch_url /tmp/repo-saltstack.pub "${fetch_url}${gpg_key}" || return 1
         rpm --import /tmp/repo-saltstack.pub || return 1
         rm -f /tmp/repo-saltstack.pub
     fi

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1875,7 +1875,7 @@ install_ubuntu_stable_deps() {
 
         # Saltstack's Stable Ubuntu repository
         if [ "$(grep -ER 'latest .+ main' /etc/apt)" = "" ]; then
-            echo "deb http://repo.saltstack.com/apt/ubuntu/ubuntu$DISTRO_MAJOR_VERSION/$STABLE_REV $DISTRO_CODENAME main" >> \
+            echo "deb http://repo.saltstack.com/apt/ubuntu/$DISTRO_VERSION/$CPU_ARCH/$STABLE_REV $DISTRO_CODENAME main" >> \
                 /etc/apt/sources.list.d/saltstack.list
         fi
 
@@ -1884,7 +1884,7 @@ install_ubuntu_stable_deps() {
         __apt_get_install_noinput wget
 
         # shellcheck disable=SC2086
-        wget $_WGET_ARGS -q https://repo.saltstack.com/apt/ubuntu/ubuntu$DISTRO_MAJOR_VERSION/$STABLE_REV/SALTSTACK-GPG-KEY.pub -O - | apt-key add - || return 1
+        wget $_WGET_ARGS -q https://repo.saltstack.com/apt/ubuntu/$DISTRO_VERSION/$CPU_ARCH/$STABLE_REV/SALTSTACK-GPG-KEY.pub -O - | apt-key add - || return 1
 
     else
         # Alternate PPAs: salt16, salt17, salt2014-1, salt2014-7
@@ -2949,7 +2949,7 @@ skip_if_unavailable=True
 gpgcheck=1
 gpgkey=${base_url}${gpg_key}
 enabled=1
-enabled_metadata=1gpg
+enabled_metadata=1
 _eof
 
         __fetch_url /tmp/repo-saltstack.pub "${fetch_url}${gpg_key}" || return 1

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2924,8 +2924,14 @@ __install_saltstack_copr_zeromq_repository() {
 }
 
 __install_saltstack_rhel_repository() {
-    base_url="https://repo.saltstack.com/yum/redhat/\$releasever/\$basearch/${STABLE_REV}/"
-    fetch_url="https://repo.saltstack.com/yum/redhat/${DISTRO_MAJOR_VERSION}/${CPU_ARCH_L}/${STABLE_REV}/"
+    if [ "$ITYPE" = "stable" ]; then
+        repo_rev="$STABLE_REV"
+    else
+        repo_rev="latest"
+    fi
+
+    base_url="https://repo.saltstack.com/yum/redhat/\$releasever/\$basearch/${repo_rev}/"
+    fetch_url="https://repo.saltstack.com/yum/redhat/${DISTRO_MAJOR_VERSION}/${CPU_ARCH_L}/${repo_rev}/"
 
     if [ "${DISTRO_MAJOR_VERSION}" -eq 5 ]; then
         gpg_key="SALTSTACK-EL5-GPG-KEY.pub"
@@ -2933,11 +2939,11 @@ __install_saltstack_rhel_repository() {
         gpg_key="SALTSTACK-GPG-KEY.pub"
     fi
 
-    repo_file="/etc/yum.repos.d/salt-${STABLE_REV}.repo"
+    repo_file="/etc/yum.repos.d/salt-${repo_rev}.repo"
     if [ ! -s "$repo_file" ]; then
         cat <<_eof > "$repo_file"
-[salt-${STABLE_REV}]
-name=SaltStack ${STABLE_REV} Release Channel for RHEL/CentOS \$releasever
+[salt-${repo_rev}]
+name=SaltStack ${repo_rev} Release Channel for RHEL/CentOS \$releasever
 baseurl=$base_url
 skip_if_unavailable=True
 gpgcheck=1

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1876,6 +1876,14 @@ install_ubuntu_deps() {
 }
 
 install_ubuntu_stable_deps() {
+    # This probably holds true for the Debians as well
+    if [ "$CPU_ARCH_L" = "amd64" -o "$CPU_ARCH_L" = "x86_64" ]; then
+        repo_arch="amd64"
+    elif [ "$CPU_ARCH_L" = "i386" -o "$CPU_ARCH_L" = "i686" ]; then
+        echoerror "repo.saltstack.com likely doesn't have 32-bit packages for Ubuntu (yet?)"
+        repo_arch="i386"
+    fi
+
     install_ubuntu_deps || return 1
 
     # the latest version of 2015.5 and all versions of 2015.8 and beyond are hosted on repo.saltstack.com
@@ -1883,7 +1891,7 @@ install_ubuntu_stable_deps() {
 
         # Saltstack's Stable Ubuntu repository
         if [ "$(grep -ER 'latest .+ main' /etc/apt)" = "" ]; then
-            echo "deb http://repo.saltstack.com/apt/ubuntu/$DISTRO_VERSION/$CPU_ARCH_L/$STABLE_REV $DISTRO_CODENAME main" >> \
+            echo "deb http://repo.saltstack.com/apt/ubuntu/$DISTRO_VERSION/$repo_arch/$STABLE_REV $DISTRO_CODENAME main" >> \
                 /etc/apt/sources.list.d/saltstack.list
         fi
 
@@ -1892,7 +1900,7 @@ install_ubuntu_stable_deps() {
         __apt_get_install_noinput wget
 
         # shellcheck disable=SC2086
-        wget $_WGET_ARGS -q https://repo.saltstack.com/apt/ubuntu/$DISTRO_VERSION/$CPU_ARCH_L/$STABLE_REV/SALTSTACK-GPG-KEY.pub -O - | apt-key add - || return 1
+        wget $_WGET_ARGS -q https://repo.saltstack.com/apt/ubuntu/$DISTRO_VERSION/$repo_arch/$STABLE_REV/SALTSTACK-GPG-KEY.pub -O - | apt-key add - || return 1
 
     else
         # Alternate PPAs: salt16, salt17, salt2014-1, salt2014-7
@@ -2938,7 +2946,7 @@ __install_saltstack_rhel_repository() {
         repo_rev="latest"
     fi
 
-    base_url="https://repo.saltstack.com/yum/redhat/\$releasever/\$basearch/${repo_rev}/"
+    base_url="http://repo.saltstack.com/yum/redhat/\$releasever/\$basearch/${repo_rev}/"
     fetch_url="https://repo.saltstack.com/yum/redhat/${DISTRO_MAJOR_VERSION}/${CPU_ARCH_L}/${repo_rev}/"
 
     if [ "${DISTRO_MAJOR_VERSION}" -eq 5 ]; then

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1877,12 +1877,12 @@ install_ubuntu_stable_deps() {
 
         # Saltstack's Stable Ubuntu repository
         if [ "$(grep -ER 'latest .+ main' /etc/apt)" = "" ]; then
-            echo "deb http://repo.saltstack.com/apt/ubuntu/ubuntu$DISTRO_MAJOR_VERSION/$STABLE_REV $DISTRO_CODENAME main" >> \
+            echo "deb https://repo.saltstack.com/apt/ubuntu/ubuntu$DISTRO_MAJOR_VERSION/$STABLE_REV $DISTRO_CODENAME main" >> \
                 /etc/apt/sources.list.d/saltstack.list
         fi
 
         # shellcheck disable=SC2086
-        wget $_WGET_ARGS -q http://repo.saltstack.com/apt/ubuntu/ubuntu$DISTRO_MAJOR_VERSION/$STABLE_REV/SALTSTACK-GPG-KEY.pub -O - | apt-key add - || return 1
+        wget $_WGET_ARGS -q https://repo.saltstack.com/apt/ubuntu/ubuntu$DISTRO_MAJOR_VERSION/$STABLE_REV/SALTSTACK-GPG-KEY.pub -O - | apt-key add - || return 1
 
     else
         # Alternate PPAs: salt16, salt17, salt2014-1, salt2014-7

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1761,9 +1761,9 @@ __enable_universe_repository() {
     elif [ "$DISTRO_MAJOR_VERSION" -lt 11 ] && [ "$DISTRO_MINOR_VERSION" -lt 10 ]; then
         # Below Ubuntu 11.10, the -y flag to add-apt-repository is not supported
         add-apt-repository "deb http://old-releases.ubuntu.com/ubuntu $(lsb_release -sc) universe" || return 1
+    else
+        add-apt-repository -y "deb http://old-releases.ubuntu.com/ubuntu $(lsb_release -sc) universe" || return 1
     fi
-
-    add-apt-repository -y "deb http://old-releases.ubuntu.com/ubuntu $(lsb_release -sc) universe" || return 1
 
     return 0
 }

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2940,7 +2940,7 @@ gpgkey=https://repo.saltstack.com/yum/rhel5/SALTSTACK-EL5-GPG-KEY.pub
 enabled=1
 enabled_metadata=1
 _eof
-        if [ "$STABLE_REV" != "latest" ]; then
+        if [ "$ITYPE" = "stable" -a "$STABLE_REV" != "latest" ]; then
             cat << _eof >> "/etc/yum.repos.d/repo-saltstack-el${DISTRO_MAJOR_VERSION}.repo"
 includepkgs=[0-9]:[!s][!a][!l][!t]* salt*${STABLE_REV}*
 _eof
@@ -2965,7 +2965,7 @@ gpgkey=https://repo.saltstack.com/yum/rhel${DISTRO_MAJOR_VERSION}/SALTSTACK-GPG-
 enabled=1
 enabled_metadata=1
 _eof
-        if [ "$STABLE_REV" != "latest" ]; then
+        if [ "$ITYPE" = "stable" -a "$STABLE_REV" != "latest" ]; then
             cat << _eof >> "/etc/yum.repos.d/repo-saltstack-el${DISTRO_MAJOR_VERSION}.repo"
 includepkgs=[0-9]:[!s][!a][!l][!t]* salt*${STABLE_REV}*
 _eof

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2925,7 +2925,7 @@ __install_saltstack_copr_zeromq_repository() {
 
 __install_saltstack_rhel_repository() {
     base_url="https://repo.saltstack.com/yum/redhat/\$releasever/\$basearch/${STABLE_REV}/"
-    fetch_url="https://repo.saltstack.com/yum/redhat/${DISTRO_MAJOR_VERSION}/${CPU_ARCH_L}/"
+    fetch_url="https://repo.saltstack.com/yum/redhat/${DISTRO_MAJOR_VERSION}/${CPU_ARCH_L}/${STABLE_REV}/"
 
     if [ "${DISTRO_MAJOR_VERSION}" -eq 5 ]; then
         gpg_key="SALTSTACK-EL5-GPG-KEY.pub"

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1205,7 +1205,7 @@ __ubuntu_codename_translation
 if ([ "${DISTRO_NAME_L}" != "ubuntu" ] && [ "$ITYPE" = "daily" ]); then
     echoerror "${DISTRO_NAME} does not have daily packages support"
     exit 1
-elif ([ "${DISTRO_NAME_L}" != "ubuntu" ] && [ "$ITYPE" = "stable" ] && [ "$STABLE_REV" != "latest" ]); then
+elif ([ "$(echo "${DISTRO_NAME_L}" | egrep '(ubuntu|centos|red_hat|scientific|oracle|amazon|fedora)')" = "" ] && [ "$ITYPE" = "stable" ] && [ "$STABLE_REV" != "latest" ]); then
     echoerror "${DISTRO_NAME} does not have major version pegged packages support"
     exit 1
 fi
@@ -2940,6 +2940,11 @@ gpgkey=https://repo.saltstack.com/yum/rhel5/SALTSTACK-EL5-GPG-KEY.pub
 enabled=1
 enabled_metadata=1
 _eof
+        if [ "$STABLE_REV" != "latest" ]; then
+            cat << _eof >> "/etc/yum.repos.d/repo-saltstack-el${DISTRO_MAJOR_VERSION}.repo"
+includepkgs=[0-9]:[!s][!a][!l][!t]* salt*${STABLE_REV}*
+_eof
+        fi
 
         __fetch_url /tmp/repo-saltstack-el5.pub "https://repo.saltstack.com/yum/rhel5/SALTSTACK-EL5-GPG-KEY.pub" || return 1
         rpm --import /tmp/repo-saltstack-el5.pub || return 1
@@ -2960,6 +2965,11 @@ gpgkey=https://repo.saltstack.com/yum/rhel${DISTRO_MAJOR_VERSION}/SALTSTACK-GPG-
 enabled=1
 enabled_metadata=1
 _eof
+        if [ "$STABLE_REV" != "latest" ]; then
+            cat << _eof >> "/etc/yum.repos.d/repo-saltstack-el${DISTRO_MAJOR_VERSION}.repo"
+includepkgs=[0-9]:[!s][!a][!l][!t]* salt*${STABLE_REV}*
+_eof
+        fi
 
         __fetch_url /tmp/repo-saltstack.pub "https://repo.saltstack.com/yum/rhel${DISTRO_MAJOR_VERSION}/SALTSTACK-GPG-KEY.pub" || return 1
         rpm --import /tmp/repo-saltstack.pub || return 1

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1877,7 +1877,7 @@ install_ubuntu_stable_deps() {
 
         # Saltstack's Stable Ubuntu repository
         if [ "$(grep -ER 'latest .+ main' /etc/apt)" = "" ]; then
-            echo "deb https://repo.saltstack.com/apt/ubuntu/ubuntu$DISTRO_MAJOR_VERSION/$STABLE_REV $DISTRO_CODENAME main" >> \
+            echo "deb http://repo.saltstack.com/apt/ubuntu/ubuntu$DISTRO_MAJOR_VERSION/$STABLE_REV $DISTRO_CODENAME main" >> \
                 /etc/apt/sources.list.d/saltstack.list
         fi
 


### PR DESCRIPTION
This patch adds major version pegging support for YUM based OS'es by leveraging Salt's new repo layout.
See the discussion for further details.

~~This admittedly hacky patch (blame your own repo infrastructure for that ;) ) adds version pegging support to repo.saltstack.com repos for any YUM based OS that properly supports glob matching in `includepkgs/exclude=`.~~
~~I've only tested it on CentOS 7, will probably test CentOS 6/7 in the very near future if this gets committed, but the `includepkgs/exclude=` syntax seems universal.~~

~~It does this by adding~~

```
includepkgs=[0-9]:[!s][!a][!l][!t]* salt*${STABLE_REV}*
```

~~to the repo definition if `STABLE_REV` isn't `latest`.
(In case you're wondering, the `[0-9]:` is because YUM also matches on a string with an 'epoch' in it)~~
