### PR TITLE
Removed ubuntu version restriction for apt-get update

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2398,9 +2398,7 @@ install_ubuntu_daily_deps() {
 }
 
 install_ubuntu_git_deps() {
-    if [ "$DISTRO_MAJOR_VERSION" -eq 12 ]; then
-        apt-get update
-    fi
+    apt-get update
     __apt_get_install_noinput git-core || return 1
     __git_clone_and_checkout || return 1
 


### PR DESCRIPTION
### What does this PR do?

Run apt-get update on all install_ubuntu_git_deps
### What issues does this PR fix or reference?

https://github.com/saltstack/salt-bootstrap/issues/821
### Previous Behavior

An apt-get update would only run for Ubuntu 12, Ubuntu 14 LXC containers provisioned through Saltstack are failing because of an outdated apt-get cache.
### New Behavior

The bootstrap of LXC containers running Ubuntu 14.04 are now successful.
### Tests written?

No
