### PR TITLE
Updated Salt Repo Domain from fedoraproject.org to fedorainfracloud.org

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2782,7 +2782,7 @@ __install_saltstack_copr_zeromq_repository() {
             __REPOTYPE="epel"
         fi
         __fetch_url /etc/yum.repos.d/saltstack-zeromq4.repo \
-            "http://copr.fedoraproject.org/coprs/saltstack/zeromq4/repo/${__REPOTYPE}-${DISTRO_MAJOR_VERSION}/saltstack-zeromq4-${__REPOTYPE}-${DISTRO_MAJOR_VERSION}.repo" || return 1
+            "http://copr.fedorainfracloud.org/coprs/saltstack/zeromq4/repo/${__REPOTYPE}-${DISTRO_MAJOR_VERSION}/saltstack-zeromq4-${__REPOTYPE}-${DISTRO_MAJOR_VERSION}.repo" || return 1
     fi
     return 0
 }
@@ -2790,7 +2790,7 @@ __install_saltstack_copr_zeromq_repository() {
 __install_saltstack_copr_salt_el5_repository() {
     if [ ! -s /etc/yum.repos.d/saltstack-salt-el5-epel-5.repo ]; then
         __fetch_url /etc/yum.repos.d/saltstack-salt-el5-epel-5.repo \
-            "http://copr.fedoraproject.org/coprs/saltstack/salt-el5/repo/epel-5/saltstack-salt-el5-epel-5.repo" || return 1
+            "http://copr.fedorainfracloud.org/coprs/saltstack/salt-el5/repo/epel-5/saltstack-salt-el5-epel-5.repo" || return 1
     fi
     return 0
 }
@@ -2808,7 +2808,7 @@ __install_saltstack_copr_salt_repository() {
 
     if [ ! -s "/etc/yum.repos.d/${__REPO_FILENAME}" ]; then
         __fetch_url "/etc/yum.repos.d/${__REPO_FILENAME}" \
-            "http://copr.fedoraproject.org/coprs/saltstack/salt/repo/${__REPOTYPE}-${DISTRO_MAJOR_VERSION}/${__REPO_FILENAME}" || return 1
+            "http://copr.fedorainfracloud.org/coprs/saltstack/salt/repo/${__REPOTYPE}-${DISTRO_MAJOR_VERSION}/${__REPO_FILENAME}" || return 1
     fi
     return 0
 }
@@ -3571,7 +3571,7 @@ install_amazon_linux_ami_deps() {
     if [ ! -s "/etc/yum.repos.d/${__REPO_FILENAME}" ]; then
         echoinfo "Adding SaltStack's COPR repository"
         __fetch_url /etc/yum.repos.d/${__REPO_FILENAME} \
-            "http://copr.fedoraproject.org/coprs/saltstack/salt/repo/epel-6/${__REPO_FILENAME}" || return 1
+            "http://copr.fedorainfracloud.org/coprs/saltstack/salt/repo/epel-6/${__REPO_FILENAME}" || return 1
     fi
 
     if [ "$_UPGRADE_SYS" -eq $BS_TRUE ]; then


### PR DESCRIPTION
Updated Salt repo domain from https://copr.fedoraproject.org/* to https://copr.fedorainfracloud.org/* as the original is now a redirect -- this breaks the bootstrap as a html redirect file is downloaded rather than the Salt repository file.
