### PR TITLE
Remove FIXME comment and fix systemsmanagement link

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -5133,8 +5133,7 @@ __ZYPPER_REQUIRES_REPLACE_FILES=-1
 __set_suse_pkg_repo() {
     suse_pkg_url_path="${DISTRO_REPO}/systemsmanagement:saltstack.repo"
     if [ "$_DOWNSTREAM_PKG_REPO" -eq $BS_TRUE ]; then
-        # FIXME: cleartext download over unsecure protocol (HTTP)
-        suse_pkg_url_base="http://download.opensuse.org/repositories/systemsmanagement:saltstack"
+        suse_pkg_url_base="http://download.opensuse.org/repositories/systemsmanagement:/saltstack"
     else
         suse_pkg_url_base="${HTTP_VAL}://repo.saltstack.com/opensuse"
     fi


### PR DESCRIPTION
The previous opensuse systemsmanagement link went to a 404 page. I have updated the link by adding a `/` before saltstack, which goes to the correct link.

This also removes the last `FIXME` reference about the http protocol, as discussed in #588.

Fixes #588