### PR TITLE
add apt-transport-https for ubuntu

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2341,6 +2341,11 @@ install_ubuntu_stable_deps() {
                 set -o nounset
             fi
 
+            # Make sure https transport is available
+            if [ "$HTTP_VAL" = "https" ] ; then
+                __apt_get_install_noinput ca-certificates apt-transport-https || return 1
+            fi
+
             # Make sure wget is available
             __apt_get_install_noinput wget
 


### PR DESCRIPTION
### What does this PR do?

add apt-transport-https for ubuntu
### What issues does this PR fix or reference?

issue not created, the apt-transport-https is missing in generic ubuntu docker images, where the boostrap script (apt-get update) end up with exit code 100 and msg: 

```
E: The method driver /usr/lib/apt/methods/https could not be found.
```
### Previous Behavior

Fails to boostrap salt in docker "ubuntu" containers.
### Tests written?

No (considering add kitchen-ci file to test script on multiple platforms)
