### PR TITLE
epel-release-6-8.noarch.rpm breaks install

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -3655,7 +3655,7 @@ install_amazon_linux_ami_deps() {
     else
         EPEL_ARCH=$CPU_ARCH_L
     fi
-    rpm -Uvh --force "http://mirrors.kernel.org/fedora-epel/6/${EPEL_ARCH}/epel-release-6-8.noarch.rpm" || return 1
+    # rpm -Uvh --force "http://mirrors.kernel.org/fedora-epel/6/${EPEL_ARCH}/epel-release-6-8.noarch.rpm" || return 1
 
     __REPO_FILENAME="saltstack-salt-epel-6.repo"
 


### PR DESCRIPTION
I don't expect anyone to take this, just to illustrate an easy fix for Amazon Linux at the time. #742
## signature

```
...
 * DEBUG: CHECK_SERVICES_FUNC=null
 *  INFO: Running install_amazon_linux_ami_git_deps()
warning: /var/tmp/rpm-tmp.3dIWVW: Header V3 RSA/SHA256 Signature, key ID 0608b895: NOKEY
Retrieving http://mirrors.kernel.org/fedora-epel/6/x86_64/epel-release-6-8.noarch.rpm
Preparing...                          ########################################
Updating / installing...
epel-release-6-8                      ########################################
Cleaning up / removing...
epel-release-6-8.9.amzn1              ########################################
 *  INFO: Adding SaltStack's COPR repository
Loaded plugins: priorities, update-motd, upgrade-helper
File contains no section headers.
file: file:///etc/yum.repos.d/saltstack-salt-epel-6.repo, line: 1
'<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">\n'
Usage: yum [options] COMMAND
...
```
##  RPM repos contents

```
[epel]
name=Extra Packages for Enterprise Linux 6 - $basearch
#baseurl=http://download.fedoraproject.org/pub/epel/6/$basearch
mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=epel-6&arch=$basearch
failovermethod=priority
enabled=1
gpgcheck=1
gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-6

[epel-debuginfo]
name=Extra Packages for Enterprise Linux 6 - $basearch - Debug
#baseurl=http://download.fedoraproject.org/pub/epel/6/$basearch/debug
mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=epel-debug-6&arch=$basearch
failovermethod=priority
enabled=0
gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-6
gpgcheck=1

[epel-source]
name=Extra Packages for Enterprise Linux 6 - $basearch - Source
#baseurl=http://download.fedoraproject.org/pub/epel/6/SRPMS
mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=epel-source-6&arch=$basearch
failovermethod=priority
enabled=0
gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-6
gpgcheck=1
```
## salty repos

```
cat /etc/yum.repos.d/saltstack-salt-epel-6.repo 
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>302 Found</title>
</head><body>
<h1>Found</h1>
<p>The document has moved <a href="https://copr.fedorainfracloud.org/coprs/saltstack/salt/repo/epel-6/saltstack-salt-epel-6.repo">here</a>.</p>
<hr>
<address>Apache/2.4.6 (Red Hat Enterprise Linux) Server at copr.fedoraproject.org Port 80</address>
</body></html>
```
## bypass epel rpm install

```
cat /etc/yum.repos.d/saltstack-salt-epel-6.repo 
[saltstack-salt]
name=Copr repo for salt owned by saltstack
baseurl=https://copr-be.cloud.fedoraproject.org/results/saltstack/salt/epel-6-$basearch/
skip_if_unavailable=True
gpgcheck=1
gpgkey=https://copr-be.cloud.fedoraproject.org/results/saltstack/salt/pubkey.gpg
enabled=1
```

```
 *  INFO: - ./bootstrap-salt.sh -- Version 2015.11.09
 *  WARN: Running the unstable version of bootstrap-salt.sh

 *  INFO: System Information:
 *  INFO:   CPU:          GenuineIntel
 *  INFO:   CPU Arch:     x86_64
 *  INFO:   OS Name:      Linux
 *  INFO:   OS Version:   4.1.10-17.31.amzn1.x86_64
 *  INFO:   Distribution: Amazon Linux AMI 2015.09

 *  INFO: Installing minion
 *  INFO: Found function install_amazon_linux_ami_deps
 *  INFO: Found function install_amazon_linux_ami_stable
 *  INFO: Found function install_amazon_linux_ami_stable_post
 *  INFO: Found function install_amazon_linux_ami_restart_daemons
 *  INFO: Found function daemons_running
 *  INFO: Running install_amazon_linux_ami_deps()
 *  INFO: Adding SaltStack's COPR repository
Loaded plugins: priorities, update-motd, upgrade-helper
949 packages excluded due to repository priority protections
Package python-ordereddict is obsoleted by python26, trying to install python26-2.6.9-2.84.amzn1.x86_64 instead
Resolving Dependencies
--> Running transaction check
---> Package python-msgpack.x86_64 0:0.4.6-1.el6 will be installed
--> Processing Dependency: libpython2.6.so.1.0()(64bit) for package: python-msgpack-0.4.6-1.el6.x86_64
---> Package python-zmq.x86_64 0:14.3.1-1.el6 will be installed
--> Processing Dependency: libzmq.so.3()(64bit) for package: python-zmq-14.3.1-1.el6.x86_64
---> Package python26.x86_64 0:2.6.9-2.84.amzn1 will be installed
---> Package python26-PyYAML.x86_64 0:3.10-3.10.amzn1 will be installed
---> Package python26-crypto.x86_64 0:2.6.1-1.12.amzn1 will be installed
---> Package python26-jinja2.noarch 0:2.7.2-2.15.amzn1 will be installed
--> Processing Dependency: python26-markupsafe for package: python26-jinja2-2.7.2-2.15.amzn1.noarch
--> Processing Dependency: python26-babel for package: python26-jinja2-2.7.2-2.15.amzn1.noarch
---> Package python26-m2crypto.x86_64 0:0.21.1-15.14.amzn1 will be installed
---> Package python26-requests.noarch 0:1.2.3-5.10.amzn1 will be installed
--> Processing Dependency: python26-urllib3 >= 1.7 for package: python26-requests-1.2.3-5.10.amzn1.noarch
--> Processing Dependency: python26-chardet for package: python26-requests-1.2.3-5.10.amzn1.noarch
--> Running transaction check
---> Package python26-babel.noarch 0:0.9.4-5.1.8.amzn1 will be installed
--> Processing Dependency: python26-setuptools for package: python26-babel-0.9.4-5.1.8.amzn1.noarch
---> Package python26-chardet.noarch 0:2.0.1-7.7.amzn1 will be installed
---> Package python26-libs.x86_64 0:2.6.9-2.84.amzn1 will be installed
---> Package python26-markupsafe.x86_64 0:0.11-4.6.amzn1 will be installed
---> Package python26-urllib3.noarch 0:1.8.2-1.5.amzn1 will be installed
--> Processing Dependency: python26-backports-ssl_match_hostname for package: python26-urllib3-1.8.2-1.5.amzn1.noarch
--> Processing Dependency: python26-six for package: python26-urllib3-1.8.2-1.5.amzn1.noarch
---> Package zeromq3.x86_64 0:3.2.5-1.el6 will be installed
--> Processing Dependency: libpgm-5.1.so.0()(64bit) for package: zeromq3-3.2.5-1.el6.x86_64
--> Running transaction check
---> Package openpgm.x86_64 0:5.1.118-3.el6 will be installed
---> Package python26-backports-ssl_match_hostname.noarch 0:3.4.0.2-1.12.amzn1 will be installed
--> Processing Dependency: python26-backports for package: python26-backports-ssl_match_hostname-3.4.0.2-1.12.amzn1.noarch
---> Package python26-setuptools.noarch 0:12.2-1.30.amzn1 will be installed
---> Package python26-six.noarch 0:1.8.0-1.23.amzn1 will be installed
--> Running transaction check
---> Package python26-backports.x86_64 0:1.0-3.14.amzn1 will be installed
--> Finished Dependency Resolution

Dependencies Resolved

================================================================================
 Package                           Arch   Version            Repository    Size
================================================================================
Installing:
 python-msgpack                    x86_64 0.4.6-1.el6        epel          69 k
 python-zmq                        x86_64 14.3.1-1.el6       epel         467 k
 python26                          x86_64 2.6.9-2.84.amzn1   amzn-updates 5.8 M
 python26-PyYAML                   x86_64 3.10-3.10.amzn1    amzn-main    186 k
 python26-crypto                   x86_64 2.6.1-1.12.amzn1   amzn-main    697 k
 python26-jinja2                   noarch 2.7.2-2.15.amzn1   amzn-main    899 k
 python26-m2crypto                 x86_64 0.21.1-15.14.amzn1 amzn-main    542 k
 python26-requests                 noarch 1.2.3-5.10.amzn1   amzn-main     94 k
Installing for dependencies:
 openpgm                           x86_64 5.1.118-3.el6      epel         165 k
 python26-babel                    noarch 0.9.4-5.1.8.amzn1  amzn-main    1.8 M
 python26-backports                x86_64 1.0-3.14.amzn1     amzn-main    5.2 k
 python26-backports-ssl_match_hostname
                                   noarch 3.4.0.2-1.12.amzn1 amzn-main     12 k
 python26-chardet                  noarch 2.0.1-7.7.amzn1    amzn-main    377 k
 python26-libs                     x86_64 2.6.9-2.84.amzn1   amzn-updates 696 k
 python26-markupsafe               x86_64 0.11-4.6.amzn1     amzn-main     27 k
 python26-setuptools               noarch 12.2-1.30.amzn1    amzn-main    582 k
 python26-six                      noarch 1.8.0-1.23.amzn1   amzn-main     31 k
 python26-urllib3                  noarch 1.8.2-1.5.amzn1    amzn-main     98 k
 zeromq3                           x86_64 3.2.5-1.el6        epel         338 k

Transaction Summary
================================================================================
Install  8 Packages (+11 Dependent packages)

Total download size: 13 M
Installed size: 40 M
Downloading packages:
warning: /var/cache/yum/x86_64/latest/epel/packages/openpgm-5.1.118-3.el6.x86_64.rpm: Header V3 RSA/SHA256 Signature, key ID 0608b895: NOKEY
Public key for openpgm-5.1.118-3.el6.x86_64.rpm is not installed
--------------------------------------------------------------------------------
Total                                              6.8 MB/s |  13 MB  00:01     
Retrieving key from file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-6
Importing GPG key 0x0608B895:
 Userid     : "EPEL (6) <epel@fedoraproject.org>"
 Fingerprint: 8c3b e96a f230 9184 da5c 0dae 3b49 df2a 0608 b895
 Package    : epel-release-6-8.noarch (installed)
 From       : /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-6
Running transaction check
Running transaction test
Transaction test succeeded
Running transaction
Warning: RPMDB altered outside of yum.
  Installing : python26-libs-2.6.9-2.84.amzn1.x86_64                       1/19 
  Installing : python26-2.6.9-2.84.amzn1.x86_64                            2/19 
  Installing : python26-six-1.8.0-1.23.amzn1.noarch                        3/19 
  Installing : python26-backports-1.0-3.14.amzn1.x86_64                    4/19 
  Installing : python26-backports-ssl_match_hostname-3.4.0.2-1.12.amzn1    5/19 
  Installing : python26-setuptools-12.2-1.30.amzn1.noarch                  6/19 
  Installing : python26-babel-0.9.4-5.1.8.amzn1.noarch                     7/19 
  Installing : python26-urllib3-1.8.2-1.5.amzn1.noarch                     8/19 
  Installing : python26-markupsafe-0.11-4.6.amzn1.x86_64                   9/19 
  Installing : python26-chardet-2.0.1-7.7.amzn1.noarch                    10/19 
  Installing : openpgm-5.1.118-3.el6.x86_64                               11/19 
  Installing : zeromq3-3.2.5-1.el6.x86_64                                 12/19 
  Installing : python-zmq-14.3.1-1.el6.x86_64                             13/19 
  Installing : python26-requests-1.2.3-5.10.amzn1.noarch                  14/19 
  Installing : python26-jinja2-2.7.2-2.15.amzn1.noarch                    15/19 
  Installing : python-msgpack-0.4.6-1.el6.x86_64                          16/19 
  Installing : python26-crypto-2.6.1-1.12.amzn1.x86_64                    17/19 
  Installing : python26-PyYAML-3.10-3.10.amzn1.x86_64                     18/19 
  Installing : python26-m2crypto-0.21.1-15.14.amzn1.x86_64                19/19 
  Verifying  : python26-2.6.9-2.84.amzn1.x86_64                            1/19 
  Verifying  : python26-setuptools-12.2-1.30.amzn1.noarch                  2/19 
  Verifying  : python26-jinja2-2.7.2-2.15.amzn1.noarch                     3/19 
  Verifying  : python26-requests-1.2.3-5.10.amzn1.noarch                   4/19 
  Verifying  : python-msgpack-0.4.6-1.el6.x86_64                           5/19 
  Verifying  : python26-crypto-2.6.1-1.12.amzn1.x86_64                     6/19 
  Verifying  : python26-libs-2.6.9-2.84.amzn1.x86_64                       7/19 
  Verifying  : python26-urllib3-1.8.2-1.5.amzn1.noarch                     8/19 
  Verifying  : python26-babel-0.9.4-5.1.8.amzn1.noarch                     9/19 
  Verifying  : python26-PyYAML-3.10-3.10.amzn1.x86_64                     10/19 
  Verifying  : python-zmq-14.3.1-1.el6.x86_64                             11/19 
  Verifying  : python26-six-1.8.0-1.23.amzn1.noarch                       12/19 
  Verifying  : python26-backports-ssl_match_hostname-3.4.0.2-1.12.amzn1   13/19 
  Verifying  : openpgm-5.1.118-3.el6.x86_64                               14/19 
  Verifying  : zeromq3-3.2.5-1.el6.x86_64                                 15/19 
  Verifying  : python26-m2crypto-0.21.1-15.14.amzn1.x86_64                16/19 
  Verifying  : python26-backports-1.0-3.14.amzn1.x86_64                   17/19 
  Verifying  : python26-markupsafe-0.11-4.6.amzn1.x86_64                  18/19 
  Verifying  : python26-chardet-2.0.1-7.7.amzn1.noarch                    19/19 

Installed:
  python-msgpack.x86_64 0:0.4.6-1.el6                                           
  python-zmq.x86_64 0:14.3.1-1.el6                                              
  python26.x86_64 0:2.6.9-2.84.amzn1                                            
  python26-PyYAML.x86_64 0:3.10-3.10.amzn1                                      
  python26-crypto.x86_64 0:2.6.1-1.12.amzn1                                     
  python26-jinja2.noarch 0:2.7.2-2.15.amzn1                                     
  python26-m2crypto.x86_64 0:0.21.1-15.14.amzn1                                 
  python26-requests.noarch 0:1.2.3-5.10.amzn1                                   

Dependency Installed:
  openpgm.x86_64 0:5.1.118-3.el6                                                
  python26-babel.noarch 0:0.9.4-5.1.8.amzn1                                     
  python26-backports.x86_64 0:1.0-3.14.amzn1                                    
  python26-backports-ssl_match_hostname.noarch 0:3.4.0.2-1.12.amzn1             
  python26-chardet.noarch 0:2.0.1-7.7.amzn1                                     
  python26-libs.x86_64 0:2.6.9-2.84.amzn1                                       
  python26-markupsafe.x86_64 0:0.11-4.6.amzn1                                   
  python26-setuptools.noarch 0:12.2-1.30.amzn1                                  
  python26-six.noarch 0:1.8.0-1.23.amzn1                                        
  python26-urllib3.noarch 0:1.8.2-1.5.amzn1                                     
  zeromq3.x86_64 0:3.2.5-1.el6                                                  

Complete!
 *  INFO: Running install_amazon_linux_ami_stable()
Loaded plugins: priorities, update-motd, upgrade-helper
949 packages excluded due to repository priority protections
Resolving Dependencies
--> Running transaction check
---> Package salt-minion.noarch 0:2015.5.8-1.el6 will be installed
--> Processing Dependency: salt = 2015.5.8-1.el6 for package: salt-minion-2015.5.8-1.el6.noarch
--> Running transaction check
---> Package salt.noarch 0:2015.5.8-1.el6 will be installed
--> Finished Dependency Resolution

Dependencies Resolved

================================================================================
 Package             Arch           Version                  Repository    Size
================================================================================
Installing:
 salt-minion         noarch         2015.5.8-1.el6           epel          26 k
Installing for dependencies:
 salt                noarch         2015.5.8-1.el6           epel         4.2 M

Transaction Summary
================================================================================
Install  1 Package (+1 Dependent package)

Total download size: 4.2 M
Installed size: 18 M
Downloading packages:
--------------------------------------------------------------------------------
Total                                               11 MB/s | 4.2 MB  00:00     
Running transaction check
Running transaction test
Transaction test succeeded
Running transaction
  Installing : salt-2015.5.8-1.el6.noarch                                   1/2 
  Installing : salt-minion-2015.5.8-1.el6.noarch                            2/2 
  Verifying  : salt-minion-2015.5.8-1.el6.noarch                            1/2 
  Verifying  : salt-2015.5.8-1.el6.noarch                                   2/2 

Installed:
  salt-minion.noarch 0:2015.5.8-1.el6                                           

Dependency Installed:
  salt.noarch 0:2015.5.8-1.el6                                                  

Complete!
 *  INFO: Running install_amazon_linux_ami_stable_post()
 *  INFO: Running install_amazon_linux_ami_restart_daemons()
Starting salt-minion daemon:                               [  OK  ]
 *  INFO: Running daemons_running()
 *  INFO: Salt installed!

```
