### PR TITLE
Use HTTPS to clone instead of Git protocol

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,5 @@
 Version 2016.05.11:
+	* Use HTTPS instead of Git protocol when cloning. (davidjb)
     * Only overwrite the minion config file if '-C' is passed. Otherwise, preserve it. (rallytime) #848
 
 Version 2016.05.10:

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -190,7 +190,7 @@ __check_config_dir() {
 #----------------------------------------------------------------------------------------------------------------------
 _KEEP_TEMP_FILES=${BS_KEEP_TEMP_FILES:-$BS_FALSE}
 _TEMP_CONFIG_DIR="null"
-_SALTSTACK_REPO_URL="git://github.com/saltstack/salt.git"
+_SALTSTACK_REPO_URL="https://github.com/saltstack/salt.git"
 _SALT_REPO_URL=${_SALTSTACK_REPO_URL}
 _DOWNSTREAM_PKG_REPO=$BS_FALSE
 _TEMP_KEYS_DIR="null"

--- a/tests/bootstrap/test_install.py
+++ b/tests/bootstrap/test_install.py
@@ -605,7 +605,7 @@ class InstallationTestCase(BootstrapTestCase):
             0,
             self.run_script(
                 script=None,
-                args=('git', 'clone', 'git://github.com/saltstack/salt.git'),
+                args=('git', 'clone', 'https://github.com/saltstack/salt.git'),
                 cwd='/tmp/git',
                 timeout=15 * 60,
                 stream_stds=True


### PR DESCRIPTION
### What does this PR do?

Switches cloning Salt from git:// to using https://.
### What issues does this PR fix or reference?

Security as git:// is an insecure, cleartext protocol and compatibility as some firewalls may block git://'s custom port but will allow HTTPS traffic.  According to GitHub support, performance is the same or better over HTTPS with updates in recent times.

FYI: See https://gist.github.com/grawity/4392747 for a summary of protocols.  GitHub is sadly light on details about which remote to use, but https://help.github.com/articles/which-remote-url-should-i-use/ recommends HTTPS and if you contact support they have actively discouraged git:// for a long time.
### Previous Behavior

Use git:// to clone
### New Behavior

Use https:// to clone
### Tests written?

Yes (adjusted existing tests)
