### PR TITLE
Fix detection of EPEL repository with not-expired metadata

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -3374,7 +3374,7 @@ __install_epel_repository() {
     fi
 
     # Check if epel repo is already enabled and flag it accordingly
-    yum repolist | grep -q "^[!]${_EPEL_REPO}/"
+    yum repolist | grep -q "^[!]\?${_EPEL_REPO}/"
     if [ $? -eq 0 ]; then
         _EPEL_REPOS_INSTALLED=$BS_TRUE
         return 0


### PR DESCRIPTION
Hello,

Currently only EPEL repository with expired metadata (repo name is prepended with "!") will be discovered during installation process. This tiny PR corrects regexp to match repositories with not-expired metadata.
