### PR TITLE
Fix expanding shell script position parameters with nounset enabled

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -21,8 +21,8 @@ set -o nounset                              # Treat unset variables as an error
 __ScriptVersion="2016.06.27"
 __ScriptName="bootstrap-salt.sh"
 
-__ScriptFullName="${0}"
-__ScriptArgs="${*}"
+__ScriptFullName="$0"
+__ScriptArgs="$*"
 
 #======================================================================================================================
 #  Environment variables taken into account.
@@ -630,7 +630,7 @@ fi
 
 echoinfo "Running version: ${__ScriptVersion}"
 echoinfo "Executed by: ${CALLER}"
-echoinfo "Command line: \"${__ScriptFullName} ${__ScriptArgs}\""
+echoinfo "Command line: '${__ScriptFullName} ${__ScriptArgs}'"
 echowarn "Running the unstable version of ${__ScriptName}"
 
 #---  FUNCTION  -------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
### What does this PR do?

Fixes bootsrapping on RHEL systems family release 5.X with `bash` version ~ 3.2.
It fails if calling bootstrap script without any arguments at all.
### What issues does this PR fix or reference?

Resolves #894.
### Previous Behavior

``` sh
# curl -s -L https://bootstrap.saltstack.com | sh
sh: line 25: *: unbound variable
```
### New Behavior

Bootstrap script works.
### Tests written?

No
