### PR TITLE
Update bootstrap-salt.ps1

### DIFF
--- a/bootstrap-salt.ps1
+++ b/bootstrap-salt.ps1
@@ -121,7 +121,7 @@ if (!$version) {
     if ($arch -eq 'x86') {$returnMatches = $returnMatches | Where {$_ -like "Salt-Minion*x86-Setup.exe"}}
     else {$returnMatches = $returnMatches | Where {$_ -like "Salt-Minion*AMD64-Setup.exe"}}
     
-    $version = $(($returnMatches | Sort-Object -Descending)[0]).Split('-')[2]
+    $version = $(($returnMatches | Sort-Object -Descending)[0]).Split(("n-","-A","-x"),([System.StringSplitOptions]::RemoveEmptyEntries))[1] 
 }
 
 # Download minion setup file


### PR DESCRIPTION
### What does this PR do?

Fixes the auto-update feature to account for hotfix updates (-n in the version name)
### What issues does this PR fix or reference?

Same as above
### Previous Behavior

Download and install would fail if version had additional hotifx in name (2015.5.6-3)
### New Behavior

Download and install could complete
### Tests written?

No

Added fix to string split to correct for version numbers have additional hotfix revision numbers.
