### PR TITLE
CONFIG_PROTECT_MASK is not realiable. Leave CONFIG_PROTECT empty

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -5654,7 +5654,7 @@ __gentoo_config_protection() {
     # this point, manually merge the changes using etc-update/dispatch-conf/
     # cfg-update and then restart the bootstrapping script, so instead we allow
     # at this point to modify certain config files directly
-    export CONFIG_PROTECT_MASK="${CONFIG_PROTECT_MASK:-} /etc/portage/package.keywords /etc/portage/package.unmask /etc/portage/package.use /etc/portage/package.license"
+    export CONFIG_PROTECT="-*"
 }
 
 __gentoo_pre_dep() {


### PR DESCRIPTION
### For Gentoo install

At the moment CONFIG_PROTECT_MASK does not work when the file is missing. 

salt-bootstrap.sh tries to emerge salt from ACCEPT_KEYWORDS="~amd64", so it needs to write /etc/portage/package.accept_keywords. As the file is missing instead of writing a new file, portage writes ._cfg000\* file as if package.accept_keywords is a protected file. 

Instead of playing around with CONFIG_PROTECT_MASK, we should just disable CONFIG_PROTECT altogether.  As a script we should not expect any user interaction, so setting CONFIG_PROTECT="-*" temporarily should be safe.
