### PR TITLE
Adding support for Linux Mint 18 (based on Ubuntu 16.04)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -236,7 +236,7 @@ Ubuntu and derivatives
 
 - Elementary OS 0.2 (based on Ubuntu 12.04)
 - Linaro 12.04
-- Linux Mint 13/14/16/17
+- Linux Mint 13/14/16/17/18
 - Trisquel GNU/Linux 6 (based on Ubuntu 12.04)
 - Ubuntu 10.x/11.x/12.x/13.x/14.x/15.x/16.04
 

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1180,6 +1180,7 @@ __ubuntu_derivatives_translation() {
 
     linuxmint_16_ubuntu_base="13.10"
     linuxmint_17_ubuntu_base="14.04"
+    linuxmint_18_ubuntu_base="16.04"
     linaro_12_ubuntu_base="12.04"
     elementary_os_02_ubuntu_base="12.04"
 


### PR DESCRIPTION
### What does this PR do?

Adds support for recently released Linux Mint 18 by declaring the corresponding Ubuntu base version.
### What issues does this PR fix or reference?
#901
### Tests written?

No
