### PR TITLE
Fix debian-7 setup.py install issue in bootstrap-salt.

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2391,7 +2391,7 @@ install_ubuntu_git() {
     fi
 
     if [ -f "${_SALT_GIT_CHECKOUT_DIR}/salt/syspaths.py" ]; then
-        python setup.py --salt-config-dir="$_SALT_ETC_DIR" --salt-cache-dir="${_SALT_CACHE_DIR}" install --install-layout=deb || return 1
+        python setup.py install --salt-config-dir="$_SALT_ETC_DIR" --salt-cache-dir="${_SALT_CACHE_DIR}" --install-layout=deb || return 1
     else
         python setup.py install --install-layout=deb || return 1
     fi
@@ -3040,7 +3040,7 @@ install_debian_8_stable() {
 
 install_debian_git() {
     if [ -f "${_SALT_GIT_CHECKOUT_DIR}/salt/syspaths.py" ]; then
-      python setup.py --salt-config-dir="$_SALT_ETC_DIR" --salt-cache-dir="${_SALT_CACHE_DIR}" install --install-layout=deb || return 1
+      python setup.py install --salt-config-dir="$_SALT_ETC_DIR" --salt-cache-dir="${_SALT_CACHE_DIR}" --install-layout=deb || return 1
     else
         python setup.py install --install-layout=deb || return 1
     fi
@@ -3265,7 +3265,7 @@ install_fedora_git_deps() {
 
 install_fedora_git() {
     if [ -f "${_SALT_GIT_CHECKOUT_DIR}/salt/syspaths.py" ]; then
-        python setup.py --salt-config-dir="$_SALT_ETC_DIR" --salt-cache-dir="${_SALT_CACHE_DIR}" install || return 1
+        python setup.py install --salt-config-dir="$_SALT_ETC_DIR" --salt-cache-dir="${_SALT_CACHE_DIR}" || return 1
     else
         python setup.py install || return 1
     fi
@@ -3626,7 +3626,7 @@ install_centos_git() {
         _PYEXE=python2
     fi
     if [ -f "${_SALT_GIT_CHECKOUT_DIR}/salt/syspaths.py" ]; then
-        $_PYEXE setup.py --salt-config-dir="$_SALT_ETC_DIR" --salt-cache-dir="${_SALT_CACHE_DIR}" install --prefix=/usr || return 1
+        $_PYEXE setup.py install --salt-config-dir="$_SALT_ETC_DIR" --salt-cache-dir="${_SALT_CACHE_DIR}" --prefix=/usr || return 1
     else
         $_PYEXE setup.py install --prefix=/usr || return 1
     fi
@@ -4269,7 +4269,7 @@ install_arch_linux_stable() {
 
 install_arch_linux_git() {
     if [ -f "${_SALT_GIT_CHECKOUT_DIR}/salt/syspaths.py" ]; then
-        python2 setup.py --salt-config-dir="$_SALT_ETC_DIR" --salt-cache-dir="${_SALT_CACHE_DIR}" install || return 1
+        python2 setup.py install --salt-config-dir="$_SALT_ETC_DIR" --salt-cache-dir="${_SALT_CACHE_DIR}" || return 1
     else
         python2 setup.py install || return 1
     fi
@@ -4611,7 +4611,7 @@ install_freebsd_git() {
         # We still can't provide the system paths, salt 0.16.x
         /usr/local/bin/python2 setup.py install || return 1
     else
-        /usr/local/bin/python2 setup.py \
+        /usr/local/bin/python2 setup.py install \
             --salt-root-dir=/usr/local \
             --salt-config-dir="${_SALT_ETC_DIR}" \
             --salt-cache-dir="${_SALT_CACHE_DIR}" \
@@ -4621,7 +4621,7 @@ install_freebsd_git() {
             --salt-base-pillar-roots-dir="${_SALT_ETC_DIR}/pillar" \
             --salt-base-master-roots-dir="${_SALT_ETC_DIR}/salt-master" \
             --salt-logs-dir=/var/log/salt \
-            --salt-pidfile-dir=/var/run install \
+            --salt-pidfile-dir=/var/run \
             || return 1
     fi
 
@@ -4976,7 +4976,7 @@ install_smartos_stable() {
 install_smartos_git() {
     # Use setuptools in order to also install dependencies
     # lets force our config path on the setup for now, since salt/syspaths.py only  got fixed in 2015.5.0
-    USE_SETUPTOOLS=1 /opt/local/bin/python setup.py --salt-config-dir="$_SALT_ETC_DIR" --salt-cache-dir="${_SALT_CACHE_DIR}" install || return 1
+    USE_SETUPTOOLS=1 /opt/local/bin/python setup.py install --salt-config-dir="$_SALT_ETC_DIR" --salt-cache-dir="${_SALT_CACHE_DIR}" || return 1
     return 0
 }
 


### PR DESCRIPTION
### What does this PR do?

Makes consistent the command to setup.py as the first argument, followed by the optional flags.
### What issues does this PR fix or reference?

Allows installation of salt from git on Debian 7. Currently broken as the arguments are not in the proper order.
### Previous Behavior

Error generated that the option was unknown.
### Tests written?

No. I've tested this change on Debian 7 on GCE. I've also syntax checked the file with bash.

Around commit c8889ce the install argument to setup.py was moved to the
middle or end of the command string.  This breaks the install on
debian-7.

Revised all setup.py commands to have install as the first argument.
