### PR TITLE
Removed libzmq4 and forking-deamon-patch for Opensuse13

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -5150,7 +5150,7 @@ install_opensuse_stable_deps() {
     if [ "$DISTRO_MAJOR_VERSION" -lt 13 ]; then
         __PACKAGES="${__PACKAGES} libzmq3"
     elif [ "$DISTRO_MAJOR_VERSION" -eq 13 ]; then
-        __PACKAGES="${__PACKAGES} libzmq4"
+        __PACKAGES="${__PACKAGES} libzmq3"
     elif [ "$DISTRO_MAJOR_VERSION" -gt 13 ]; then
         __PACKAGES="${__PACKAGES} libzmq5"
     fi
@@ -5184,13 +5184,6 @@ install_opensuse_git_deps() {
     __zypper_install patch || return 1
 
     __git_clone_and_checkout || return 1
-
-    if [ -f "${_SALT_GIT_CHECKOUT_DIR}/pkg/suse/use-forking-daemon.patch" ]; then
-        # shellcheck disable=SC2164
-        cd "${_SALT_GIT_CHECKOUT_DIR}"
-        echowarn "Applying patch to systemd service unit file"
-        patch -p1 < pkg/suse/use-forking-daemon.patch || return 1
-    fi
 
     if [ -f "${_SALT_GIT_CHECKOUT_DIR}/requirements/base.txt" ]; then
         # We're on the develop branch, install whichever tornado is on the requirements file


### PR DESCRIPTION
### What does this PR do?

Libzmq4 does not exists on OpenSUSE13, so I changed it back to libzmq3.

The foking-daemon patch is incorrect on 2015.8.8.2 and would cause bootstrap to fail. I've removed section where this patch is applied.

these changes allow opensuse 13 to properly bootstrap. 
### What issues does this PR fix or reference?

OpenSUSE13 not bootstrapping. 
### Tests written?

No
