### PR TITLE
Change temporary directory for storing executable to C:\Windows\Temp

### DIFF
--- a/bootstrap-salt.ps1
+++ b/bootstrap-salt.ps1
@@ -221,7 +221,7 @@ $saltExe = "Salt-Minion-$version-$arch-Setup.exe"
 Write-Output "Downloading Salt minion installer $saltExe"
 $webclient = New-Object System.Net.WebClient
 $url = "$repourl/$saltExe"
-$file = "C:\tmp\$saltExe"
+$file = "C:\Windows\Temp\$saltExe"
 $webclient.DownloadFile($url, $file)
 
 #===============================================================================
@@ -241,7 +241,7 @@ If($runservice -eq $false) {$parameters = "$parameters /start-service=0"}
 #===============================================================================
 #Wait for process to exit before continuing.
 Write-Output "Installing Salt minion"
-Start-Process C:\tmp\$saltExe -ArgumentList "/S $parameters" -Wait -NoNewWindow -PassThru | Out-Null
+Start-Process C:\Windows\Temp\$saltExe -ArgumentList "/S $parameters" -Wait -NoNewWindow -PassThru | Out-Null
 
 #===============================================================================
 # Configure the minion service


### PR DESCRIPTION
### What does this PR do?

Change temporary directory for storing executable to `C:\Windows\Temp`

Yep, `$env:temp` is even better but lets change things step by step.

This makes script inconsistent somehow as other parts still use `c:\tmp` for storing configuration files. I don't want to change them as it is _very_ likely that some users already upload configuration files there using either vagrant or some other scripts.

Installation file is not configuration and therefore is OK to put somewhere where system will take care later to remove.
