### PR TITLE
Add -R option to allow a custom repo URL

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -337,7 +337,7 @@ __usage() {
         option assumes all necessary repository configuration is already present
         on the system.
     -R  Specify a custom repository URL. Assumes the custom repository URL points
-        to a repository that rsyncs Salt packages located at repo.saltstack.com.
+        to a repository that mirrors Salt packages located at repo.saltstack.com.
         The option passed with -R replaces "repo.saltstack.com". If -R is passed,
         -r is also set. Currently only works on CentOS/RHEL based distributions.
     -J  Replace the Master config file with data passed in as a json string. If a


### PR DESCRIPTION
Add the `-R` option to allow users to specify a custom repo URL to use instead of `repo.saltstack.com`. This option assumes that the custom URL specified mirrors the packages on `repo.saltstack.com`.

If the `-R` option is passed and the `-r` option is not passed via the CLI, then the `-r` is set to `True` automatically. `-r` was implemented in #814.

This option currently only works currently on CentOS/RHEL, but could likely be expanded to other distros.

CLI Example:

```
sh install_salt.sh -R my-custom-repo.url.com
```

Fixes #710
