### PR TITLE
added distro codename for xenial

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1217,6 +1217,9 @@ __ubuntu_codename_translation() {
                 DISTRO_CODENAME="wily"
             fi
             ;;
+        "16")
+            DISTRO_CODENAME="xenial"
+            ;;
         *)
             DISTRO_CODENAME="trusty"
             ;;


### PR DESCRIPTION
### What does this PR do?

Adds a codename translation for Ubuntu 16.04 LTS
### What issues does this PR fix or reference?

Fixes issue #862 
### Previous Behavior

Due to missing codename a faulty default codename of "trusty" would be inserted into "/etc/apt/sources.list.d/saltstack.list" thereby breaking the script on 16.04
### New Behavior

Adds the correct codename of xenial to "/etc/apt/sources.list.d/saltstack.list"
### Tests written?

No
