### PR TITLE
switch repositories for suse and sles fixes #706

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -4444,11 +4444,11 @@ install_opensuse_stable_deps() {
     fi
 
     # Is the repository already known
-    __zypper repos | grep devel_languages_python >/dev/null 2>&1
+    __zypper repos | grep systemsmanagement_saltstack >/dev/null 2>&1
     if [ $? -eq 1 ]; then
-        # zypper does not yet know nothing about devel_languages_python
+        # zypper does not yet know nothing about systemsmanagement_saltstack
         __zypper addrepo --refresh \
-            "http://download.opensuse.org/repositories/devel:/languages:/python/${DISTRO_REPO}/devel:languages:python.repo" || return 1
+            "http://download.opensuse.org/repositories/systemsmanagement:saltstack/${DISTRO_REPO}/systemsmanagement:saltstack.repo" || return 1
     fi
 
     __zypper --gpg-auto-import-keys refresh
@@ -4663,11 +4663,11 @@ install_suse_11_stable_deps() {
     DISTRO_REPO="SLE_${DISTRO_MAJOR_VERSION}${DISTRO_PATCHLEVEL}"
 
     # Is the repository already known
-    __zypper repos | grep devel_languages_python >/dev/null 2>&1
+    __zypper repos | grep systemsmanagement_saltstack >/dev/null 2>&1
     if [ $? -eq 1 ]; then
-        # zypper does not yet know nothing about devel_languages_python
+        # zypper does not yet know nothing about systemsmanagement_saltstack
         __zypper addrepo --refresh \
-            "http://download.opensuse.org/repositories/devel:/languages:/python/${DISTRO_REPO}/devel:languages:python.repo" || return 1
+            "http://download.opensuse.org/repositories/systemsmanagement:saltstack/${DISTRO_REPO}/systemsmanagement:saltstack.repo" || return 1
     fi
 
     __zypper --gpg-auto-import-keys refresh || return 1


### PR DESCRIPTION
Caution !!! don't merge without checking

This needs to be coordinated with the merge in salt:
https://github.com/saltstack/salt/pull/30410

We need to check if the merge with the documentation and salt-bootstrap 
can occur when everything is in place,

I don't know if there is an announcement neccesary for this change,
but it will change how suse / opensuse will get it packages.

These are the new upstream packages.

Please hold this until there is a go ahead. for salt.

this fixes: 
saltstack/salt-bootstrap#706
