### PR TITLE
Split up python-requests and python-msgpack packages for newer Fedora

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -3118,7 +3118,13 @@ install_fedora_deps() {
         __install_saltstack_copr_salt_repository || return 1
     fi
 
-    __PACKAGES="yum-utils PyYAML libyaml m2crypto python-crypto python-jinja2 python-msgpack python-zmq python-requests"
+    __PACKAGES="yum-utils PyYAML libyaml m2crypto python-crypto python-jinja2 python-zmq"
+
+    if [ "$DISTRO_MAJOR_VERSION" -ge 23 ]; then
+        __PACKAGES="${__PACKAGES} python2-msgpack python2-requests"
+    else
+        __PACKAGES="${__PACKAGES} python-msgpack python-requests"
+    fi
 
     if [ "$_INSTALL_CLOUD" -eq $BS_TRUE ]; then
         __PACKAGES="${__PACKAGES} python-libcloud"


### PR DESCRIPTION
### What does this PR do?

If running on Fedora 23 or newer, the python-requests and python-msgpack packages have been split up into python2-\* and python3-\* versions instead. This change allows for the correct packages to be installed.
### What issues does this PR fix or reference?

Fixes #875 
### Previous Behavior

Updated Fedora 23 would fail on bootstrap because the python-requests and python-msgpack packages could no longer be found.
### New Behavior

Fedora 23 bootstraps successfully.
