### PR TITLE
Add opensuse_Tumbleweed support

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -4434,9 +4434,11 @@ __zypper_install() {
 }
 
 install_opensuse_stable_deps() {
-    if [ "${DISTRO_MAJOR_VERSION}" -ge 42 ]; then
+    if [ "${DISTRO_MAJOR_VERSION}" -gt 2015 ]; then
+        DISTRO_REPO="openSUSE_Tumbleweed"
+    elif [ "${DISTRO_MAJOR_VERSION}" -ge 42 ]; then
         DISTRO_REPO="openSUSE_Leap_${DISTRO_MAJOR_VERSION}.${DISTRO_MINOR_VERSION}"
-    else
+    elif [ "${DISTRO_MAJOR_VERSION}" -lt 42 ]; then
         DISTRO_REPO="openSUSE_${DISTRO_MAJOR_VERSION}.${DISTRO_MINOR_VERSION}"
     fi
 


### PR DESCRIPTION
This will add the opensuse Tumbleweed support..

Tested it: couldn't find the mock installation, so it bugs, that already installed stuff...

```
oot@tumble:~SSH$ ./bootstrap-salt.sh 
 *  INFO: /bin/sh ./bootstrap-salt.sh -- Version 2015.11.09
 *  WARN: Running the unstable version of bootstrap-salt.sh

 *  INFO: System Information:
 *  INFO:   CPU:          GenuineIntel
 *  INFO:   CPU Arch:     x86_64
 *  INFO:   OS Name:      Linux
 *  INFO:   OS Version:   4.3.3-3-default
 *  INFO:   Distribution: opensuse 20160101

 *  INFO: Installing minion
 *  INFO: Found function install_opensuse_stable_deps
 *  INFO: Found function install_opensuse_stable
 *  INFO: Found function install_opensuse_stable_post
 *  INFO: Found function install_opensuse_restart_daemons
 *  INFO: Found function daemons_running
 *  INFO: Found function install_opensuse_check_services
 *  INFO: Running install_opensuse_stable_deps()
Adding repository 'Python Modules (openSUSE_Tumbleweed)' [......done]
Repository 'Python Modules (openSUSE_Tumbleweed)' successfully added
Enabled     : Yes                                                                                    
Autorefresh : Yes                                                                                    
GPG Check   : Yes                                                                                    
Priority    : 99                                                                                     
URI         : http://download.opensuse.org/repositories/devel:/languages:/python/openSUSE_Tumbleweed/

Retrieving repository 'Python Modules (openSUSE_Tumbleweed)' metadata [..done]
Building repository 'Python Modules (openSUSE_Tumbleweed)' cache [....done]
Repository 'home project (openSUSE_Tumbleweed)' is up to date.
Repository 'openSUSE-Tumbleweed-Non-Oss' is up to date.
Retrieving repository 'openSUSE-Tumbleweed-oss' metadata [....done]
Building repository 'openSUSE-Tumbleweed-oss' cache [....done]
Repository 'openSUSE-Tumbleweed-Update' is up to date.
Repository 'SaltStack, dependencies, and addons (openSUSE_Tumbleweed)' is up to date.
Repository 'Testing EXPERIMENTAL Salt versions (openSUSE_Tumbleweed)' is up to date.
All repositories have been refreshed.
Loading repository data...
Reading installed packages...
'python' is already installed.
No update candidate for 'python-2.7.10-3.2.x86_64'. The highest available version is already installed.
'python-xml' is already installed.
No update candidate for 'python-xml-2.7.10-3.1.x86_64'. The highest available version is already installed.
'python-requests' is already installed.
There is an update candidate for 'python-requests', but it is from a different vendor. Use 'zypper install python-requests-2.8.1-79.1.noarch' to install this candidate.
'python-PyYAML' is already installed.
There is an update candidate for 'python-PyYAML', but it is from a different vendor. Use 'zypper install python-PyYAML-3.11-27.10.x86_64' to install this candidate.
'python-pycrypto' is already installed.
There is an update candidate for 'python-pycrypto', but it is from a different vendor. Use 'zypper install python-pycrypto-2.6.1-39.11.x86_64' to install this candidate.
'python-pyzmq' is already installed.
There is an update candidate for 'python-pyzmq', but it is from a different vendor. Use 'zypper install python-pyzmq-14.7.0-59.4.x86_64' to install this candidate.
'python-Jinja2' is already installed.
There is an update candidate for 'python-Jinja2', but it is from a different vendor. Use 'zypper install python-Jinja2-2.8-69.2.noarch' to install this candidate.
'python-msgpack-python' is already installed.
There is an update candidate for 'python-msgpack-python', but it is from a different vendor. Use 'zypper install python-msgpack-python-0.4.6-41.2.x86_64' to install this candidate.
'python-M2Crypto' is already installed.
There is an update candidate for 'python-M2Crypto', but it is from a different vendor. Use 'zypper install python-M2Crypto-0.22.5-45.3.x86_64' to install this candidate.
'libzmq5' is already installed.
No update candidate for 'libzmq5-4.1.3-2.2.x86_64'. The highest available version is already installed.
'python-zypp' is already installed.
No update candidate for 'python-zypp-0.7.3-1.4.x86_64'. The highest available version is already installed.
Resolving package dependencies...

Nothing to do.
 *  INFO: Running install_opensuse_stable()
Loading repository data...
Reading installed packages...
'salt-minion' is already installed.
No update candidate for 'salt-minion-2015.8.3-292.3.x86_64'. The highest available version is already installed.
Resolving package dependencies...

Nothing to do.
 *  INFO: Running install_opensuse_stable_post()
disabled
Created symlink from /etc/systemd/system/multi-user.target.wants/salt-minion.service to /usr/lib/systemd/system/salt-minion.service.
 *  INFO: Running install_opensuse_check_services()
 *  INFO: Running install_opensuse_restart_daemons()
 *  INFO: Running daemons_running()
 *  INFO: Salt installed!
root@tumble:~SSH$ 
```

This is the new /etc/SuSE-release file for tumbleweed...

```
root@tumble:~SSH$ find /etc/ -name '*-release' -print -exec cat {} \;
/etc/SuSE-release
openSUSE 20160101 (x86_64)
VERSION = 20160101
CODENAME = Tumbleweed
# /etc/SuSE-release is deprecated and will be removed in the future, use /etc/os-release instead
/etc/os-release
NAME=openSUSE
VERSION="Tumbleweed"
VERSION_ID="20160101"
PRETTY_NAME="openSUSE Tumbleweed (20160101) (x86_64)"
ID=opensuse
ANSI_COLOR="0;32"
CPE_NAME="cpe:/o:opensuse:opensuse:20160101"
BUG_REPORT_URL="https://bugs.opensuse.org"
HOME_URL="https://opensuse.org/"
ID_LIKE="suse"
```
