### PR TITLE
Make sure $STABLE_REV is set before setting up SaltStack repo

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -4087,6 +4087,14 @@ _eof
 }
 
 install_amazon_linux_ami_git_deps() {
+
+    # When installing from git, this variable might not be set yet for amazon linux. Set this
+    # to "latest" in order to set up the SaltStack repository and avoid a malformed baseurl
+    # and gpgkey reference in the install_amazon_linux_amI_deps function. 
+    if [ "$STABLE_REV" = "" ]; then
+        STABLE_REV="latest"
+    fi
+
     install_amazon_linux_ami_deps || return 1
 
     if ! __check_command_exists git; then
@@ -4102,7 +4110,6 @@ install_amazon_linux_ami_git_deps() {
             yum install -y python-tornado
         fi
     fi
-
 
     # Let's trigger config_salt()
     if [ "$_TEMP_CONFIG_DIR" = "null" ]; then


### PR DESCRIPTION
### What does this PR do?

When installing salt on Amazon Linux with a git reference, the $STABLE_REV
variable might not be set yet, causing malformed baseurl and gpgkey links
referenced in the /etc/yum.repos.d/saltstack-repo.repo file. We need to
ensure this variable is set before setting up the repo file.
### What issues does this PR fix or reference?

Fixes #882
### Previous Behavior

Bootstrapping Amazon Linux would fail when installing via git because the `/etc/yum.repos.d/saltstack-repo.repo` file contained invalid links in the baseurl and gpgkey options due to $STABLE_REV being empty.
### New Behavior

Checks if $STABLE_REV is empty when installing via git. If it is, it is set to `latest` by default. This allows the repo set up step to function as normal and the git installation can continue successfully.
