### PR TITLE
Add dependency python-systemd for Ubuntu and Debian

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2254,9 +2254,15 @@ install_ubuntu_deps() {
     if [ "$DISTRO_MAJOR_VERSION" -ge 15 ]; then
         __PACKAGES="${__PACKAGES} python2.7"
     fi
+
+    if [ "$DISTRO_MAJOR_VERSION" -ge 16 ]; then
+        __PACKAGES="${__PACKAGES} python-systemd"
+    fi
+
     if [ "$_VIRTUALENV_DIR" != "null" ]; then
         __PACKAGES="${__PACKAGES} python-virtualenv"
     fi
+
     # Need python-apt for managing packages via Salt
     __PACKAGES="${__PACKAGES} python-apt"
 
@@ -2661,6 +2667,11 @@ install_debian_deps() {
         __PACKAGES="${__PACKAGES} python-pip"
         # shellcheck disable=SC2089
         __PIP_PACKAGES="${__PIP_PACKAGES} 'requests>=$_PY_REQUESTS_MIN_VERSION'"
+    fi
+
+    if [ "$DISTRO_MAJOR_VERSION" -gt 8 ]; then
+        # Debian 8 uses systemd. Additional requirements
+        __PACKAGES="${__PACKAGES} python-systemd"
     fi
 
     # shellcheck disable=SC2086


### PR DESCRIPTION
### What does this PR do?

Adding python-systemd package as a dependency for Debian 8.x and >=16.04.

Ubuntu 16.04 and Debian 8.x are using sytemd. Without the package Salt cannot start the salt master and/or minion service after an installation from Github.
### What issues does this PR fix or reference?

Relates: #682 
Closes: #682 
### Previous Behavior

Salt was not able to start master/minion services after successful installation from Github due to missing systemd-python package
### New Behavior

Salt is now able to start master/minion services after successful installation from Github
### Tests written?

No
