### PR TITLE
replace --prefix by --salt-root-dir upon install_centos_git()

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -3160,9 +3160,9 @@ install_centos_git() {
         _PYEXE=python2
     fi
     if [ -f "${__SALT_GIT_CHECKOUT_DIR}/salt/syspaths.py" ]; then
-        $_PYEXE setup.py --prefix=/usr --salt-config-dir="$_SALT_ETC_DIR" install || return 1
+        $_PYEXE setup.py --salt-root-dir=/usr --salt-config-dir="$_SALT_ETC_DIR" install || return 1
     else
-        $_PYEXE setup.py install --prefix=/usr || return 1
+        $_PYEXE setup.py install --salt-root-dir=/usr || return 1
     fi
     return 0
 }
@@ -4549,7 +4549,7 @@ install_opensuse_stable() {
 }
 
 install_opensuse_git() {
-    python setup.py install --prefix=/usr || return 1
+    python setup.py install --salt-root-dir=/usr || return 1
     return 0
 }
 


### PR DESCRIPTION
looks like --prefix is now obsoleted?

```
2015.8.0
usage: setup.py [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
   or: setup.py --help [cmd1 cmd2 ...]
   or: setup.py --help-commands
   or: setup.py cmd --help

error: option --prefix not recognized
```

I've tested this patch on the following system only:

```
# salt-call --versions
Salt Version:
           Salt: 2015.8.3-5389-g8823d7f

Dependency Versions:
         Jinja2: 2.7.2
       M2Crypto: 0.21.1
           Mako: Not Installed
         PyYAML: 3.11
          PyZMQ: 14.7.0
         Python: 2.7.5 (default, Jun 24 2015, 00:41:19)
           RAET: Not Installed
        Tornado: 4.2.1
            ZMQ: 4.0.5
           cffi: Not Installed
       cherrypy: Not Installed
       dateutil: Not Installed
          gitdb: Not Installed
      gitpython: Not Installed
          ioflo: Not Installed
        libgit2: Not Installed
        libnacl: Not Installed
   msgpack-pure: Not Installed
 msgpack-python: 0.4.6
   mysql-python: Not Installed
      pycparser: Not Installed
       pycrypto: 2.6.1
         pygit2: Not Installed
   python-gnupg: Not Installed
          smmap: Not Installed
        timelib: Not Installed

System Versions:
           dist: centos 7.1.1503 Core
        machine: x86_64
        release: 3.10.0-229.20.1.el7.x86_64
         system: CentOS Linux 7.1.1503 Core
```
