### PR TITLE
Add option to make setup.py install quiet

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -356,7 +356,7 @@ EOT
 }   # ----------  end of function __usage  ----------
 
 
-while getopts ":hvnDc:Gg:wk:s:MSNXCPFUKIA:i:Lp:dH:ZbflV:J:j:rR:a" opt
+while getopts ":hvnDc:Gg:wk:s:MSNXCPFUKIA:i:Lp:dH:ZbflV:J:j:rR:aq" opt
 do
   case "${opt}" in
 
@@ -2494,9 +2494,9 @@ install_ubuntu_git() {
     fi
 
     if [ -f "${_SALT_GIT_CHECKOUT_DIR}/salt/syspaths.py" ]; then
-        python setup.py --salt-config-dir="$_SALT_ETC_DIR" --salt-cache-dir="${_SALT_CACHE_DIR}" install "${SETUP_PY_INSTALL_ARGS}" --install-layout=deb || return 1
+        python setup.py --salt-config-dir="$_SALT_ETC_DIR" --salt-cache-dir="${_SALT_CACHE_DIR}" ${SETUP_PY_INSTALL_ARGS} install --install-layout=deb || return 1
     else
-        python setup.py install "${SETUP_PY_INSTALL_ARGS}" --install-layout=deb || return 1
+        python setup.py ${SETUP_PY_INSTALL_ARGS} install--install-layout=deb || return 1
     fi
     return 0
 }
@@ -2965,9 +2965,9 @@ install_debian_8_stable() {
 
 install_debian_git() {
     if [ -f "${_SALT_GIT_CHECKOUT_DIR}/salt/syspaths.py" ]; then
-      python setup.py --salt-config-dir="$_SALT_ETC_DIR" --salt-cache-dir="${_SALT_CACHE_DIR}" install "${SETUP_PY_INSTALL_ARGS}" --install-layout=deb || return 1
+      python setup.py --salt-config-dir="$_SALT_ETC_DIR" --salt-cache-dir="${_SALT_CACHE_DIR}" ${SETUP_PY_INSTALL_ARGS} install --install-layout=deb || return 1
     else
-        python setup.py install "${SETUP_PY_INSTALL_ARGS}" --install-layout=deb || return 1
+        python setup.py ${SETUP_PY_INSTALL_ARGS} install --install-layout=deb || return 1
     fi
 }
 
@@ -3201,9 +3201,9 @@ install_fedora_git_deps() {
 
 install_fedora_git() {
     if [ -f "${_SALT_GIT_CHECKOUT_DIR}/salt/syspaths.py" ]; then
-        python setup.py --salt-config-dir="$_SALT_ETC_DIR" --salt-cache-dir="${_SALT_CACHE_DIR}" install "${SETUP_PY_INSTALL_ARGS}" || return 1
+        python setup.py --salt-config-dir="$_SALT_ETC_DIR" --salt-cache-dir="${_SALT_CACHE_DIR}" ${SETUP_PY_INSTALL_ARGS} install || return 1
     else
-        python setup.py install "${SETUP_PY_INSTALL_ARGS}" || return 1
+        python setup.py ${SETUP_PY_INSTALL_ARGS} install || return 1
     fi
     return 0
 }
@@ -3576,9 +3576,9 @@ install_centos_git() {
         _PYEXE=python2
     fi
     if [ -f "${_SALT_GIT_CHECKOUT_DIR}/salt/syspaths.py" ]; then
-        $_PYEXE setup.py --salt-config-dir="$_SALT_ETC_DIR" --salt-cache-dir="${_SALT_CACHE_DIR}" install "${SETUP_PY_INSTALL_ARGS}" --prefix=/usr || return 1
+        $_PYEXE setup.py --salt-config-dir="$_SALT_ETC_DIR" --salt-cache-dir="${_SALT_CACHE_DIR}" ${SETUP_PY_INSTALL_ARGS} install --prefix=/usr || return 1
     else
-        $_PYEXE setup.py install "${SETUP_PY_INSTALL_ARGS}" --prefix=/usr || return 1
+        $_PYEXE setup.py ${SETUP_PY_INSTALL_ARGS} install --prefix=/usr || return 1
     fi
     return 0
 }
@@ -4221,9 +4221,9 @@ install_arch_linux_stable() {
 
 install_arch_linux_git() {
     if [ -f "${_SALT_GIT_CHECKOUT_DIR}/salt/syspaths.py" ]; then
-        python2 setup.py --salt-config-dir="$_SALT_ETC_DIR" --salt-cache-dir="${_SALT_CACHE_DIR}" install "${SETUP_PY_INSTALL_ARGS}" || return 1
+        python2 setup.py --salt-config-dir="$_SALT_ETC_DIR" --salt-cache-dir="${_SALT_CACHE_DIR}" ${SETUP_PY_INSTALL_ARGS} install || return 1
     else
-        python2 setup.py install "${SETUP_PY_INSTALL_ARGS}" || return 1
+        python2 setup.py ${SETUP_PY_INSTALL_ARGS} install || return 1
     fi
     return 0
 }
@@ -4561,7 +4561,7 @@ install_freebsd_git() {
     # Install from git
     if [ ! -f salt/syspaths.py ]; then
         # We still can't provide the system paths, salt 0.16.x
-        /usr/local/bin/python2 setup.py install "${SETUP_PY_INSTALL_ARGS}" || return 1
+        /usr/local/bin/python2 setup.py ${SETUP_PY_INSTALL_ARGS} install || return 1
     else
         /usr/local/bin/python2 setup.py \
             --salt-root-dir=/usr/local \
@@ -4573,7 +4573,7 @@ install_freebsd_git() {
             --salt-base-pillar-roots-dir="${_SALT_ETC_DIR}/pillar" \
             --salt-base-master-roots-dir="${_SALT_ETC_DIR}/salt-master" \
             --salt-logs-dir=/var/log/salt \
-            --salt-pidfile-dir=/var/run install "${SETUP_PY_INSTALL_ARGS}" \
+            --salt-pidfile-dir=/var/run ${SETUP_PY_INSTALL_ARGS} install \
             || return 1
     fi
 
@@ -4767,7 +4767,7 @@ install_openbsd_git() {
     #
     if [ ! -f salt/syspaths.py ]; then
         # We still can't provide the system paths, salt 0.16.x
-        /usr/local/bin/python2.7 setup.py install "${SETUP_PY_INSTALL_ARGS}" || return 1
+        /usr/local/bin/python2.7 setup.py ${SETUP_PY_INSTALL_ARGS} install || return 1
     fi
     return 0
 }
@@ -4928,7 +4928,7 @@ install_smartos_stable() {
 install_smartos_git() {
     # Use setuptools in order to also install dependencies
     # lets force our config path on the setup for now, since salt/syspaths.py only  got fixed in 2015.5.0
-    USE_SETUPTOOLS=1 /opt/local/bin/python setup.py --salt-config-dir="$_SALT_ETC_DIR" --salt-cache-dir="${_SALT_CACHE_DIR}" install "${SETUP_PY_INSTALL_ARGS}" || return 1
+    USE_SETUPTOOLS=1 /opt/local/bin/python setup.py --salt-config-dir="$_SALT_ETC_DIR" --salt-cache-dir="${_SALT_CACHE_DIR}" ${SETUP_PY_INSTALL_ARGS} install || return 1
     return 0
 }
 
@@ -5162,7 +5162,7 @@ install_opensuse_stable() {
 }
 
 install_opensuse_git() {
-    python setup.py install "${SETUP_PY_INSTALL_ARGS}" --prefix=/usr || return 1
+    python setup.py ${SETUP_PY_INSTALL_ARGS} install --prefix=/usr || return 1
     return 0
 }
 


### PR DESCRIPTION
### What does this PR do?

setup.py install is very verbose by default. This makes bootstrapping via slow connections cumbersome, since all the output has to be sent to the origin. The -q switch adds -q to setup.py install commands when installing from git.
### What issues does this PR fix or reference?

n/a
### Previous Behavior

still present / -q switch is only optional
### New Behavior

-q switch turns of verbose installation
### Tests written?

No
