### PR TITLE
Restore abilty to perform "one liner" bootstrap

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -19,7 +19,8 @@
 set -o nounset                              # Treat unset variables as an error
 
 __ScriptVersion="2016.06.24"
-__ScriptName="$(basename "${0}")"
+__ScriptName="bootstrap-salt.sh"
+
 __ScriptFullName="${0}"
 __ScriptArgs="${*}"
 
@@ -6330,7 +6331,7 @@ if [ "$DAEMONS_RUNNING_FUNC" != "null" ] && [ $_START_DAEMONS -eq $BS_TRUE ]; th
             [ $fname = "syndic" ] && [ "$_INSTALL_SYNDIC" -eq $BS_FALSE ] && continue
 
             if [ "$_ECHO_DEBUG" -eq $BS_FALSE ]; then
-                echoerror "salt-$fname was not found running. Pass '-D' to $__ScriptName when bootstrapping for additional debugging information..."
+                echoerror "salt-$fname was not found running. Pass '-D' to ${__ScriptName} when bootstrapping for additional debugging information..."
                 continue
             fi
 


### PR DESCRIPTION
### What does this PR do?

Fix race condition when doing one-liner bootstrap.
Blame this line:

```
__ScriptName="$(basename "${0}")"
```

It drives shell crazy later during these executions:

```
# Define our logging file and pipe paths                                                                                
LOGFILE="/tmp/$( echo "$__ScriptName" | sed s/.sh/.log/g )"                                                             
LOGPIPE="/tmp/$( echo "$__ScriptName" | sed s/.sh/.logpipe/g )"                                                         

# Create our logging pipe                                                                                               
# On FreeBSD we have to use mkfifo instead of mknod                                                                     
mknod "$LOGPIPE" p >/dev/null 2>&1 || mkfifo "$LOGPIPE" >/dev/null 2>&1                                                 
if [ $? -ne 0 ]; then                                                                                                   
    echoerror "Failed to create the named pipe required to log"                                                         
    exit 1                                                                                                              
fi                                                                                                                      

# What ever is written to the logpipe gets written to the logfile                                                       
tee < "$LOGPIPE" "$LOGFILE" &                                                                                           

# Close STDOUT, reopen it directing it to the logpipe                                                                   
exec 1>&-                                                                                                               
exec 1>"$LOGPIPE"                                                                                                       
# Close STDERR, reopen it directing it to the logpipe                                                                   
exec 2>&-                                                                                                               
exec 2>"$LOGPIPE"                                                                                                       
```
### What issues does this PR fix or reference?

It should fix #888.
### Previous Behavior

Infinite loop in the shell.
### New Behavior

One-liners work correctly.
### Tests written?

No
