### PR TITLE
Update supported versions for Fedora: 23, 24, and 25.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -200,7 +200,7 @@ Supported Operating Systems
 .. note::
 
   Bootstrap may fail to install Salt on the cutting-edge version of distributions with frequent
-  release cycle, such as: Amazon Linux, Fedora, openSUSE Tumbleweed or Ubuntu non-LTS. Check the
+  release cycles such as: Amazon Linux, Fedora, openSUSE Tumbleweed, or Ubuntu non-LTS. Check the
   versions from the list below. Also, see the `Unsupported Distro`_ and
   `Adding Support for Other Operating Systems`_ sections.
 
@@ -231,7 +231,7 @@ Red Hat family
 
 - Amazon Linux 2012.09/2013.03/2013.09/2014.03/2014.09
 - CentOS 5/6/7
-- Fedora 17/18/20/21/22
+- Fedora 23/24/25
 - Oracle Linux 5/6/7
 - Red Hat Enterprise Linux 5/6/7
 - Scientific Linux 5/6/7

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -3294,13 +3294,13 @@ install_fedora_stable_post() {
 install_fedora_git_deps() {
 
     if [ "$_INSECURE_DL" -eq $BS_FALSE ] && [ "${_SALT_REPO_URL%%://*}" = "https" ]; then
-        dnf ca-certificates || return 1
+        dnf install -y ca-certificates || return 1
     fi
 
     install_fedora_deps || return 1
 
     if ! __check_command_exists git; then
-       dnf install -y git || return 1
+        dnf install -y git || return 1
     fi
 
     __git_clone_and_checkout || return 1


### PR DESCRIPTION
The bootstrap script should match the supported versions of SaltStack
more closely, and we don't support versions that are considered EOL by
the OS distributors themselves.

This change updates the bootstrap script to support Fedora 23, 24, and 25.

Since "dnf" replaced "yum" as the package provider in Fedora 23, we no
longer need to set the $FEDORA_PACKAGE_MANAGER variable based on the
version of Fedora. This can simply be "dnf" now for Fedora installs.