### PR TITLE
RHEL6: disable stdin to fix shell session hang on killing tee pipe

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -3754,9 +3754,9 @@ install_centos_restart_daemons() {
                 return 1
             fi
         elif [ -f /etc/init.d/salt-$fname ]; then
-            # Still in SysV init!?
-            /etc/init.d/salt-$fname stop > /dev/null 2>&1
-            /etc/init.d/salt-$fname start
+            # Disable stdin to fix shell session hang on killing tee pipe
+            service salt-$fname stop < /dev/null > /dev/null 2>&1
+            service salt-$fname start < /dev/null
         elif [ -f /usr/bin/systemctl ]; then
             # CentOS 7 uses systemd
             /usr/bin/systemctl stop salt-$fname > /dev/null 2>&1


### PR DESCRIPTION
### What does this PR do?
It makes sure that System V style init scripts for starting up Salt services on older RHEL/CentOS will be unable to read from `stdin`.

### What issues does this PR fix or reference?
From time to time I encounter weird thing when trying to bootstrap Salt "interactively" on CentOS 6 boxes.
The scenario is following:
* ssh to the machine
* download and execute the bootsrtap script
* see that everything have been installed successfully and Salt daemons came up
* log off

And before the last step the terminal session just hangs... Sometimes it hangs on named log pipe removal, sometimes on killing `tee` listening on the pipe or during final exit. But in most cases the interactive session freezes on log out, after you enter `exit`. That's not a big deal though. I do this rarely and usually kill the session or leave it to terminate by timeout. And automated "non-interactive" bootstrapping works just fine.

But recently I started being annoyed by this... awkwardness.
I was unable to pin point the exact root cause of the issue or detect if that's some kind of environment specific, but it appears that if you don't have `pty` allocated for bootstrapping shell or `stdin` was not associated with a terminal, the issue never reveals itself.
It looks like that magic casted by the script for logging its own output somehow resonates with spells used in shell functions provided by RHEL `initscripts` package. Maybe to get colored "OK/FAIL" message, I really don't know.

Anyhow, the workaround is to feed `service` commands with `/dev/null` as `stdin`, which always works.
