### PR TITLE
[-R option] Fix logic error where we trying to enable epel with -R

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1548,7 +1548,7 @@ __rpm_import_gpg() {
 __yum_install_noinput() {
 
     ENABLE_EPEL_CMD=""
-    if [ $_DISABLE_REPOS -eq $BS_TRUE ]; then
+    if [ $_DISABLE_REPOS -eq $BS_FALSE ]; then
         ENABLE_EPEL_CMD="--enablerepo=${_EPEL_REPO}"
     fi
 


### PR DESCRIPTION
### What does this PR do?
Fixes a small logic error that broke using the `-R` option with RHEL-based installations. Previously, if `-r` or `-R` was passed, the `--enablerepo=epel` option was added to the install command. This is the opposite of what we want when using either of the "r" options.

### What issues does this PR fix or reference?
PR #928

### Previous Behavior
When using the `-R <my-repo>` option for boxes not connected to the internet, it would try to reach out to epel when it shouldn't.

### New Behavior
Doesn't reach out to epel if the `-R` or `-r` options are passed and restores the `-R` functionality to working order.

