### PR TITLE
fix bootstrap in Arch Linux by updating package name from salt-zmq to…

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -4420,7 +4420,7 @@ install_arch_linux_stable() {
     pacman -S --noconfirm --needed bash || return 1
     pacman -Su --noconfirm || return 1
     # We can now resume regular salt update
-    pacman -Syu --noconfirm salt-zmq || return 1
+    pacman -Syu --noconfirm salt || return 1
     return 0
 }
 


### PR DESCRIPTION
### What does this PR do?
Fixes bootstrap on archlinux due to renamed package from salt-zmq to salt in official repositories (see issue https://github.com/saltstack/salt-bootstrap/issues/1005 )

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-bootstrap/issues/1005

### Previous Behavior
Install `salt-zmq` package (in official repositories it is now renamed to salt)

### New Behavior
Install `salt` package