### PR TITLE
Better EPEL repository detection on RHEL and CentOS

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2873,7 +2873,7 @@ __install_epel_repository() {
     fi
 
     # Check if epel repo is already enabled and flag it accordingly
-    yum repolist | grep -i "epel" > /dev/null 2>&1
+    yum repolist | grep -i '^epel/' > /dev/null 2>&1
     if [ $? -eq 0 ]; then
         __EPEL_REPOS_INSTALLED=${BS_TRUE}
         return 0

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2873,7 +2873,7 @@ __install_epel_repository() {
     fi
 
     # Check if epel repo is already enabled and flag it accordingly
-    yum repolist | grep -i '^epel/' > /dev/null 2>&1
+    yum repolist | grep -q "^[!]${_EPEL_REPO}/"
     if [ $? -eq 0 ]; then
         __EPEL_REPOS_INSTALLED=${BS_TRUE}
         return 0


### PR DESCRIPTION
Hi,

I had a problem with bootstrapping some CentOS machines were was pre-configured YUM repository which name contains "epel" substring, but that's not main Fedora's EPEL.

In such case script failed with very uninformative error:

```
         *  INFO: Running install_centos_stable_deps()
        Loaded plugins: fastestmirror


        Error getting repository data for epel, repository not found
         * ERROR: Failed to run install_centos_stable_deps()!!!
```

Providing more specific regex for grep fixes it.

P.S. I know this is kind of edge case, but somebody may fall into it as well.
