### PR TITLE
Drop support for Debian 6 old-old-stable "squeeze": reached end-of-life

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -206,7 +206,7 @@ Supported Operating Systems
 Debian and derivatives
 ~~~~~~~~~~~~~~~~~~~~~~
 
-- Debian GNU/Linux 6/7/8
+- Debian GNU/Linux 7/8
 - Linux Mint Debian Edition 1 (based on Debian 8)
 - Kali Linux 1.0 (based on Debian 7)
 


### PR DESCRIPTION
### What does this PR do?

Subj. https://www.debian.org/News/2016/20160212
### Previous Behavior

Script tries to bootstrap modern Salt version on outdated distro.
### New Behavior

Display "EOL" error message and exit when Debian 6 would be detected.
### Tests written?

No

Ping @s0undt3ch 
