### PR TITLE
Fix grep pattern in `__check_services_sysvinit`

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2023,7 +2023,7 @@ __check_services_sysvinit() {
     servicename=$1
     echodebug "Checking if service ${servicename} is enabled"
 
-    if [ "$(LC_ALL=C /sbin/chkconfig --list  | grep salt-"$fname" | grep '[2-5]:on')" != "" ]; then
+    if [ "$(LC_ALL=C /sbin/chkconfig --list | grep "\<${servicename}\>" | grep '[2-5]:on')" != "" ]; then
         echodebug "Service ${servicename} is enabled"
         return 0
     else


### PR DESCRIPTION
### What does this PR do?

Fixes unsafe usage of external variable `$fname` in `__check_services_sysvinit` function.
This variable is out of the function's scope and hasn't checked for non-empty value, so some false positive `grep` pattern matchings are possible. The function's first positional argument is assigned to the `servicename` variable which should be used instead.
