### PR TITLE
Remove chris-lea python-zmq repo

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2316,12 +2316,6 @@ install_ubuntu_deps() {
                 fi
             fi
 
-            if [ "$DISTRO_MAJOR_VERSION" -gt 12 ] || ([ "$DISTRO_MAJOR_VERSION" -eq 12 ] && [ "$DISTRO_MINOR_VERSION" -gt 03 ]); then
-                if ([ "$DISTRO_MAJOR_VERSION" -lt 15 ] && [ "$_ENABLE_EXTERNAL_ZMQ_REPOS" -eq $BS_TRUE ]); then
-                    echoinfo "Installing ZMQ>=4/PyZMQ>=14 from Chris Lea's PPA repository"
-                    add-apt-repository -y ppa:chris-lea/zeromq || return 1
-                fi
-            fi
         fi
     fi
 


### PR DESCRIPTION
python-zmq is provided by repo.saltstack.com now, for platforms that do not have a recent enough version.

Fixes #926

Also references https://github.com/saltstack/salt/issues/34122
