### PR TITLE
Debian 8: support git installation on non-x86_64 architectures

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -211,12 +211,19 @@ Debian and derivatives
 - Debian GNU/Linux 7/8
 - Linux Mint Debian Edition 1 (based on Debian 8)
 - Kali Linux 1.0 (based on Debian 7)
+- Raspbian 8 (limited support for ``armhf`` architecture, see the note below)
 
 .. note::
 
-  Installation of Salt packages on Debian distribution from repo.saltstack.com repository is
-  currently supported for ``amd64`` (``x86-64``) architechture ONLY. Use ``git`` bootstrap
-  mode as mentioned above to install Salt on other architechtures, such as ``i386`` or ``armel``.
+  Installation of Salt packages on Debian 8 based distribution from repo.saltstack.com repository
+  is currently supported for ``amd64`` (``x86-64``) and ``armhf`` architechtures ONLY. Use ``git``
+  bootstrap mode as described above to install Salt on other architechtures, such as ``i386`` or
+  ``armel``. You also may need to disable repository configuration and allow ``pip`` installations
+  by providing ``-r`` and ``-P`` options to the bootstrap script, i.e.:
+
+  .. code:: console
+
+    wget -O - https://bootstrap.saltstack.com | sudo sh -s -- -r -P git develop
 
 
 Red Hat family
@@ -293,7 +300,6 @@ are not developed yet:
 
 **Linux**:
 
-- Raspbian (detected as Debian)
 - Slackware
 
 **SunOS**

--- a/README.rst
+++ b/README.rst
@@ -212,6 +212,12 @@ Debian and derivatives
 - Linux Mint Debian Edition 1 (based on Debian 8)
 - Kali Linux 1.0 (based on Debian 7)
 
+.. note::
+
+  Installation of Salt packages on Debian distribution from repo.saltstack.com repository is
+  currently supported for ``amd64`` (``x86-64``) architechture ONLY. Use ``git`` bootstrap
+  mode as mentioned above to install Salt on other architechtures, such as ``i386`` or ``armel``.
+
 
 Red Hat family
 ~~~~~~~~~~~~~~

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -265,27 +265,27 @@ __usage() {
     - ${__ScriptName}
     - ${__ScriptName} stable
     - ${__ScriptName} stable 2015.8
-    - ${__ScriptName} stable 2015.8.9
+    - ${__ScriptName} stable 2015.8.10
     - ${__ScriptName} daily
     - ${__ScriptName} testing
     - ${__ScriptName} git
     - ${__ScriptName} git 2015.8
-    - ${__ScriptName} git v2015.8.9
+    - ${__ScriptName} git v2015.8.10
     - ${__ScriptName} git 8c3fadf15ec183e5ce8c63739850d543617e4357
 
   Options:
     -h  Display this message
     -v  Display script version
-    -n  No colours.
-    -D  Show debug output.
+    -n  No colours
+    -D  Show debug output
     -c  Temporary configuration directory
     -g  Salt repository URL. Default: ${_SALTSTACK_REPO_URL}
     -G  Instead of cloning from ${_SALTSTACK_REPO_URL}, clone from
         https://${_SALTSTACK_REPO_URL#*://}
-        (Usually necessary on systems which have the regular git protocol port
+        (usually necessary on systems which have the regular git protocol port
         blocked, where https usually is not)
     -w  Install packages from downstream package repository rather than
-        upstream, saltstack package repository.  This is currently only
+        upstream, saltstack package repository. This is currently only
         implemented for SUSE.
     -k  Temporary directory holding the minion keys which will pre-seed
         the master.
@@ -295,6 +295,10 @@ __usage() {
     -S  Also install salt-syndic
     -N  Do not install salt-minion
     -X  Do not start daemons after installation
+    -d  Disable check_service functions. Setting this flag disables the
+        'install_<distro>_check_services' checks. You can also do this by
+        touching /tmp/disable_salt_checks on the target host.
+        Default: \${BS_FALSE}
     -C  Only run the configuration function. This option automatically bypasses
         any installation. Implies -F (forced overwrite). To overwrite master or
         syndic configs, -M or -S, respectively, must also be specified.
@@ -303,10 +307,10 @@ __usage() {
         distribution. Using this flag allows the script to use pip as a last
         resort method. NOTE: This only works for functions which actually
         implement pip based installations.
-    -F  Allow copied files to overwrite existing (config, init.d, etc).
-    -U  If set, fully upgrade the system prior to bootstrapping salt
+    -F  Allow copied files to overwrite existing (config, init.d, etc)
+    -U  If set, fully upgrade the system prior to bootstrapping Salt
     -K  If set, keep the temporary files in the temporary directories specified
-        with -c and -k.
+        with -c and -k
     -I  If set, allow insecure connections while downloading any files. For
         example, pass '--no-check-certificate' to 'wget' or '--insecure' to
         'curl'
@@ -314,17 +318,14 @@ __usage() {
         \${BS_SALT_ETC_DIR}/minion.d/99-master-address.conf
     -i  Pass the salt-minion id. This will be stored under
         \${BS_SALT_ETC_DIR}/minion_id
-    -L  Install the Apache Libcloud package if possible(required for salt-cloud)
-    -p  Extra-package to install while installing salt dependencies. One package
+    -L  Install the Apache Libcloud package if possible
+        (required for salt-cloud)
+    -p  Extra-package to install while installing Salt dependencies. One package
         per -p flag. You're responsible for providing the proper package name.
-    -d  Disable check_service functions. Setting this flag disables the
-        'install_<distro>_check_services' checks. You can also do this by
-        touching /tmp/disable_salt_checks on the target host.
-        Default: \${BS_FALSE}
     -H  Use the specified HTTP proxy for all download URLs (including https://).
         For example: http://myproxy.example.com:3128
     -Z  Enable additional package repository for newer ZeroMQ
-        (Only available for RHEL/CentOS/Fedora/Ubuntu based distributions)
+        (only available for RHEL/CentOS/Fedora/Ubuntu based distributions)
     -b  Assume that dependencies are already installed and software sources are
         set up. If git is selected, git tree is still checked out as dependency
         step.
@@ -332,27 +333,29 @@ __usage() {
         This may result in an "n/a" in the version number.
     -l  Disable ssl checks. When passed, switches "https" calls to "http" where
         possible.
-    -V  Install salt into virtualenv(Only available for Ubuntu base distributions)
-    -a  Pip install all python pkg dependencies for salt. Requires -V to install
-        all pip pkgs into the virtualenv(Only available for Ubuntu based
-        distributions)
+    -V  Install Salt into virtualenv
+        (only available for Ubuntu based distributions)
+    -a  Pip install all Python pkg dependencies for Salt. Requires -V to install
+        all pip pkgs into the virtualenv.
+        (Only available for Ubuntu based distributions)
     -r  Disable all repository configuration performed by this script. This
         option assumes all necessary repository configuration is already present
         on the system.
-    -R  Specify a custom repository URL. Assumes the custom repository URL points
-        to a repository that mirrors Salt packages located at repo.saltstack.com.
-        The option passed with -R replaces "repo.saltstack.com". If -R is passed,
-        -r is also set. Currently only works on CentOS/RHEL based distributions.
-    -J  Replace the Master config file with data passed in as a json string. If a
-        Master config file is found, a reasonable effort will be made to save the
-        file with a ".bak" extension. If used in conjunction with -C or -F, no ".bak"
-        file will be created as either of those options will force a complete
-        overwrite of the file.
-    -j  Replace the Minion config file with data passed in as a json string. If a
-        Minion config file is found, a reasonable effort will be made to save the
-        file with a ".bak" extension. If used in conjunction with -C or -F, no ".bak"
-        file will be created as either of those options will force a complete
-        overwrite of the file.
+    -R  Specify a custom repository URL. Assumes the custom repository URL
+        points to a repository that mirrors Salt packages located at
+        repo.saltstack.com. The option passed with -R replaces the
+        "repo.saltstack.com". If -R is passed, -r is also set. Currently only
+        works on CentOS/RHEL based distributions.
+    -J  Replace the Master config file with data passed in as a json string. If
+        a Master config file is found, a reasonable effort will be made to save
+        the file with a ".bak" extension. If used in conjunction with -C or -F,
+        no ".bak" file will be created as either of those options will force
+        a complete overwrite of the file.
+    -j  Replace the Minion config file with data passed in as a json string. If
+        a Minion config file is found, a reasonable effort will be made to save
+        the file with a ".bak" extension. If used in conjunction with -C or -F,
+        no ".bak" file will be created as either of those options will force
+        a complete overwrite of the file.
     -q  Quiet salt installation from git (setup.py install -q)
 
 EOT

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -6007,6 +6007,10 @@ config_salt() {
         echowarn "No configuration or keys were copied over. No configuration was done!"
         exit 0
     fi
+
+    # Create default logs directory if not exists (happens with git installations)
+    mkdir -p /var/log/salt
+
     return 0
 }
 #

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2793,9 +2793,8 @@ install_debian_7_deps() {
 
     apt-get update || return 1
 
-    __PACKAGES="libzmq3 libzmq3-dev python-zmq python-requests python-apt python-psutil"
     # Additionally install procps and pciutils which allows for Docker bootstraps. See 366#issuecomment-39666813
-    __PACKAGES="${__PACKAGES} procps pciutils"
+    __PACKAGES='procps pciutils'
 
     if [ "$_INSTALL_CLOUD" -eq $BS_TRUE ]; then
         # Install python-libcloud if asked to
@@ -2875,9 +2874,8 @@ install_debian_8_deps() {
 
     apt-get update || return 1
 
-    __PACKAGES="libzmq3 libzmq3-dev python-zmq python-requests python-apt python-psutil"
     # Additionally install procps and pciutils which allows for Docker bootstraps. See 366#issuecomment-39666813
-    __PACKAGES="${__PACKAGES} procps pciutils"
+    __PACKAGES='procps pciutils'
 
     if [ "$_INSTALL_CLOUD" -eq $BS_TRUE ]; then
         # Install python-libcloud if asked to
@@ -2908,8 +2906,9 @@ install_debian_git_deps() {
     __git_clone_and_checkout || return 1
 
     # shellcheck disable=SC2086
-    __apt_get_install_noinput lsb-release python-backports.ssl-match-hostname python-crypto python-jinja2 \
-        python-m2crypto python-msgpack python-tornado python-yaml || return 1
+    __apt_get_install_noinput libzmq3 libzmq3-dev lsb-release python-apt python-backports.ssl-match-hostname \
+        python-crypto python-jinja2 python-m2crypto python-msgpack python-requests python-tornado python-yaml \
+        python-zmq || return 1
 
     # Let's trigger config_salt()
     if [ "$_TEMP_CONFIG_DIR" = "null" ]; then
@@ -2936,7 +2935,7 @@ install_debian_8_git_deps() {
 
     __git_clone_and_checkout || return 1
 
-    __PACKAGES='lsb-release python-crypto python-jinja2 python-m2crypto python-msgpack python-yaml'
+    __PACKAGES='libzmq3 libzmq3-dev lsb-release python-apt python-crypto python-jinja2 python-m2crypto python-msgpack python-requests python-yaml python-zmq'
     __PIP_PACKAGES=''
 
     if (__check_pip_allowed >/dev/null 2>&1); then

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1169,7 +1169,7 @@ __gather_system_info() {
 #   DESCRIPTION:  Determine primary architecture for packages to install on Debian and derivatives
 #----------------------------------------------------------------------------------------------------------------------
 __get_dpkg_architecture() {
-    if ! __check_command_exists dpkg; then
+    if __check_command_exists dpkg; then
         DPKG_ARCHITECTURE="$(dpkg --print-architecture)"
     else
         echoerror "dpkg: command not found."
@@ -2793,7 +2793,7 @@ install_debian_7_deps() {
 
     apt-get update || return 1
 
-    __PACKAGES="libzmq3 libzmq3-dev python-zmq python-requests python-apt"
+    __PACKAGES="libzmq3 libzmq3-dev python-zmq python-requests python-apt python-psutil"
     # Additionally install procps and pciutils which allows for Docker bootstraps. See 366#issuecomment-39666813
     __PACKAGES="${__PACKAGES} procps pciutils"
 
@@ -2875,7 +2875,7 @@ install_debian_8_deps() {
 
     apt-get update || return 1
 
-    __PACKAGES="libzmq3 libzmq3-dev python-zmq python-requests python-apt"
+    __PACKAGES="libzmq3 libzmq3-dev python-zmq python-requests python-apt python-psutil"
     # Additionally install procps and pciutils which allows for Docker bootstraps. See 366#issuecomment-39666813
     __PACKAGES="${__PACKAGES} procps pciutils"
 

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -265,13 +265,13 @@ __usage() {
     - ${__ScriptName}
     - ${__ScriptName} stable
     - ${__ScriptName} stable 2016.3
-    - ${__ScriptName} stable 2016.3.0
+    - ${__ScriptName} stable 2016.3.1
     - ${__ScriptName} daily
     - ${__ScriptName} testing
     - ${__ScriptName} git
     - ${__ScriptName} git 2016.3
-    - ${__ScriptName} git v2016.3.0
-    - ${__ScriptName} git 11acecc43e2c2e4e9a0e73d76b46b035afe8d538
+    - ${__ScriptName} git v2016.3.1
+    - ${__ScriptName} git 06f249901a2e2f1ed310d58ea3921a129f214358
 
   Options:
     -h  Display this message
@@ -520,7 +520,7 @@ if [ "$ITYPE" = "git" ]; then
     fi
 
     # Disable shell warning about unbound variable during git install
-    STABLE_REV=""
+    STABLE_REV="latest"
 
 # If doing stable install, check if version specified
 elif [ "$ITYPE" = "stable" ]; then
@@ -2361,6 +2361,7 @@ install_ubuntu_stable_deps() {
             echoerror "repo.saltstack.com likely doesn't have all required 32-bit packages for Ubuntu $DISTRO_MAJOR_VERSION (yet?)."
         elif [ "$DPKG_ARCHITECTURE" != "amd64" ]; then
             echoerror "repo.saltstack.com doesn't have packages for your system architecture: $DPKG_ARCHITECTURE."
+            echoerror "You can try git installation mode, i.e.: sh ${__ScriptName} git v2016.3.1"
             exit 1
         fi
 
@@ -2762,7 +2763,7 @@ install_debian_7_deps() {
 
         if [ "$DPKG_ARCHITECTURE" = "i386" ]; then
             echoerror "repo.saltstack.com likely doesn't have all required 32-bit packages for Debian $DISTRO_MAJOR_VERSION (yet?)."
-            echoerror "You can try git installation mode, i.e.: sh ${__ScriptName} git v2016.3.0"
+            echoerror "You can try git installation mode, i.e.: sh ${__ScriptName} git v2016.3.1"
         elif [ "$DPKG_ARCHITECTURE" != "amd64" ]; then
             echoerror "repo.saltstack.com doesn't have packages for your system architecture: $DPKG_ARCHITECTURE."
 
@@ -2843,7 +2844,7 @@ install_debian_8_deps() {
 
         if [ "$DPKG_ARCHITECTURE" = "i386" ]; then
             echoerror "repo.saltstack.com likely doesn't have all required 32-bit packages for Debian $DISTRO_MAJOR_VERSION (yet?)."
-            echoerror "You can try git installation mode, i.e.: sh ${__ScriptName} git v2016.3.0"
+            echoerror "You can try git installation mode, i.e.: sh ${__ScriptName} git v2016.3.1"
         elif [ "$DPKG_ARCHITECTURE" != "amd64" ]; then
             echoerror "repo.saltstack.com doesn't have packages for your system architecture: $DPKG_ARCHITECTURE."
             echoerror "Try git installation mode and disable SaltStack apt repository, for example:"


### PR DESCRIPTION
### What does this PR do?
- Fixes Salt **git** installation on Debian 8 `i386` (by adding backports repo)
- If `pip` installation allowed, always grab latest `tornado` Python module from there
- Installs `python-tornado` package from SaltStack corp repo on `x86_64` if `pip` not allowed
### What issues does this PR fix or reference?

This PR should resolve #774 by allowing git installation on non-`x86_64` architectures such as `arm*`.

Example usage:

``` sh
sh bootstrap-salt.sh -D -r -P git v2016.3.0
```
### Previous Behavior
- Fail to bootstrap Salt from git on non-`x86_64` architecture
### New Behavior
- Display error message on non-`x86` architectures with suggestion how to perform git installation mode with disabled repo configuration.
### Tests written?

No. Tested on Debian 8.4 `x86_64` and `i386` systems.
