### PR TITLE
Update OpenBSD 6.0+ provisioning

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -37,6 +37,7 @@ Diego Woitasen              diegows                diego@flugel.it
 Elias Probst                eliasp
 eliezerlp                   eliezerlp
 Emiel Kollof                ekollof
+Eric Radman                 eradman                ericshane@eradman.com
 Erik Ankrom                 erikankrom
 Erik Johnson                terminalmage           erik@saltstack.com
 EYJ                         eyj


### PR DESCRIPTION
### What does this PR do?

This change makes provisioning OpenBSD 6.0-release fully functional
using salt-cloud by taking into account the changes since 5.8-current.
### Testing on AWS

**driver**

```
az:
  id: <key_id>
  key: <key>
  keyname: <key_name>
  private_key: <ssh_key>
  driver: ec2
  location: us-east-1
```

**profile**

```
aws-dev:
  provider: az
  image: ami-c75a10d0
  size: t2.micro
  ssh_username: root
  script_args: -D
  network_interfaces:
  - DeviceIndex: 0
    SubnetId: subnet-<id>
    PrivateIpAddresses:
      - Primary: True
    AssociatePublicIpAddress: True
    SecurityGroupId:
      - sg-<id>
```
### Details

_Mirror Selection_
- Address fixme: use mirrors from /etc/examples/pkg.conf instead of
  fetching a web page
- Bugfix: return an answer if the first mirror is the fastest
- Bugfix: avoid manually formatting package source path

_Service Management_
- Cleanup: rely on rc.d files installed by the salt package
- Cleanup: no longer any reason to run sed on rc.d files
- Modernize: use rcctl to check existing configuration
- Modernize: use rcctl to enable and start services

_Package Installation_
- Cleanup: use salt package maintained by OpenBSD project
- Bugfix: eliminate package conflicts introduced by `pip install`
