### PR TITLE
Enable shallow cloning for version branches by default, not only tags

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1300,7 +1300,7 @@ __git_clone_and_checkout() {
         if [ "$_FORCE_SHALLOW_CLONE" -eq "${BS_TRUE}" ]; then
             echoinfo "Forced shallow cloning of git repository."
             __SHALLOW_CLONE="${BS_TRUE}"
-        elif [ "$(echo "$GIT_REV" | sed 's/^.*\(v[[:digit:]]\{1,4\}\.[[:digit:]]\{1,2\}\)\(\.[[:digit:]]\{1,2\}\)\?.*$/MATCH/')" = "MATCH" ]; then
+        elif [ "$(echo "$GIT_REV" | sed 's/^.*\(v\?[[:digit:]]\{1,4\}\.[[:digit:]]\{1,2\}\)\(\.[[:digit:]]\{1,2\}\)\?.*$/MATCH/')" = "MATCH" ]; then
             echoinfo "Git revision matches a Salt version tag, shallow cloning enabled."
             __SHALLOW_CLONE="${BS_TRUE}"
         else


### PR DESCRIPTION
Now running

```
sudo sh bootstrap-salt.sh git 2015.8
```

will also be faster with shallow clone if supported by git version installed.
