### PR TITLE
Add "yakkety" to ubuntu_codename_translation function

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1272,7 +1272,11 @@ __ubuntu_codename_translation() {
             fi
             ;;
         "16")
-            DISTRO_CODENAME="xenial"
+            if [ "$_april" ]; then
+                DISTRO_CODENAME="xenial"
+            else
+                DISTRO_CODENAME="yakkety"
+            fi
             ;;
         *)
             DISTRO_CODENAME="trusty"


### PR DESCRIPTION
Follow up to #998 and #976

This change will make it so the xenial repo.saltstack.com is not added in `/etc/apt/sources.list.d/saltstack.list` file, but is instead added as yakkety. The 16.10 link to repo.saltstack.com currently will throw 404 errors, but the install will succeed by installing 2016.3.1 from Ubuntu's repo. Git installs will work.

It's possible that a 16.10 repo will be added in the future. When that happens, the bootstrap script will be ready.

