### PR TITLE
Sometimes bootstrap doesn't install zmq

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2516,7 +2516,7 @@ install_debian_8_git_deps() {
         __apt_get_install_noinput git || return 1
     fi
 
-    if [ "$(python -c 'import zmq; print(zmq.pyzmq_version())')" = "" ]; then
+    if [ "$(dpkg-query -l 'python-zmq')" = "" ]; then
         __apt_get_install_noinput libzmq3 libzmq3-dev python-zmq || return 1
     fi
 

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2516,7 +2516,7 @@ install_debian_8_git_deps() {
         __apt_get_install_noinput git || return 1
     fi
 
-    if [ "$(python -c 'import zmq; print zmq.pyzmq_version()')" = "" ]; then
+    if [ "$(python -c 'import zmq; print(zmq.pyzmq_version())')" = "" ]; then
         __apt_get_install_noinput libzmq3 libzmq3-dev python-zmq || return 1
     fi
 

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2516,6 +2516,10 @@ install_debian_8_git_deps() {
         __apt_get_install_noinput git || return 1
     fi
 
+    if [ "$(python -c 'import zmq; print zmq.pyzmq_version()')" = "" ]; then
+        __apt_get_install_noinput libzmq3 libzmq3-dev python-zmq || return 1
+    fi
+
     __apt_get_install_noinput lsb-release python python-pkg-resources python-crypto \
         python-jinja2 python-m2crypto python-yaml msgpack-python python-pip || return 1
 


### PR DESCRIPTION
When installing from git, bootstrap seems to skip over the zmq installation.
This checks if zmq has been installed, if not, it installs it.
