### PR TITLE
Fix issues with replacing configs when python3 is default in os.

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1898,8 +1898,15 @@ __overwriteconfig() {
         tempfile="/tmp/salt-config-$$"
     fi
 
+    # If python does not have yaml installed we're on Arch and should use python2
+    if python -c "import yaml" 2> /dev/null; then
+        good_python=python
+    else
+        good_python=python2
+    fi
+
     # Convert json string to a yaml string and write it to config file. Output is dumped into tempfile.
-    python -c "import json; import yaml; jsn=json.loads('$json'); yml=yaml.safe_dump(jsn, line_break='\n', default_flow_style=False); config_file=open('$target', 'w'); config_file.write(yml); config_file.close();" 2>$tempfile
+    $good_python -c "import json; import yaml; jsn=json.loads('$json'); yml=yaml.safe_dump(jsn, line_break='\n', default_flow_style=False); config_file=open('$target', 'w'); config_file.write(yml); config_file.close();" 2>$tempfile
 
     # No python errors output to the tempfile
     if [ ! -s "$tempfile" ]; then

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1901,17 +1901,14 @@ __overwriteconfig() {
     # Convert json string to a yaml string and write it to config file. Output is dumped into tempfile.
     python -c "import json; import yaml; jsn=json.loads('$json'); yml=yaml.safe_dump(jsn, line_break='\n', default_flow_style=False); config_file=open('$target', 'w'); config_file.write(yml); config_file.close();" 2>$tempfile
 
-    # Check if there were any errors output to the tempfile
-    filesize=$(python -c "import os; print os.stat('$tempfile').st_size;")
-
     # No python errors output to the tempfile
-    if [ "$filesize" -eq 0 ]; then
+    if [ ! -s "$tempfile" ]; then
         rm -f "$tempfile"
         return 0
     fi
 
-    # Errors are present in the tempfile - let's expose the that to the user.
-    fullerror=$(python -c "tmp_file=open('$tempfile'); print tmp_file.read(); tmp_file.close()")
+    # Errors are present in the tempfile - let's expose them to the user.
+    fullerror=$(cat "$tempfile")
     echodebug "$fullerror"
     echoerror "Python error encountered. This is likely due to passing in a malformed JSON string. Please use -D to see stacktrace."
 


### PR DESCRIPTION
### What does this PR do?
1. __overwriteconfig does not use python when reporting errors anymore (less stuff to break)
2. __overwriteconfig checks if python can import yaml before using it to convert configs. If it can't it assumes python is python3 and uses python2 instead
### What issues does this PR fix or reference?

https://github.com/saltstack/salt-bootstrap/issues/953
### New Behavior

`bootstrap-salt.sh -j '{"master": "example.com"}'` works on Arch now
