### PR TITLE
Set repo_arch for raspberry pi installs.

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2714,6 +2714,8 @@ install_debian_7_deps() {
     if [ $_DISABLE_REPOS -eq $BS_FALSE ]; then
         if [ "$CPU_ARCH_L" = "amd64" ] || [ "$CPU_ARCH_L" = "x86_64" ]; then
             repo_arch="amd64"
+        elif [ "$CPU_ARCH_L" = "armv7l" ]; then
+            repo_arch="armhf"
         elif [ "$CPU_ARCH_L" = "i386" ] || [ "$CPU_ARCH_L" = "i686" ]; then
             echoerror "repo.saltstack.com likely doesn't have 32-bit packages for Debian (yet?)"
             repo_arch="i386"
@@ -2790,6 +2792,8 @@ install_debian_8_deps() {
     if [ $_DISABLE_REPOS -eq $BS_FALSE ]; then
         if [ "$CPU_ARCH_L" = "amd64" ] || [ "$CPU_ARCH_L" = "x86_64" ]; then
             repo_arch="amd64"
+        elif [ "$CPU_ARCH_L" = "armv7l" ]; then
+            repo_arch="armhf"
         elif [ "$CPU_ARCH_L" = "i386" ] || [ "$CPU_ARCH_L" = "i686" ]; then
             echoerror "repo.saltstack.com likely doesn't have 32-bit packages for Debian (yet?)"
             repo_arch="i386"


### PR DESCRIPTION
### What does this PR do?

Set `$repo_arch` to `armhf` for armv7l chipsets so that raspbian builds can find the packages built for that arch.
