### PR TITLE
Deprecate `-G` option: use `https` scheme for GitHub by default

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,7 +66,7 @@ If you want to install a specific release version (based on the Git tags):
 .. code:: console
 
   curl -o bootstrap_salt.sh -L https://bootstrap.saltstack.com
-  sudo sh bootstrap_salt.sh git v2015.8.8
+  sudo sh bootstrap_salt.sh git v2016.3.2
 
 To install a specific branch from a Git fork:
 
@@ -88,7 +88,7 @@ If your host has Internet access only via HTTP proxy:
 
   PROXY='http://user:password@myproxy.example.com:3128'
   curl -o bootstrap_salt.sh -L -x "$PROXY" https://bootstrap.saltstack.com
-  sudo sh bootstrap_salt.sh -G -H "$PROXY" git
+  sudo sh bootstrap_salt.sh -H "$PROXY" git
 
 
 Install using wget
@@ -106,7 +106,7 @@ Installing a specific version from git using ``wget``:
 .. code:: console
 
   wget -O bootstrap_salt.sh https://bootstrap.saltstack.com
-  sudo sh bootstrap_salt.sh -P git v2015.8.7
+  sudo sh bootstrap_salt.sh -P git v2015.8.11
 
 .. note::
 
@@ -548,8 +548,8 @@ Salt is ready and working in the Docker container with Minion authenticated on M
 .. _`pre-accepted Minion key`: https://docs.saltstack.com/en/latest/topics/tutorials/preseed_key.html
 
 
-.. vim: fenc=utf-8 spell spl=en cc=100 tw=99 fo=want sts=2 sw=2 et
-
 .. |windows_build|  image:: https://ci.appveyor.com/api/projects/status/github/saltstack/salt-bootstrap?branch=develop&svg=true
     :target: https://ci.appveyor.com/project/saltstack-public/salt-bootstrap
     :alt: Build status of the develop branch on Windows
+
+.. vim: fenc=utf-8 spell spl=en cc=100 tw=99 fo=want sts=2 sw=2 et

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -193,7 +193,7 @@ __check_config_dir() {
 #----------------------------------------------------------------------------------------------------------------------
 _KEEP_TEMP_FILES=${BS_KEEP_TEMP_FILES:-$BS_FALSE}
 _TEMP_CONFIG_DIR="null"
-_SALTSTACK_REPO_URL="git://github.com/saltstack/salt.git"
+_SALTSTACK_REPO_URL="https://github.com/saltstack/salt.git"
 _SALT_REPO_URL=${_SALTSTACK_REPO_URL}
 _DOWNSTREAM_PKG_REPO=$BS_FALSE
 _TEMP_KEYS_DIR="null"
@@ -280,10 +280,6 @@ __usage() {
     -D  Show debug output
     -c  Temporary configuration directory
     -g  Salt Git repository URL. Default: ${_SALTSTACK_REPO_URL}
-    -G  Instead of cloning from ${_SALTSTACK_REPO_URL}, clone from
-        https://${_SALTSTACK_REPO_URL#*://}
-        (usually necessary on systems which have the regular git protocol port
-        blocked, where https usually is not)
     -w  Install packages from downstream package repository rather than
         upstream, saltstack package repository. This is currently only
         implemented for SUSE.
@@ -360,7 +356,7 @@ EOT
 }   # ----------  end of function __usage  ----------
 
 
-while getopts ":hvnDc:Gg:wk:s:MSNXCPFUKIA:i:Lp:dH:ZbflV:J:j:rR:aq" opt
+while getopts ":hvnDc:g:wk:s:MSNXCPFUKIA:i:Lp:dH:ZbflV:J:j:rR:aq" opt
 do
   case "${opt}" in
 
@@ -382,14 +378,6 @@ do
          ;;
 
     g )  _SALT_REPO_URL=$OPTARG                         ;;
-
-    G )  if [ "${_SALT_REPO_URL}" = "${_SALTSTACK_REPO_URL}" ]; then
-             _SALTSTACK_REPO_URL="https://github.com/saltstack/salt.git"
-             _SALT_REPO_URL=${_SALTSTACK_REPO_URL}
-         else
-             _SALTSTACK_REPO_URL="https://github.com/saltstack/salt.git"
-         fi
-         ;;
 
     w )  _DOWNSTREAM_PKG_REPO=$BS_TRUE                  ;;
 
@@ -1553,8 +1541,7 @@ __git_clone_and_checkout() {
             # shellcheck disable=SC2164
             cd "${_SALT_GIT_CHECKOUT_DIR}"
 
-            if ! echo "$_SALT_REPO_URL" | \
-                grep -q -x '\(\(git\|https\)://github\.com/\|git@github\.com:\)saltstack/salt\.git'; then
+            if ! echo "$_SALT_REPO_URL" | grep -q -F -w "${_SALTSTACK_REPO_URL#*://}"; then
                 # We need to add the saltstack repository as a remote and fetch tags for proper versioning
                 echoinfo "Adding SaltStack's Salt repository as a remote"
                 git remote add upstream "$_SALTSTACK_REPO_URL" || return 1

--- a/tests/bootstrap/test_install.py
+++ b/tests/bootstrap/test_install.py
@@ -605,7 +605,7 @@ class InstallationTestCase(BootstrapTestCase):
             0,
             self.run_script(
                 script=None,
-                args=('git', 'clone', 'git://github.com/saltstack/salt.git'),
+                args=('git', 'clone', 'https://github.com/saltstack/salt.git'),
                 cwd='/tmp/git',
                 timeout=15 * 60,
                 stream_stds=True


### PR DESCRIPTION
### What does this PR do?

It makes Salt Bootstrap to clone from SaltStack GitHub repo using https scheme by default.
Also, the `-G` option is going to be deprecated. REAME and usage info updated accordingly.
### What issues does this PR fix or reference?

It supersedes PR #854 and completely resolves issue #944.
### Previous Behavior

The script utilized insecure git protocol to fetch Salt sources from GitHub.
### New Behavior

The script will clone Salt repo by https.
