### PR TITLE
Update bootstrap-salt.sh

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -4299,7 +4299,7 @@ install_alpine_linux_git_post() {
         [ $fname = "syndic" ] && continue
 
         if [ -f /sbin/rc-update ]; then
-            /sbin/rc-update add salt-$fname > dev/null 2>&1
+            /sbin/rc-update add salt-$fname > /dev/null 2>&1
             continue
         fi
 


### PR DESCRIPTION
This is a typo fix on line 4302 of boostrap-salt.sh (applies to Alpine Linux) - missing leading / on the redirect to /dev/null.

It squashes a shell error, but makes no functional difference to the install.


