### PR TITLE
Install `salt-cloud` package with `-L` option in `stable` mode

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -5821,9 +5821,7 @@ __gentoo_post_dep() {
     __gentoo_config_protection
 
     if [ "$_INSTALL_CLOUD" -eq $BS_TRUE ]; then
-        __check_pip_allowed "You need to allow pip based installations (-P) in order to install apache-libcloud"
-        __emerge -v 'dev-python/pip'
-        pip install -U "apache-libcloud>=$_LIBCLOUD_MIN_VERSION"
+        __emerge -v 'dev-python/libcloud'
     fi
 
     __emerge -vo 'dev-python/requests'


### PR DESCRIPTION
### What does this PR do?

It allows to install `salt-cloud` package (from SaltStack Corp repo in most cases) using `-L` option, not only Apache Libcloud Python module.
Currently supported on RHEL-family distributions, support for other platforms will be added soon.
### Previous Behavior

By giving the `-L` option to the `bootstrap-salt.sh` script, it only installed `apache-libcloud`  from `pip` without actually installing `salt-cloud`.
### New Behavior
- `sh bootstrap-salt.sh -L stable` installation mode:
  
  install `salt-cloud` package with all needed dependencies using package manager from configured SaltStack repository. `pip` not required.
- `sh bootstrap-salt.sh -L git` installation mode:
  
  1) install `python-libcloud` package using package manager from any available repository (SaltStack, EPEL, local mirror). `pip` not required.
  2) copy relevant config files from Salt checkout directory
