### PR TITLE
Add yum-utils package to be installed on Amazon Linux

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -4120,7 +4120,7 @@ _eof
         fi
     fi
 
-    __PACKAGES="PyYAML python-crypto python-msgpack python-zmq python26-ordereddict python-jinja2 python-requests"
+    __PACKAGES="PyYAML python-crypto python-msgpack python-zmq python26-ordereddict python-jinja2 python-requests yum-utils"
 
     # shellcheck disable=SC2086
     yum -y install ${__PACKAGES} ${ENABLE_EPEL_CMD} || return 1

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -4089,6 +4089,10 @@ install_scientific_linux_check_services() {
 
 install_amazon_linux_ami_deps() {
 
+    # We need to install yum-utils before doing anything else when installing on
+    # Amazon Linux ECS-optimized images. See issue #974.
+    yum -y install yum-utils
+
     ENABLE_EPEL_CMD=""
     if [ $_DISABLE_REPOS -eq $BS_TRUE ]; then
         ENABLE_EPEL_CMD="--enablerepo=${_EPEL_REPO}"
@@ -4120,7 +4124,7 @@ _eof
         fi
     fi
 
-    __PACKAGES="PyYAML python-crypto python-msgpack python-zmq python26-ordereddict python-jinja2 python-requests yum-utils"
+    __PACKAGES="PyYAML python-crypto python-msgpack python-zmq python26-ordereddict python-jinja2 python-requests"
 
     # shellcheck disable=SC2086
     yum -y install ${__PACKAGES} ${ENABLE_EPEL_CMD} || return 1


### PR DESCRIPTION
### What does this PR do?

Add the yum-utils package to the list of packages that need to be installed in order to run the bootstrap script on an Amazon ECS-optimized AMI.
### What issues does this PR fix or reference?

Fixes #974
