### PR TITLE
Exclude path of script when called from another dir

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -19,7 +19,7 @@
 set -o nounset                              # Treat unset variables as an error
 
 __ScriptVersion="2016.05.11"
-__ScriptName="${0}"
+__ScriptName="$(basename ${0})"
 
 #======================================================================================================================
 #  Environment variables taken into account.


### PR DESCRIPTION
### What does this PR do?

Call `basename` to remove the path of the script when called outside the same directory.
### What issues does this PR fix or reference?

When running the script from vagrant I was getting:

``` bash
==> debian-wheezy: Running provisioner: shell...
    debian-wheezy: Running: /tmp/vagrant-shell20160609-9278-134a7v.sh
==> debian-wheezy: stdin: is not a tty
==> debian-wheezy:  *  INFO: Running version: 2016.05.11
==> debian-wheezy:  *  INFO: Command line: " /tmp/vagrant-shell "
==> debian-wheezy:  *  WARN: Running the unstable version of /tmp/vagrant-shell
==> debian-wheezy:  * ERROR: Failed to create the named pipe required to log
The SSH command responded with a non-zero exit status. Vagrant
assumes that this means the command failed. The output for this command
should be in the log above. Please read the output to determine what
went wrong.
```

This is because the variable `__ScriptName="${0}"` will include the path when called outside of the local directory of the script. It then attempts to create a log in `/tmp` but will fail when __ScriptName includes an additional path.
### New Behavior

Call `__ScriptName="$(basename ${0})"` instead so that we can ensure its just the script name and no path.

Now it doesn't fail in vagrant:

``` bash
==> debian-wheezy: Running provisioner: shell...
    debian-wheezy: Running: /tmp/vagrant-shell20160609-11006-1sncr1s.sh
==> debian-wheezy: stdin: is not a tty
==> debian-wheezy:  *  INFO: Running version: 2016.05.11
==> debian-wheezy:  *  INFO: Command line: " /tmp/vagrant-shell "
==> debian-wheezy:  *  WARN: Running the unstable version of vagrant-shell
==> debian-wheezy:
==> debian-wheezy:  *  INFO: System Information:
==> debian-wheezy:  *  INFO:   CPU:          GenuineIntel
==> debian-wheezy:  *  INFO:   CPU Arch:     x86_64
==> debian-wheezy:  *  INFO:   OS Name:      Linux
==> debian-wheezy:  *  INFO:   OS Version:   3.2.0-4-amd64
==> debian-wheezy:  *  INFO:   Distribution: Debian 7.10
==> debian-wheezy:
==> debian-wheezy:  *  INFO: Installing minion
```
### Tests written?

No, manually tested against debian wheezy
