### PR TITLE
Adding 2016.11 to stable version

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -524,14 +524,14 @@ elif [ "$ITYPE" = "stable" ]; then
     else
         __check_unparsed_options "$*"
 
-        if [ "$(echo "$1" | egrep '^(latest|1\.6|1\.7|2014\.1|2014\.7|2015\.5|2015\.8|2016\.3)$')" != "" ]; then
+        if [ "$(echo "$1" | egrep '^(latest|1\.6|1\.7|2014\.1|2014\.7|2015\.5|2015\.8|2016\.3|2016\.11)$')" != "" ]; then
             STABLE_REV="$1"
             shift
         elif [ "$(echo "$1" | egrep '^([0-9]*\.[0-9]*\.[0-9]*)$')" != "" ]; then
             STABLE_REV="archive/$1"
             shift
         else
-            echo "Unknown stable version: $1 (valid: 1.6, 1.7, 2014.1, 2014.7, 2015.5, 2015.8, 2016.3, latest, \$MAJOR.\$MINOR.\$PATCH)"
+            echo "Unknown stable version: $1 (valid: 1.6, 1.7, 2014.1, 2014.7, 2015.5, 2015.8, 2016.3, 2016.11, latest, \$MAJOR.\$MINOR.\$PATCH)"
             exit 1
         fi
     fi


### PR DESCRIPTION
### What does this PR do?
Make bootstrap to recognise 2016.11 as a stable version.

### What issues does this PR fix or reference?
None

### Previous Behavior
bootstrap script doesn't recognise 2016.11 as a stable version.

### New Behavior
bootstrap script now recognise 2016.11 as a stable version.
