### PR TITLE
do not install copr repo on fedora 22+

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2988,6 +2988,7 @@ __install_saltstack_copr_salt_repository() {
     echoinfo "Adding SaltStack's COPR repository"
 
     if [ "${DISTRO_NAME_L}" = "fedora" ]; then
+        [ "$DISTRO_MAJOR_VERSION" -ge 22 ] && return 0
         __REPOTYPE="${DISTRO_NAME_L}"
     else
         __REPOTYPE="epel"


### PR DESCRIPTION
- there is no copr repo for fedora 23
- copr repo for fedora 22 is outdated; hence using the packages of fedora
#736
