### PR TITLE
Try to install SP4 packages on SLE 11 when SP version is older

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -5560,7 +5560,11 @@ install_suse_12_restart_daemons() {
 install_suse_11_stable_deps() {
     SUSE_PATCHLEVEL=$(awk '/PATCHLEVEL/ {print $3}' /etc/SuSE-release )
     if [ "${SUSE_PATCHLEVEL}" != "" ]; then
-        DISTRO_PATCHLEVEL="_SP${SUSE_PATCHLEVEL}"
+        if [ "${SUSE_PATCHLEVEL}" != "4" ]; then
+            echowarn "Salt packages for SLE 11 are only build for SP4."
+            echowarn "Attempting to install SP4 packages on SP${SUSE_PATCHLEVEL}."
+        fi
+        DISTRO_PATCHLEVEL="_SP4"
     fi
     DISTRO_REPO="SLE_${DISTRO_MAJOR_VERSION}${DISTRO_PATCHLEVEL}"
 


### PR DESCRIPTION
### What does this PR do?

If we detect an older service pack when installing Salt on SLES, we should warn the user that we'll attempt to install SP4 Salt packages, and then attempt to do so.

repo.saltstack.com pegs the SLE 11 repo at SP4, as does SUSE, so we should attempt to install those instead of failing like this:

```
File '/opensuse/SLE_11_SP3/systemsmanagement:saltstack.repo' not found on medium 'https://repo.saltstack.com/'
```
### What issues does this PR fix or reference?

Fixes #941
### Previous Behavior

When installing on SLE SP3, the bootstrap script would error out because it couldn't find the SLE_11_SP3 files, because they don't exist.
### New Behavior

Warns the user that we're attempting to install SP4 packages on an SP3 machine and tries to install the SP4 packages.
