### PR TITLE
AWS Linux Native Support

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -4443,8 +4443,8 @@ install_amazon_linux_ami_deps() {
         fi
 
         # This should prob be refactored to use __install_saltstack_rhel_repository()
-        # With args passed in to do the right thing.  Reformated to be more like the 
-        # __install_saltstack_rhel_respository() yum file.
+        # With args passed in to do the right thing.  Reformatted to be more like the
+        # amazon linux yum file.
         if [ ! -s "/etc/yum.repos.d/${__REPO_FILENAME}" ]; then
           cat <<_eof > "/etc/yum.repos.d/${__REPO_FILENAME}"
 [saltstack-repo]

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1428,7 +1428,7 @@ __ubuntu_codename_translation
 if ([ "${DISTRO_NAME_L}" != "ubuntu" ] && [ "$ITYPE" = "daily" ]); then
     echoerror "${DISTRO_NAME} does not have daily packages support"
     exit 1
-elif ([ "$(echo "${DISTRO_NAME_L}" | egrep '(debian|ubuntu|centos|red_hat|oracle|scientific)')" = "" ] && [ "$ITYPE" = "stable" ] && [ "$STABLE_REV" != "latest" ]); then
+elif ([ "$(echo "${DISTRO_NAME_L}" | egrep '(debian|ubuntu|centos|red_hat|oracle|scientific|amazon)')" = "" ] && [ "$ITYPE" = "stable" ] && [ "$STABLE_REV" != "latest" ]); then
     echoerror "${DISTRO_NAME} does not have major version pegged packages support"
     exit 1
 fi
@@ -4386,6 +4386,31 @@ daemons_running_alpine_linux() {
 
 install_amazon_linux_ami_deps() {
 
+    # Shim to figure out if we're using old (rhel) or new (aws) rpms.
+    _USEAWS=$BS_FALSE
+    # See if STABLE_REV is set, if not, then we're a testing, which we'll just default to old way for now.
+    if [ "$ITYPE" = "stable" ]; then
+        repo_rev="$STABLE_REV"
+    else
+        repo_rev="latest"
+    fi
+
+    # Remove "archive/" from the version
+    # shellcheck disable=SC2034,SC2039
+    IFS='.' read -r MAJOR MINOR PATCH <<< "$repo_rev"
+    # shellcheck disable=SC2034,SC2039
+    if [[ "$MAJOR" == *"archive/"** ]]; then
+       # shellcheck disable=SC2034,SC2039
+       IFS='/' read -r JUNK MAJOR <<< "$MAJOR"
+    fi
+
+    # Do we have versions new enough to use the aws built packages? or default back to rhel/centos 6.
+    # shellcheck disable=SC2034,SC2039
+    if [ "$repo_rev" == "latest" ]; then
+       _USEAWS=$BS_TRUE
+    elif [[ ("$MAJOR" -ge "2016" && "$MINOR" -ge "11") || "$MAJOR" -gt "2016" ]]; then
+       _USEAWS=$BS_TRUE
+    fi
     # We need to install yum-utils before doing anything else when installing on
     # Amazon Linux ECS-optimized images. See issue #974.
     yum -y install yum-utils
@@ -4404,15 +4429,31 @@ install_amazon_linux_ami_deps() {
 
         __REPO_FILENAME="saltstack-repo.repo"
 
+        # Set a few vars to make life easier.
+        if [ $_USEAWS -eq $BS_TRUE ]; then
+           base_url="$HTTP_VAL://repo.saltstack.com/yum/amazon/latest/\$basearch/$repo_rev/"
+           gpg_key="${base_url}SALTSTACK-GPG-KEY.pub"
+           repo_name="SaltStack repo for Amazon Linux"
+           pkg_append="python27"
+        else
+           base_url="$HTTP_VAL://repo.saltstack.com/yum/redhat/6/\$basearch/$repo_rev/"
+           gpg_key="${base_url}SALTSTACK-GPG-KEY.pub"
+           repo_name="SaltStack repo for RHEL/CentOS 6"
+           pkg_append="python"
+        fi
+
+        # This should prob be refactored to use __install_saltstack_rhel_repository()
+        # With args passed in to do the right thing.  Reformated to be more like the 
+        # __install_saltstack_rhel_respository() yum file.
         if [ ! -s "/etc/yum.repos.d/${__REPO_FILENAME}" ]; then
           cat <<_eof > "/etc/yum.repos.d/${__REPO_FILENAME}"
 [saltstack-repo]
-disabled=False
-name=SaltStack repo for RHEL/CentOS 6
+name=$repo_name
+failovermethod=priority
+priority=10
 gpgcheck=1
-gpgkey=$HTTP_VAL://repo.saltstack.com/yum/redhat/6/\$basearch/$STABLE_REV/SALTSTACK-GPG-KEY.pub
-baseurl=$HTTP_VAL://repo.saltstack.com/yum/redhat/6/\$basearch/$STABLE_REV/
-humanname=SaltStack repo for RHEL/CentOS 6
+gpgkey=$gpg_key
+baseurl=$base_url
 _eof
         fi
 
@@ -4420,8 +4461,9 @@ _eof
             yum -y update || return 1
         fi
     fi
-
-    __PACKAGES="PyYAML python-crypto python-msgpack python-zmq python26-ordereddict python-jinja2 python-requests"
+    #ordereddict removed.
+    #Package python-ordereddict-1.1-2.el6.noarch is obsoleted by python26-2.6.9-2.88.amzn1.x86_64 which is already installed
+    __PACKAGES="${pkg_append}-PyYAML ${pkg_append}-crypto ${pkg_append}-msgpack ${pkg_append}-zmq ${pkg_append}-jinja2 ${pkg_append}-requests"
 
     # shellcheck disable=SC2086
     yum -y install ${__PACKAGES} ${ENABLE_EPEL_CMD} || return 1


### PR DESCRIPTION
### What does this PR do?
Add in logic to use the new native AWS repo rather than default to RHEL6.
Also added version pinning support and to use the right repos accordingly
Fix packages for AWS so they install the correct versions
Add ability to do specific version pinning with AWS linux that was previously unavailable for some reason.

** Does use some bashisms in the logic check, but figured this was safe since AWS installs bash as /bin/sh.

### What issues does this PR fix or reference?
N/A 

### Previous Behavior
Install RHEL/CentOS 6 versions, including python 2.6

### New Behavior
Does a version check to see if install version is at least 2016.11 and then uses the appropriate repo to do the install.  If installation is 2016.11 or newer, then installer will use the AWS specific repo, which includes using python 2.7 and no longer installing python 2.6 and dependencies.

