### PR TITLE
Alpine: check Salt services have been enabled to start on boot

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2158,7 +2158,7 @@ __check_services_alpine() {
     echodebug "Checking if service ${servicename} is enabled"
 
     # shellcheck disable=SC2086,SC2046,SC2144
-    if rc-service ${servicename} status; then
+    if rc-status $(rc-status -r) | tail -n +2 | grep -q "\<$servicename\>"; then
         echodebug "Service ${servicename} is enabled"
         return 0
     else
@@ -4208,7 +4208,6 @@ install_alpine_linux_git_deps() {
         py2-jinja2 py2-yaml py2-markupsafe py2-msgpack py2-psutil \
         py2-zmq zeromq py2-requests || return 1
 
-    # Don't fail if un-installing python2-distribute threw an error
     if ! __check_command_exists git; then
         apk -U add git  || return 1
     fi
@@ -4281,7 +4280,6 @@ install_alpine_linux_post() {
             /sbin/rc-update add salt-$fname > /dev/null 2>&1
             continue
         fi
-
     done
 }
 
@@ -4328,11 +4326,6 @@ install_alpine_linux_restart_daemons() {
 }
 
 install_alpine_linux_check_services() {
-    if [ ! -f /usr/bin/systemctl ]; then
-        # Not running systemd!? Don't check!
-        return 0
-    fi
-
     for fname in api master minion syndic; do
         # Skip salt-api since the service should be opt-in and not necessarily started on boot
         [ $fname = "api" ] && continue

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -4302,12 +4302,11 @@ install_alpine_linux_git_post() {
             /sbin/rc-update add salt-$fname > /dev/null 2>&1
             continue
         fi
-
     done
 }
 
 install_alpine_linux_restart_daemons() {
-    [ $_START_DAEMONS -eq $BS_FALSE ] && return
+    [ "${_START_DAEMONS}" -eq $BS_FALSE ] && return
 
     for fname in api master minion syndic; do
         # Skip salt-api since the service should be opt-in and not necessarily started on boot
@@ -4320,8 +4319,9 @@ install_alpine_linux_restart_daemons() {
         [ $fname = "master" ] && [ "$_INSTALL_MASTER" -eq $BS_FALSE ] && continue
         [ $fname = "minion" ] && [ "$_INSTALL_MINION" -eq $BS_FALSE ] && continue
 
-        /sbin/rc-service salt-$fname stop > /dev/null 2>&1
-        /sbin/rc-service salt-$fname start
+        # Disable stdin to fix shell session hang on killing tee pipe
+        /sbin/rc-service salt-$fname stop < /dev/null > /dev/null 2>&1
+        /sbin/rc-service salt-$fname start < /dev/null
     done
 }
 
@@ -4344,7 +4344,7 @@ install_alpine_linux_check_services() {
 }
 
 daemons_running_alpine_linux() {
-    [ "$_START_DAEMONS" -eq $BS_FALSE ] && return 0
+    [ "${_START_DAEMONS}" -eq $BS_FALSE ] && return
 
     FAILED_DAEMONS=0
     for fname in api master minion syndic; do


### PR DESCRIPTION
### What does this PR do?
It fixes some issues with checking Salt services to be enabled to start on boot in Alpine Linux.

### What issues does this PR fix or reference?
The OpenRC enables all new init scripts installed by default, but the Salt Bootstrap script is designed to check that explicitly. And current implementation has couple of issues with that. 

### Previous Behavior
* The Salt services have not been checked because of negative test for `systemd` binary present. Alpine Linux neither use nor support `systemd` at all.
* The `__check_services_alpine` function checks that particular service is "running", instead of checking if it is enabled in current runlevel.

### New Behavior
* The `install_alpine_linux_check_services()` checks that all installed Salt services are enabled by default.
* The `__check_services_alpine()` function checks that the service is actually enabled to start in current runlevel.

