### PR TITLE
Don't sleep 11 seconds if the user allowed overwrite of config files

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -5908,8 +5908,10 @@ config_salt() {
 
     if [ "$_CONFIG_ONLY" -eq "$BS_TRUE" ]; then
         echowarn "Passing -C (config only) option implies -F (forced overwrite)."
-        echowarn "Overwriting configs in 11 seconds!"
-        sleep 11
+        if [ "$_FORCE_OVERWRITE" -ne "$BS_TRUE" ]; then
+            echowarn "Overwriting configs in 11 seconds!"
+            sleep 11
+        fi
     fi
 
     if [ "$_INSTALL_MINION" -eq "$BS_TRUE" ] || [ "$_CONFIG_ONLY" -eq "$BS_TRUE" ]; then


### PR DESCRIPTION
### What does this PR do?

Removes the 11 second penalty if the user explicitly gave the force overwrite (-F) flag.
### What issues does this PR fix or reference?
### Previous Behavior

Always waits 11 seconds.
### New Behavior

Only waits 11 seconds if user did not specify -F
### Tests written?

No

-C implies a overwrite and warns about this with a 11 second sleep.
If the user explicitly allowed overwrite, there is no reason for this 11 second penelty.
