### PR TITLE
Updated supported versions for Ubuntu: 12.04, 14.04, 16.04, and 16.10 (best effort)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -253,7 +253,7 @@ Ubuntu and derivatives
 - Linaro 12.04
 - Linux Mint 13/14/16/17/18
 - Trisquel GNU/Linux 6 (based on Ubuntu 12.04)
-- Ubuntu 10.x/11.x/12.x/13.x/14.x/15.x/16.04
+- Ubuntu 12.04/14.04/16.04
 
 
 Other Linux distro

--- a/README.rst
+++ b/README.rst
@@ -257,17 +257,15 @@ Ubuntu and derivatives
 
 Ubuntu Best Effort Support: Non-LTS releases 
 
-This script provides best-effort support for current, non-LTS 
-Ubuntu releases. If package repositories are not provided on 
-[repo.saltstack.com](http://repo.saltstack.com/#ubuntu) for 
-the non-LTS release, the bootstrap script will attempt to 
-install the packages for the most closely related LTS Ubuntu
-release instead. 
+This script provides best-effort support for current, non-LTS Ubuntu releases. If package 
+repositories are not provided on `SaltStack's Ubuntu repository`_ for the non-LTS release, the
+bootstrap script will attempt to install the packages for the most closely related LTS Ubuntu
+release instead.
 
-For example, when installing Salt on Ubuntu 16.10, the bootstrap
-script will setup the repository for Ubuntu 16.04 from 
-[repo.saltstack.com](http://repo.saltstack.com/#ubuntu) and 
-install the 16.04 packages.
+For example, when installing Salt on Ubuntu 16.10, the bootstrap script will setup the repository 
+for Ubuntu 16.04 from `SaltStack's Ubuntu repository`_ and install the 16.04 packages.
+
+.. _`SaltStack's Ubuntu repository`: http://repo.saltstack.com/#ubuntu
 
 
 Other Linux distro

--- a/README.rst
+++ b/README.rst
@@ -216,8 +216,8 @@ Debian and derivatives
 .. note::
 
   Installation of Salt packages on Debian 8 based distribution from repo.saltstack.com repository
-  is currently supported for ``amd64`` (``x86-64``) and ``armhf`` architechtures ONLY. Use ``git``
-  bootstrap mode as described above to install Salt on other architechtures, such as ``i386`` or
+  is currently supported for ``amd64`` (``x86-64``) and ``armhf`` architectures ONLY. Use ``git``
+  bootstrap mode as described above to install Salt on other architectures, such as ``i386`` or
   ``armel``. You also may need to disable repository configuration and allow ``pip`` installations
   by providing ``-r`` and ``-P`` options to the bootstrap script, i.e.:
 
@@ -251,7 +251,7 @@ Ubuntu and derivatives
 
 - Elementary OS 0.2 (based on Ubuntu 12.04)
 - Linaro 12.04
-- Linux Mint 13/14/16/17/18
+- Linux Mint 13/17/18
 - Trisquel GNU/Linux 6 (based on Ubuntu 12.04)
 - Ubuntu 12.04/14.04/16.04
 

--- a/README.rst
+++ b/README.rst
@@ -255,6 +255,20 @@ Ubuntu and derivatives
 - Trisquel GNU/Linux 6 (based on Ubuntu 12.04)
 - Ubuntu 12.04/14.04/16.04
 
+Ubuntu Best Effort Support: Non-LTS releases 
+
+This script provides best-effort support for current, non-LTS 
+Ubuntu releases. If package repositories are not provided on 
+[repo.saltstack.com](http://repo.saltstack.com/#ubuntu) for 
+the non-LTS release, the bootstrap script will attempt to 
+install the packages for the most closely related LTS Ubuntu
+release instead. 
+
+For example, when installing Salt on Ubuntu 16.10, the bootstrap
+script will setup the repository for Ubuntu 16.04 from 
+[repo.saltstack.com](http://repo.saltstack.com/#ubuntu) and 
+install the 16.04 packages.
+
 
 Other Linux distro
 ~~~~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -255,7 +255,8 @@ Ubuntu and derivatives
 - Trisquel GNU/Linux 6 (based on Ubuntu 12.04)
 - Ubuntu 12.04/14.04/16.04
 
-Ubuntu Best Effort Support: Non-LTS releases 
+Ubuntu Best Effort Support: Non-LTS Releases 
+********************************************
 
 This script provides best-effort support for current, non-LTS Ubuntu releases. If package 
 repositories are not provided on `SaltStack's Ubuntu repository`_ for the non-LTS release, the

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1258,13 +1258,6 @@ __ubuntu_codename_translation() {
         "14")
             DISTRO_CODENAME="trusty"
             ;;
-        "15")
-            if [ -n "$_april" ]; then
-                DISTRO_CODENAME="vivid"
-            else
-                DISTRO_CODENAME="wily"
-            fi
-            ;;
         "16")
             DISTRO_CODENAME="xenial"
             ;;

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2404,7 +2404,7 @@ install_ubuntu_stable_deps() {
         # Versions starting with 2015.5.6, 2015.8.1 and 2016.3.0 are hosted at repo.saltstack.com
         if [ "$(echo "$STABLE_REV" | egrep '^(2015\.5|2015\.8|2016\.3|2016\.11|latest|archive\/)')" != "" ]; then
             # Workaround for latest non-LTS ubuntu
-            if [ "$DISTRO_MAJOR_VERSION" -eq 16 ] && [ "$DISTRO_MINOR_VERSION" -eq 10 ]; then
+            if [ "$DISTRO_VERSION" = "16.10" ]; then
                 echowarn "Non-LTS Ubuntu detected, but stable packages requested. Trying packages from latest LTS release. You may experience problems."
                 UBUNTU_VERSION=16.04
                 UBUNTU_CODENAME=xenial

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1201,12 +1201,6 @@ __ubuntu_derivatives_translation() {
     # Mappings
     trisquel_6_ubuntu_base="12.04"
     linuxmint_13_ubuntu_base="12.04"
-    linuxmint_14_ubuntu_base="12.10"
-    #linuxmint_15_ubuntu_base="13.04"
-    # Bug preventing add-apt-repository from working on Mint 15:
-    # https://bugs.launchpad.net/linuxmint/+bug/1198751
-
-    linuxmint_16_ubuntu_base="13.10"
     linuxmint_17_ubuntu_base="14.04"
     linuxmint_18_ubuntu_base="16.04"
     linaro_12_ubuntu_base="12.04"


### PR DESCRIPTION
The bootstrap script should match the supported versions of SaltStack
more closely, and we don't support versions that are considered EOL by
the OS distributors themselves.

This change updates the bootstrap script to support Ubuntu 12.04, 14.04,
16.04, and 16.10 (which the .10 release is a "best-effort" support since
it is a non-LTS OS release from Ubuntu).

@vutny I'd appreciate a review on this one as well if you have a moment.