### PR TITLE
Alpine Linux: fix installation of multiple pkgs ("stable" bootstrap)

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -4248,7 +4248,8 @@ install_alpine_linux_stable() {
         __PACKAGES="${__PACKAGES} salt-syndic"
     fi
 
-    apk -U add "${__PACKAGES}" || return 1
+    # shellcheck disable=SC2086
+    apk -U add ${__PACKAGES} || return 1
     return 0
 }
 


### PR DESCRIPTION
### What does this PR do?
It fixes multiple "stable" packages installation on Alpine Linux Edge from the community repository.

### Previous Behavior
```console
# sh bootstrap-salt.sh -M -L -S
...
ERROR: 'salt salt-cloud salt-master salt-minion salt-syndic' is not a valid dependency, format is name(@tag)([<>=]version)
```

### New Behavior
```console
# sh bootstrap-salt.sh -M -L -S
...
(41/46) Installing salt (2016.11.2-r0)
(42/46) Installing salt-master (2016.11.2-r0)
(43/46) Installing py2-libcloud (1.1.0-r1)
(44/46) Installing salt-cloud (2016.11.2-r0)
(45/46) Installing salt-minion (2016.11.2-r0)
(46/46) Installing salt-syndic (2016.11.2-r0)
Executing busybox-1.25.1-r1.trigger
Executing ca-certificates-20161130-r0.trigger
OK: 148 MiB in 57 packages
 *  INFO: Running install_alpine_linux_post()
 *  INFO: Salt installed!
```
