### PR TITLE
Fix bootstrapping from git on Debian 8 by installing latest `tornado` via pip

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2893,7 +2893,7 @@ install_debian_git_deps() {
     fi
 
     if [ "$_INSTALL_CLOUD" -eq $BS_TRUE ]; then
-        __check_pip_allowed "You need to allow pip based installations (-P) in order to install requested 'apache-libcloud"
+        __check_pip_allowed "You need to allow pip based installations (-P) in order to install requested 'apache-libcloud' module"
         pip install -U "apache-libcloud>=$_LIBCLOUD_MIN_VERSION"
     fi
 
@@ -2970,7 +2970,7 @@ install_debian_8_git_deps() {
     if [ -f "${_SALT_GIT_CHECKOUT_DIR}/requirements/base.txt" ]; then
         __REQUIRED_TORNADO="$(grep tornado "${_SALT_GIT_CHECKOUT_DIR}/requirements/base.txt")"
         if [ -n "${__REQUIRED_TORNADO}" ]; then
-            __check_pip_allowed "You need to allow pip based installations (-P) in order to install required 'tornado' package"
+            __check_pip_allowed "You need to allow pip based installations (-P) in order to install required 'tornado' module"
 
             __PACKAGES="python-dev"
             if ! __check_command_exists pip; then

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -477,22 +477,26 @@ if [ "$ITYPE" = "git" ]; then
         GIT_REV="$1"
         shift
     fi
+
+    # Disable shell warning about unbound variable during git install
+    STABLE_REV=""
+
 # If doing stable install, check if version specified
 elif [ "$ITYPE" = "stable" ]; then
     if [ "$#" -eq 0 ];then
         STABLE_REV="latest"
     else
         __check_unparsed_options "$*"
-        if [ "$(echo "$1" | egrep '^(latest|1\.6|1\.7|2014\.1|2014\.7|2015\.5|2015\.8)$')" != "" ]; then
-          STABLE_REV="$1"
-          shift
-        elif [ "$(echo "$1" | egrep '^([0-9]*\.[0-9]*\.[0-9]*)$')" != "" ]; then
-          STABLE_REV="archive/$1"
-          shift
-        else
-          echo "Unknown stable version: $1 (valid: 1.6, 1.7, 2014.1, 2014.7, 2015.5, 2015.8, latest, \$MAJOR.\$MINOR.\$PATCH)"
-          exit 1
 
+        if [ "$(echo "$1" | egrep '^(latest|1\.6|1\.7|2014\.1|2014\.7|2015\.5|2015\.8)$')" != "" ]; then
+            STABLE_REV="$1"
+            shift
+        elif [ "$(echo "$1" | egrep '^([0-9]*\.[0-9]*\.[0-9]*)$')" != "" ]; then
+            STABLE_REV="archive/$1"
+            shift
+        else
+            echo "Unknown stable version: $1 (valid: 1.6, 1.7, 2014.1, 2014.7, 2015.5, 2015.8, latest, \$MAJOR.\$MINOR.\$PATCH)"
+            exit 1
         fi
     fi
 fi

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2956,18 +2956,11 @@ install_debian_7_git_deps() {
 install_debian_8_git_deps() {
     install_debian_8_deps || return 1
 
-    # No user interaction, libc6 restart services for example
-    export DEBIAN_FRONTEND=noninteractive
-
     if ! __check_command_exists git; then
         __apt_get_install_noinput git || return 1
     fi
 
-    if [ "$(dpkg-query -l 'python-zmq')" = "" ]; then
-        __apt_get_install_noinput libzmq3 libzmq3-dev python-zmq || return 1
-    fi
-
-    __apt_get_install_noinput lsb-release python python-pkg-resources python-crypto \
+    __apt_get_install_noinput lsb-release python-pkg-resources python-crypto \
         python-jinja2 python-m2crypto python-yaml msgpack-python || return 1
 
     __git_clone_and_checkout || return 1
@@ -2992,16 +2985,6 @@ install_debian_8_git_deps() {
     if [ "$_TEMP_CONFIG_DIR" = "null" ]; then
         _TEMP_CONFIG_DIR="${_SALT_GIT_CHECKOUT_DIR}/conf/"
         CONFIG_SALT_FUNC="config_salt"
-    fi
-
-    if [ "$_UPGRADE_SYS" -eq $BS_TRUE ]; then
-        __apt_get_upgrade_noinput || return 1
-    fi
-
-    if [ "${_EXTRA_PACKAGES}" != "" ]; then
-        echoinfo "Installing the following extra packages as requested: ${_EXTRA_PACKAGES}"
-        # shellcheck disable=SC2086
-        __apt_get_install_noinput ${_EXTRA_PACKAGES} || return 1
     fi
 
     return 0

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1889,8 +1889,8 @@ __check_services_debian() {
     servicename=$1
     echodebug "Checking if service ${servicename} is enabled"
 
-    # shellcheck disable=SC2086,SC2046,SC2144
-    if [ -f /etc/rc$(runlevel | awk '{ print $2 }').d/S*${servicename} ]; then
+    # Check if the service is going to be started at any runlevel, fixes bootstrap in container (Docker, LXC)
+    if ls /etc/rc?.d/S*"${servicename}" >/dev/null 2>&1; then
         echodebug "Service ${servicename} is enabled"
         return 0
     else


### PR DESCRIPTION
### What does this PR do?

Fixes git installation type on Debian Jessie. Also puts corrected `systemd` service units in the right place.
### What issues does this PR fix or reference?
#820
### Previous Behavior

Salt services unable to start because of old version of `python-tornado` distribution package.
### New Behavior

Support installing latest `tornado` module by enabling pip based installation (-P).
