### PR TITLE
Add repourl option

### DIFF
--- a/bootstrap-salt.ps1
+++ b/bootstrap-salt.ps1
@@ -46,7 +46,7 @@
     Name or IP of the master server. Installer defaults to "salt".
 
 .PARAMETER repourl
-    URL to the windows packages. Default is "http://repo.saltstack.com/windows"
+    URL to the windows packages. Default is "https://repo.saltstack.com/windows"
 
 .NOTES
     All of the parameters are optional. The default should be the latest
@@ -80,7 +80,7 @@ Param(
     [string]$master = "not-specified",
 
     [Parameter(Mandatory=$false,ValueFromPipeline=$true)]
-    [string]$repourl= "http://repo.saltstack.com/windows"
+    [string]$repourl= "https://repo.saltstack.com/windows"
 )
 
 #===============================================================================


### PR DESCRIPTION
### What does this PR do?

Adds a `repourl` parameter for the bootstrap for windows. Accepts a URL to the download location for windows salt installer binaries. Default is `http://repo.saltstack.com/windows`

Standardize formatting.
### What issues does this PR fix or reference?

https://github.com/saltstack/zh/issues/772
### Previous Behavior

No ability to point the bootstrap to a custom location
### New Behavior

Adds ability to point the bootstrap to a custom location
### Tests written?

NA
