### PR TITLE
Install TLS certs before cloning git repo via https

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -3301,6 +3301,11 @@ install_fedora_stable_post() {
 
 install_fedora_git_deps() {
     __fedora_get_package_manager
+
+    if [ "$_INSECURE_DL" -eq $BS_FALSE ] && [ "${_SALT_REPO_URL%%://*}" = "https" ]; then
+        $FEDORA_PACKAGE_MANAGER ca-certificates || return 1
+    fi
+
     install_fedora_deps || return 1
 
     if ! __check_command_exists git; then
@@ -3641,6 +3646,14 @@ install_centos_stable_post() {
 }
 
 install_centos_git_deps() {
+    if [ "$_INSECURE_DL" -eq $BS_FALSE ] && [ "${_SALT_REPO_URL%%://*}" = "https" ]; then
+        if [ "$DISTRO_MAJOR_VERSION" -gt 5 ]; then
+            __yum_install_noinput ca-certificates || return 1
+        else
+            __yum_install_noinput "openssl.${CPU_ARCH_L}" || return 1
+        fi
+    fi
+
     install_centos_stable_deps || return 1
 
     if ! __check_command_exists git; then
@@ -4248,6 +4261,10 @@ _eof
 }
 
 install_amazon_linux_ami_git_deps() {
+    if [ "$_INSECURE_DL" -eq $BS_FALSE ] && [ "${_SALT_REPO_URL%%://*}" = "https" ]; then
+        yum -y install ca-certificates || return 1
+    fi
+
     install_amazon_linux_ami_deps || return 1
 
     ENABLE_EPEL_CMD=""
@@ -5249,6 +5266,10 @@ install_opensuse_stable_deps() {
 }
 
 install_opensuse_git_deps() {
+    if [ "$_INSECURE_DL" -eq $BS_FALSE ] && [ "${_SALT_REPO_URL%%://*}" = "https" ]; then
+        __zypper_install ca-certificates || return 1
+    fi
+
     install_opensuse_stable_deps || return 1
 
     if ! __check_command_exists git; then

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2498,7 +2498,15 @@ install_ubuntu_daily_deps() {
 
 install_ubuntu_git_deps() {
     apt-get update
-    __apt_get_install_noinput git-core || return 1
+
+    if ! __check_command_exists git; then
+        __apt_get_install_noinput git-core || return 1
+    fi
+
+    if [ "$_INSECURE_DL" -eq $BS_FALSE ] && [ "${_SALT_REPO_URL%%://*}" = "https" ]; then
+        __apt_get_install_noinput ca-certificates
+    fi
+
     __git_clone_and_checkout || return 1
 
     __PACKAGES=""
@@ -2955,6 +2963,10 @@ install_debian_git_deps() {
         __apt_get_install_noinput git || return 1
     fi
 
+    if [ "$_INSECURE_DL" -eq $BS_FALSE ] && [ "${_SALT_REPO_URL%%://*}" = "https" ]; then
+        __apt_get_install_noinput ca-certificates
+    fi
+
     __git_clone_and_checkout || return 1
 
     __PACKAGES="libzmq3 libzmq3-dev lsb-release python-apt python-backports.ssl-match-hostname python-crypto"
@@ -2990,6 +3002,10 @@ install_debian_8_git_deps() {
 
     if ! __check_command_exists git; then
         __apt_get_install_noinput git || return 1
+    fi
+
+    if [ "$_INSECURE_DL" -eq $BS_FALSE ] && [ "${_SALT_REPO_URL%%://*}" = "https" ]; then
+        __apt_get_install_noinput ca-certificates
     fi
 
     __git_clone_and_checkout || return 1


### PR DESCRIPTION
### What does this PR do?
It makes sure that CA TLS PKI is installed and up-to-date before attempting to clone from Salt GitHub repository via `https` transport.

### Previous Behavior
Example of issue you might encounter on older systems (Ubuntu 14.04 here) where CA root TLS certificates are not installed or outdated:
```
 * DEBUG: Installed git version: 1.9.1
 *  INFO: Git revision matches a Salt version tag, shallow cloning enabled.
 *  INFO: Attempting to shallow clone v2016.11.0 from Salt's repository https://github.com/saltstack/salt.git
Cloning into 'salt'...
fatal: unable to access 'https://github.com/saltstack/salt.git/': Problem with the SSL CA cert (path? access rights?)
 *  WARN: Failed to shallow clone.
 *  INFO: Resuming regular git clone and remote SaltStack repository addition procedure
Cloning into 'salt'...
fatal: unable to access 'https://github.com/saltstack/salt.git/': Problem with the SSL CA cert (path? access rights?)
 * ERROR: Failed to run install_ubuntu_git_deps()!!!
 * DEBUG: Removing the logging pipe /tmp/bootstrap-salt.logpipe
 * DEBUG: Killing logging pipe tee's with pid(s): 169
```

### New Behavior
Everything works just fine :smile:
```
 * DEBUG: Installed git version: 1.9.1
 *  INFO: Git revision matches a Salt version tag, shallow cloning enabled.
 *  INFO: Attempting to shallow clone v2016.11.0 from Salt's repository https://github.com/saltstack/salt.git
Cloning into 'salt'...
Note: checking out 'f44724cca5147595557cba04ff215ee31c35fe73'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -b with the checkout command again. Example:

  git checkout -b new_branch_name

 *  INFO: Cloning Salt's git repository succeeded
```
