### PR TITLE
Remove SaltStack COPR repository configuration for CentOS/RHEL5

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2924,14 +2924,6 @@ __install_saltstack_copr_zeromq_repository() {
     return 0
 }
 
-__install_saltstack_copr_salt_el5_repository() {
-    if [ ! -s /etc/yum.repos.d/saltstack-salt-el5-epel-5.repo ]; then
-        __fetch_url /etc/yum.repos.d/saltstack-salt-el5-epel-5.repo \
-            "http://copr.fedoraproject.org/coprs/saltstack/salt-el5/repo/epel-5/saltstack-salt-el5-epel-5.repo" || return 1
-    fi
-    return 0
-}
-
 __install_saltstack_rhel5_repository() {
     if [ ! -s /etc/yum.repos.d/repo-saltstack-el5.repo ]; then
         cat <<_eof > /etc/yum.repos.d/repo-saltstack-el5.repo


### PR DESCRIPTION
The function `__install_saltstack_copr_salt_el5_repository` is not referenced anywhere else in the script, and COPR became deprecated for RHEL/CentOS recently.
