### PR TITLE
Ubuntu 12.04 needs to be updated before installing packages

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2307,6 +2307,9 @@ install_ubuntu_daily_deps() {
 }
 
 install_ubuntu_git_deps() {
+    if [ "$DISTRO_MAJOR_VERSION" -eq 12 ]; then
+        apt-get update
+    fi
     __apt_get_install_noinput git-core || return 1
     __git_clone_and_checkout || return 1
 


### PR DESCRIPTION
### What does this PR do?

Ubuntu 12.04 will fail installing git-core, or other packages before an apt-get update is run.
### Tests written?

n/a
