### PR TITLE
Add support for stable installation on Alpine Linux release 3.5

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -275,6 +275,7 @@ for Ubuntu 16.04 from `SaltStack's Ubuntu repository`_ and install the 16.04 pac
 Other Linux distro
 ~~~~~~~~~~~~~~~~~~
 
+- Alpine Linux 3.5/edge
 - Arch Linux
 - Gentoo
 

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -4194,13 +4194,13 @@ install_cloud_linux_check_services() {
 #   Alpine Linux Install Functions
 #
 install_alpine_linux_stable_deps() {
-    __COMUNITY_REPO_ENABLED="$(grep '^https://dl-cdn.alpinelinux.org/alpine/edge/community$' /etc/apk/repositories)"
-    if [ "${__COMUNITY_REPO_ENABLED}" != "" ]; then
-        apk update
-    else
-        echo 'https://dl-cdn.alpinelinux.org/alpine/edge/community' >> /etc/apk/repositories
-        apk update
+    if ! grep -q '^[^#].\+alpine/.\+/community' /etc/apk/repositories; then
+        # Add community repository entry based on the "main" repo URL
+        __REPO=$(grep '^[^#].\+alpine/.\+/main\>' /etc/apk/repositories)
+        echo "${__REPO}" | sed -e 's/main/community/' >> /etc/apk/repositories
     fi
+
+    apk update
 }
 
 install_alpine_linux_git_deps() {


### PR DESCRIPTION
### Previous Behavior
```console
# sh bootstrap-salt.sh -M -L -S
 *  INFO: Running install_alpine_linux_stable()
fetch http://dl-cdn.alpinelinux.org/alpine/v3.5/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/edge/community/x86_64/APKINDEX.tar.gz
ERROR: unsatisfiable constraints:
  so:libgit2.so.25 (missing):
    required by:
                 py2-pygit2-0.25.0-r0[so:libgit2.so.25]
 * ERROR: Failed to run install_alpine_linux_stable()!!!
```

### New Behavior
```console
# sh bootstrap-salt.sh -M -L -S
41/46) Installing salt (2016.11.2-r0)
(42/46) Installing salt-master (2016.11.2-r0)
(43/46) Installing py2-libcloud (1.1.0-r1)
(44/46) Installing salt-cloud (2016.11.2-r0)
(45/46) Installing salt-minion (2016.11.2-r0)
(46/46) Installing salt-syndic (2016.11.2-r0)
Executing busybox-1.25.1-r0.trigger
Executing ca-certificates-20161130-r0.trigger
OK: 148 MiB in 57 packages
 *  INFO: Running install_alpine_linux_post()
 *  INFO: Salt installed!
```

