### PR TITLE
Allow correct salt paths to be used when -c is passed

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -4401,10 +4401,6 @@ install_arch_check_services() {
 #
 #   FreeBSD Install Functions
 #
-config_freebsd_salt() {
-    _SALT_ETC_DIR=${BS_SALT_ETC_DIR:-/usr/local/etc/salt}
-    config_salt
-}
 
 __freebsd_get_packagesite() {
     if [ "$CPU_ARCH_L" = "amd64" ]; then
@@ -4571,7 +4567,7 @@ install_freebsd_git_deps() {
     # Let's trigger config_salt()
     if [ "$_TEMP_CONFIG_DIR" = "null" ]; then
         _TEMP_CONFIG_DIR="${_SALT_GIT_CHECKOUT_DIR}/conf/"
-        CONFIG_SALT_FUNC="config_freebsd_salt"
+        CONFIG_SALT_FUNC="config_salt"
 
     fi
 

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -4563,15 +4563,16 @@ install_freebsd_git_deps() {
     fi
     echodebug "Finished patching"
 
+    # Set _SALT_ETC_DIR to ports default
+    _SALT_ETC_DIR=${BS_SALT_ETC_DIR:-/usr/local/etc/salt}
+    # We also need to redefine the PKI directory
+    _PKI_DIR=${_SALT_ETC_DIR}/pki
+
     # Let's trigger config_salt()
     if [ "$_TEMP_CONFIG_DIR" = "null" ]; then
         _TEMP_CONFIG_DIR="${_SALT_GIT_CHECKOUT_DIR}/conf/"
-        CONFIG_SALT_FUNC="config_salt"
+        CONFIG_SALT_FUNC="config_freebsd_salt"
 
-        # Set _SALT_ETC_DIR to ports default
-        _SALT_ETC_DIR=${BS_SALT_ETC_DIR:-/usr/local/etc/salt}
-        # We also need to redefine the PKI directory
-        _PKI_DIR=${_SALT_ETC_DIR}/pki
     fi
 
     return 0


### PR DESCRIPTION
### What does this PR do?

Allows keys to be placed in the correct directory when `-c` is passed to bootstrap. 

@rallytime 
### What issues does this PR fix or reference?

Fixes https://github.com/saltstack/salt/issues/36197
