### PR TITLE
Allow -R option to work for Debian/Ubuntu

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -239,6 +239,7 @@ _CUSTOM_REPO_URL="null"
 _CUSTOM_MASTER_CONFIG="null"
 _CUSTOM_MINION_CONFIG="null"
 _QUIET_GIT_INSTALLATION=$BS_FALSE
+_REPO_URL="repo.saltstack.com"
 
 #---  FUNCTION  -------------------------------------------------------------------------------------------------------
 #         NAME:  __usage
@@ -558,8 +559,6 @@ if [ "$_CUSTOM_REPO_URL" != "null" ]; then
         echowarn "Detected -R option. No other repositories will be configured when -R is used. Setting -r option to True."
         _DISABLE_REPOS=$BS_TRUE
     fi
-else
-    _REPO_URL="repo.saltstack.com"
 fi
 
 # Check for any unparsed arguments. Should be an error.
@@ -2936,7 +2935,7 @@ install_debian_8_deps() {
             exit 1
         fi
 
-        # Versions starting with 2015.5.6, 2015.8.1 and 2016.3.0 are hosted at $_REPO_URL
+        # Versions starting with 2015.5.6, 2015.8.1 and 2016.3.0 are hosted at repo.saltstack.com
         if [ "$(echo "$STABLE_REV" | egrep '^(2015\.5|2015\.8|2016\.3|2016\.11|latest|archive\/201[5-6]\.)')" != "" ]; then
             SALTSTACK_DEBIAN_URL="${HTTP_VAL}://${_REPO_URL}/apt/debian/${DISTRO_MAJOR_VERSION}/${__REPO_ARCH}/${STABLE_REV}"
             echo "deb $SALTSTACK_DEBIAN_URL jessie main" > "/etc/apt/sources.list.d/saltstack.list"

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -544,6 +544,7 @@ if [ "$ITYPE" != "git" ]; then
         exit 1
     fi
     if [ "$_VIRTUALENV_DIR" != "null" ]; then
+        echoerror "Virtualenv installs via -V is only possible when installing Salt via git"
         exit 1
     fi
 fi

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -556,6 +556,7 @@ if [ "$_CUSTOM_REPO_URL" != "null" ]; then
     if [ "$_DISABLE_REPOS" -eq $BS_FALSE ]; then
         echowarn "Detected -R option. No other repositories will be configured when -R is used. Setting -r option to True."
         _DISABLE_REPOS=$BS_TRUE
+    fi
 else
     _REPO_URL="repo.saltstack.com"
 fi

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -342,7 +342,7 @@ __usage() {
         points to a repository that mirrors Salt packages located at
         repo.saltstack.com. The option passed with -R replaces the
         "repo.saltstack.com". If -R is passed, -r is also set. Currently only
-        works on CentOS/RHEL based distributions.
+        works on CentOS/RHEL and Debian based distributions.
     -J  Replace the Master config file with data passed in as a JSON string. If
         a Master config file is found, a reasonable effort will be made to save
         the file with a ".bak" extension. If used in conjunction with -C or -F,
@@ -544,7 +544,6 @@ if [ "$ITYPE" != "git" ]; then
         exit 1
     fi
     if [ "$_VIRTUALENV_DIR" != "null" ]; then
-        echoerror "Virtualenv installs via -V is only possible when installing Salt via git"
         exit 1
     fi
 fi
@@ -2439,12 +2438,12 @@ install_ubuntu_stable_deps() {
         __REPO_ARCH="$DPKG_ARCHITECTURE"
 
         if [ "$DPKG_ARCHITECTURE" = "i386" ]; then
-            echoerror "repo.saltstack.com likely doesn't have all required 32-bit packages for Ubuntu $DISTRO_MAJOR_VERSION (yet?)."
+            echoerror "$_REPO_URL likely doesn't have all required 32-bit packages for Ubuntu $DISTRO_MAJOR_VERSION (yet?)."
 
             # amd64 is just a part of repository URI, 32-bit pkgs are hosted under the same location
             __REPO_ARCH="amd64"
         elif [ "$DPKG_ARCHITECTURE" != "amd64" ]; then
-            echoerror "repo.saltstack.com doesn't have packages for your system architecture: $DPKG_ARCHITECTURE."
+            echoerror "$_REPO_URL doesn't have packages for your system architecture: $DPKG_ARCHITECTURE."
             if [ "$ITYPE" != "git" ]; then
                 echoerror "You can try git installation mode, i.e.: sh ${__ScriptName} git v2016.3.1"
                 exit 1
@@ -2464,7 +2463,7 @@ install_ubuntu_stable_deps() {
             fi
 
             # SaltStack's stable Ubuntu repository:
-            SALTSTACK_UBUNTU_URL="${HTTP_VAL}://repo.saltstack.com/apt/ubuntu/${UBUNTU_VERSION}/${__REPO_ARCH}/${STABLE_REV}"
+            SALTSTACK_UBUNTU_URL="${HTTP_VAL}://${_REPO_URL}/apt/ubuntu/${UBUNTU_VERSION}/${__REPO_ARCH}/${STABLE_REV}"
             echo "deb $SALTSTACK_UBUNTU_URL $UBUNTU_CODENAME main" > /etc/apt/sources.list.d/saltstack.list
 
             # Make sure https transport is available
@@ -2840,7 +2839,7 @@ install_debian_7_deps() {
         __REPO_ARCH="$DPKG_ARCHITECTURE"
 
         if [ "$DPKG_ARCHITECTURE" = "i386" ]; then
-            echoerror "repo.saltstack.com likely doesn't have all required 32-bit packages for Debian $DISTRO_MAJOR_VERSION (yet?)."
+            echoerror "$_REPO_URL likely doesn't have all required 32-bit packages for Debian $DISTRO_MAJOR_VERSION (yet?)."
 
             if [ "$ITYPE" != "git" ]; then
                 echoerror "You can try git installation mode, i.e.: sh ${__ScriptName} git v2016.3.1"
@@ -2849,14 +2848,14 @@ install_debian_7_deps() {
             # amd64 is just a part of repository URI, 32-bit pkgs are hosted under the same location
             __REPO_ARCH="amd64"
         elif [ "$DPKG_ARCHITECTURE" != "amd64" ]; then
-            echoerror "repo.saltstack.com doesn't have packages for your system architecture: $DPKG_ARCHITECTURE."
+            echoerror "$_REPO_URL doesn't have packages for your system architecture: $DPKG_ARCHITECTURE."
             exit 1
         fi
 
         # Versions starting with 2015.8.7 and 2016.3.0 are hosted at repo.saltstack.com
         if [ "$(echo "$STABLE_REV" | egrep '^(2015\.8|2016\.3|2016\.11|latest|archive\/201[5-6]\.)')" != "" ]; then
             # amd64 is just a part of repository URI, 32-bit pkgs are hosted under the same location
-            SALTSTACK_DEBIAN_URL="${HTTP_VAL}://repo.saltstack.com/apt/debian/${DISTRO_MAJOR_VERSION}/${__REPO_ARCH}/${STABLE_REV}"
+            SALTSTACK_DEBIAN_URL="${HTTP_VAL}://${_REPO_URL}/apt/debian/${DISTRO_MAJOR_VERSION}/${__REPO_ARCH}/${STABLE_REV}"
             echo "deb $SALTSTACK_DEBIAN_URL wheezy main" > "/etc/apt/sources.list.d/saltstack.list"
 
             if [ "$HTTP_VAL" = "https" ] ; then
@@ -2872,7 +2871,7 @@ install_debian_7_deps() {
 
         apt-get update
     else
-        echowarn "Packages from repo.saltstack.com are required to install Salt version 2015.8 or higher on Debian $DISTRO_MAJOR_VERSION."
+        echowarn "Packages from $_REPO_URL are required to install Salt version 2015.8 or higher on Debian $DISTRO_MAJOR_VERSION."
     fi
 
     # Additionally install procps and pciutils which allows for Docker bootstraps. See 366#issuecomment-39666813
@@ -2919,7 +2918,7 @@ install_debian_8_deps() {
         __REPO_ARCH="$DPKG_ARCHITECTURE"
 
         if [ "$DPKG_ARCHITECTURE" = "i386" ]; then
-            echoerror "repo.saltstack.com likely doesn't have all required 32-bit packages for Debian $DISTRO_MAJOR_VERSION (yet?)."
+            echoerror "$_REPO_URL likely doesn't have all required 32-bit packages for Debian $DISTRO_MAJOR_VERSION (yet?)."
 
             if [ "$ITYPE" != "git" ]; then
                 echoerror "You can try git installation mode, i.e.: sh ${__ScriptName} git v2016.3.1"
@@ -2928,16 +2927,16 @@ install_debian_8_deps() {
             # amd64 is just a part of repository URI, 32-bit pkgs are hosted under the same location
             __REPO_ARCH="amd64"
         elif [ "$DPKG_ARCHITECTURE" != "amd64" ] && [ "$DPKG_ARCHITECTURE" != "armhf" ]; then
-            echoerror "repo.saltstack.com doesn't have packages for your system architecture: $DPKG_ARCHITECTURE."
+            echoerror "$_REPO_URL doesn't have packages for your system architecture: $DPKG_ARCHITECTURE."
             echoerror "Try git installation mode with pip and disable SaltStack apt repository, for example:"
             echoerror "    sh ${__ScriptName} -r -P git v2016.3.1"
 
             exit 1
         fi
 
-        # Versions starting with 2015.5.6, 2015.8.1 and 2016.3.0 are hosted at repo.saltstack.com
+        # Versions starting with 2015.5.6, 2015.8.1 and 2016.3.0 are hosted at $_REPO_URL
         if [ "$(echo "$STABLE_REV" | egrep '^(2015\.5|2015\.8|2016\.3|2016\.11|latest|archive\/201[5-6]\.)')" != "" ]; then
-            SALTSTACK_DEBIAN_URL="${HTTP_VAL}://repo.saltstack.com/apt/debian/${DISTRO_MAJOR_VERSION}/${__REPO_ARCH}/${STABLE_REV}"
+            SALTSTACK_DEBIAN_URL="${HTTP_VAL}://${_REPO_URL}/apt/debian/${DISTRO_MAJOR_VERSION}/${__REPO_ARCH}/${STABLE_REV}"
             echo "deb $SALTSTACK_DEBIAN_URL jessie main" > "/etc/apt/sources.list.d/saltstack.list"
 
             if [ "$HTTP_VAL" = "https" ] ; then


### PR DESCRIPTION
### What does this PR do?
Allows the `-R` option to work with Debian-based distributions.

I put together the initial commits for this a while ago, but never finished up and tested the change. After a quick test and a small change, this is ready to go.

### What issues does this PR fix or reference?
Fixes #968

### Previous Behavior
The `-R` option was restricted to only working on RHEL-based distributions.

### New Behavior
The `-R` option has been expanded to also work with Debian/Ubuntu.