### PR TITLE
Fix badge url

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -538,6 +538,6 @@ Salt is ready and working in the Docker container with Minion authenticated on M
 
 .. vim: fenc=utf-8 spell spl=en cc=100 tw=99 fo=want sts=2 sw=2 et
 
-.. |windows_build|  image:: https://ci.appveyor.com/api/projects/status/github/themalkolm/salt-bootstrap?branch=develop&svg=true
-    :target: https://ci.appveyor.com/project/themalkolm/salt-bootstrap
+.. |windows_build|  image:: https://ci.appveyor.com/api/projects/status/github/saltstack/salt-bootstrap?branch=develop&svg=true
+    :target: https://ci.appveyor.com/project/saltstack-public/salt-bootstrap
     :alt: Build status of the develop branch on Windows


### PR DESCRIPTION
### What does this PR do?

Fixes badge url
### What issues does this PR fix or reference?

Fix badge url to refer to saltstack repo instead of mine. This was merged by mistake here https://github.com/saltstack/salt-bootstrap/pull/893
