### PR TITLE
RFC: Add tests for bootstrap-salt.ps1

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,8 @@
 Bootstrapping Salt
 ==================
 
+|windows_build|
+
 Before `Salt`_ can be used for provisioning on the desired machine, the binaries need to be
 installed. Since `Salt`_ supports many different distributions and versions of operating systems,
 the `Salt`_ installation process is handled by this shell script ``bootstrap-salt.sh``.  This
@@ -535,3 +537,7 @@ Salt is ready and working in the Docker container with Minion authenticated on M
 
 
 .. vim: fenc=utf-8 spell spl=en cc=100 tw=99 fo=want sts=2 sw=2 et
+
+.. |windows_build|  image:: https://ci.appveyor.com/api/projects/status/github/themalkolm/salt-bootstrap?branch=develop&svg=true
+    :target: https://ci.appveyor.com/project/themalkolm/salt-bootstrap
+    :alt: Build status of the develop branch on Windows

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,32 @@
+platform: Any CPU
+
+environment:
+  matrix:
+    - bootstrap_args:
+      test_args:      -master salt -runservice
+
+    - bootstrap_args: -runservice false
+      test_args:      -master salt -noservice
+
+    - bootstrap_args: -minion a-minion
+      test_args:      -minion a-minion -master salt -runservice
+
+    - bootstrap_args: -minion a-minion -master a-master
+      test_args:      -minion a-minion -master a-master -runservice
+
+build_script:
+  - ps: |
+      $Path = (Get-Location).Path | Join-Path -ChildPath bootstrap-salt.ps1
+      Invoke-Expression "$Path -verbose $env:bootstrap_args"
+
+before_test:
+  - SET PATH=%PATH%;C:\salt
+  - salt-call --version
+
+test_script:
+  - ps: |
+      $Path = (Get-Location).Path | Join-Path -ChildPath tests\runtests.ps1
+      Invoke-Expression "$Path -verbose $env:test_args"
+
+matrix:
+  fast_finish: true

--- a/tests/runtests.ps1
+++ b/tests/runtests.ps1
@@ -1,0 +1,105 @@
+<#
+.SYNOPSIS
+    A simple Powershell script to test installed salt minion on windows.
+
+.PARAMETER version
+    Salt version installed.
+
+.PARAMETER runservice
+    Boolean flag whenever to test if service is running.
+
+.PARAMETER noservice
+    Boolean flag whenever to test if service is not running.
+
+.PARAMETER minion
+    Name of the minion installed on this host.
+
+.PARAMETER master
+    Name of the master configured on this host.
+
+.EXAMPLE
+    ./runtests.ps1
+    Runs without any parameters. Uses all the default values/settings.
+#>
+
+#===============================================================================
+# Commandlet Binding
+#===============================================================================
+[CmdletBinding()]
+Param(
+    [Parameter(Mandatory=$False,ValueFromPipeline=$True)]
+    [string]$version = $null,
+
+    [Parameter(Mandatory=$False,ValueFromPipeline=$True)]
+    [switch]$runservice,
+
+    [Parameter(Mandatory=$False,ValueFromPipeline=$True)]
+    [switch]$noservice,
+
+    [Parameter(Mandatory=$False,ValueFromPipeline=$True)]
+    [string]$minion = $null,
+
+    [Parameter(Mandatory=$False,ValueFromPipeline=$True)]
+    [string]$master = $null
+)
+
+#===============================================================================
+# Script Functions
+#===============================================================================
+function Get-Grains ([string]$Name) {
+    $Command = "salt-call --local --out json --out-indent -1 grains.get $Name"
+    $Result = iex $Command | Out-String | ConvertFrom-Json
+
+    Write-Verbose "salt-call grains.get ${Name}:`n${Result}"
+    return $Result."local"
+}
+
+function Get-Service-Status([string]$Name) {
+    $Service = Get-Service $Name -ErrorAction Stop
+    $Status = $Service.Status
+
+    Write-Verbose "${Name}: ${Status}"
+    return $Status
+}
+
+function Assert-Equal {
+    [CmdletBinding()]
+    Param (
+        [Parameter(Mandatory=$True,ValueFromPipeline=$True)]
+        [string]$Actual,
+
+        [Parameter(Mandatory=$True,ValueFromPipeline=$True)]
+        [string]$Expected
+    )
+
+    If ($Actual -ne $Expected) {
+        throw "Assert: $Actual != $Expected"
+    }
+}
+
+#===============================================================================
+# Do enabled checks
+#===============================================================================
+if ($True) {
+    Get-Grains -Name os_family | Assert-Equal -Expected "Windows"
+}
+
+if ($version) {
+    Get-Grains -Name saltversion | Assert-Equal -Expected $version
+}
+
+if ($master) {
+    Get-Grains -Name master | Assert-Equal -Expected $master
+}
+
+if ($minion) {
+    Get-Grains -Name id | Assert-Equal -Expected $minion
+}
+
+if ($runservice) {
+    Get-Service-Status salt-minion | Assert-Equal -Expected "Running"
+}
+
+if ($noservice) {
+    Get-Service-Status salt-minion | Assert-Equal -Expected "Stopped"
+}


### PR DESCRIPTION
**DO NOT MERGE AS EVERYTHING IS CONFIGURED TO WORK ON MY REPO**

We heavily rely on this script and would like to somehow ensure it won't be broken in future releases. I also would like to fix some minor issues but very reluctant unless there are tests. So here you are, first attempt to make tests using https://www.appveyor.com/

I'm open to comments, suggestions and ideas how it must be structured in a better way. For now it heavily relies on running in AppVeyor and therefore no cleanup logic as AppVeyor will spin up a new worker for every build.
### What does this PR do?

Adds AppVeyor configuration enabling automatic smoke tests for `bootstrap-salt.ps1`. It does not test for all possible cases. Itmostly works as smoke tests to ensure that at least something works. While it sounds strange, the power is in the fact that it runs **automatically** and has in-built support for matrix builds.
### What issues does this PR fix or reference?

It add smoke tests for `bootstrap-salt.ps1` and a nice status badge.
