### PR TITLE
Add ability to install and use a different python version when installing salt

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -3771,9 +3771,9 @@ install_centos_git_deps() {
 install_centos_git() {
     if [ "$DISTRO_MAJOR_VERSION" -eq 5 ]; then
         _PYEXE=python2.6
-    elif [ ${_PY_EXE:='None'} != 'None' ]; then
+    elif [ "${_PY_EXE}" != "" ]; then
         _PYEXE=${_PY_EXE}
-        echoinfo "Using the following python version: ${_PY-EXE} to install salt"
+        echoinfo "Using the following python version: ${_PY_EXE} to install salt"
     else
         _PYEXE=python2
     fi

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1114,11 +1114,11 @@ __install_python_and_deps() {
 
     if [ $_DISABLE_REPOS -eq $BS_FALSE ]; then
         echoinfo "Installing IUS repo"
-        __yum_install_noinput ${__PYTHON_REPO_URL} || return 1
+        __yum_install_noinput "${__PYTHON_REPO_URL}" || return 1
     fi
 
     echoinfo "Installing ${__PACKAGES}"
-    __yum_install_noinput ${__PACKAGES} || return 1
+    __yum_install_noinput "${__PACKAGES}" || return 1
 
     _PIP_PACKAGES="tornado PyYAML msgpack-python jinja2 pycrypto zmq"
     __install_pip_pkgs "${_PIP_PACKAGES}" "${_PY_EXE}" || return 1
@@ -2279,7 +2279,7 @@ __install_pip_pkgs() {
     _py_pkg=$(echo "$_py_exe" | sed -r "s/\.//g")
     _pip_cmd="${_py_exe} -m pip"
 
-    if [ $_py_exe = "" ]; then
+    if [ "${_py_exe}" = "" ]; then
         _py_exe='python'
     fi
 
@@ -2288,10 +2288,12 @@ __install_pip_pkgs() {
     # Install pip and pip dependencies
     if ! __check_command_exists "${_pip_cmd} --version"; then
         __PACKAGES="${_py_pkg}-setuptools ${_py_pkg}-pip gcc ${_py_pkg}-devel"
+        # shellcheck disable=SC2086
         __yum_install_noinput ${__PACKAGES} || return 1
     fi
 
     echoinfo "Installing pip packages: ${_pip_pkgs} using ${_py_exe}"
+    # shellcheck disable=SC2086
     ${_pip_cmd} install ${_pip_pkgs} || return 1
 }
 

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1103,14 +1103,17 @@ __install_python_and_deps() {
     __PYTHON_REPO_URL="https://centos${DISTRO_MAJOR_VERSION}.iuscommunity.org/ius-release.rpm"
 
     if [ $_DISABLE_REPOS -eq $BS_FALSE ]; then
+        echoinfo "Installing IUS repo"
         yum install -y ${__PYTHON_REPO_URL} || return 1
     fi
 
+    echoinfo "Installing ${_PY_EXE}"
     yum install -y ${__PACKAGES} || return 1
 
     _PIP_PACKAGES="tornado PyYAML msgpack-python jinja2 pycrypto zmq"
 
     # Install Dependencies with different python version
+    echoinfo "Installing salt dependencies using the ${_PY_EXE} pip executable"
     ${_PY_EXE} -m pip install ${_PIP_PACKAGES} || return 1
 }
 

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1126,6 +1126,10 @@ __install_python_and_deps() {
     __yum_install_noinput "${__PACKAGES}" || return 1
 
     _PIP_PACKAGES="tornado PyYAML msgpack-python jinja2 pycrypto zmq"
+    if [ "$_INSTALL_CLOUD" -eq $BS_TRUE ]; then
+        _PIP_PACKAGES="${_PIP_PACKAGES} apache-libcloud"
+    fi
+
     __install_pip_pkgs "${_PIP_PACKAGES}" "${_PY_EXE}" || return 1
 }
 

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -241,6 +241,7 @@ _CUSTOM_MINION_CONFIG="null"
 _QUIET_GIT_INSTALLATION=$BS_FALSE
 _REPO_URL="repo.saltstack.com"
 _PY_EXE=""
+_INSTALL_PY="$BS_FALSE"
 
 #---  FUNCTION  -------------------------------------------------------------------------------------------------------
 #         NAME:  __usage
@@ -1102,17 +1103,21 @@ __install_python_and_deps() {
     PY_PKG_V=$(echo "$_PY_EXE" | sed -r "s/\.//g")
     __PACKAGES="${PY_PKG_V}"
 
-    case "$DISTRO_NAME_L" in
-        [red_hat] | [centos]*)
-            __PYTHON_REPO_URL="https://centos${DISTRO_MAJOR_VERSION}.iuscommunity.org/ius-release.rpm"
-            ;;
-        *)
-            echoerror "__install_python_and_deps is not currently supported on your platform"
-            exit 1
-            ;;
-    esac
 
     if [ $_DISABLE_REPOS -eq $BS_FALSE ]; then
+        echoinfo "Attempting to install a repo to help provide a separate python package"
+        echoinfo "$DISTRO_NAME_L"
+        case "$DISTRO_NAME_L" in
+            "red_hat"|"centos")
+                __PYTHON_REPO_URL="https://centos${DISTRO_MAJOR_VERSION}.iuscommunity.org/ius-release.rpm"
+                ;;
+            *)
+                echoerror "Installing a repo to provide a python package is only supported on Redhat/CentOS.
+                If a repo is already available please try running script with -r"
+                exit 1
+                ;;
+        esac
+
         echoinfo "Installing IUS repo"
         __yum_install_noinput "${__PYTHON_REPO_URL}" || return 1
     fi
@@ -3754,7 +3759,7 @@ install_centos_git_deps() {
         __PACKAGES="${__PACKAGES} python-libcloud"
     fi
 
-    if [ "${_INSTALL_PY:='None'}" = "${BS_TRUE}" ]; then
+    if [ "${_INSTALL_PY}" = "${BS_TRUE}" ]; then
         __install_python_and_deps || return 1
     else
         # shellcheck disable=SC2086

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -356,14 +356,15 @@ __usage() {
         a complete overwrite of the file.
     -q  Quiet salt installation from git (setup.py install -q)
     -x  Changes the python version used to install a git version of salt. Currently
-        this is considered experimental and has only been tested on Centos 6.
+        this is considered experimental and has only been tested on Centos 6. This
+        only works for git installations.
     -y  Installs a different python version on host. Currently this has only been
         tested with Centos 6 and is considered experimental. This will install the
         ius repo on the box if disable repo is false. This must be used in conjunction
         with -x <pythonversion>.  For example:
             sh bootstrap.sh -y -x python2.7 git v2016.11.3
         The above will install python27 and install the git version of salt using the
-        python2.7 executable.
+        python2.7 executable. This only works for git installations.
 
 EOT
 }   # ----------  end of function __usage  ----------
@@ -1092,12 +1093,13 @@ __gather_linux_system_info() {
 #                 tested on Centos 6 and is considered experimental.
 #----------------------------------------------------------------------------------------------------------------------
 __install_python_and_deps() {
-    if [[ ${_PY_EXE:='None'} == 'None' ]]; then
+    if [ ${_PY_EXE:='None'} = 'None' ]; then
         echoerror "Must specify -x <pythonversion> with -y to install a specific python version"
         exit 1
     fi
 
-    __PACKAGES="${_PY_EXE//./} ${_PY_EXE//./}-pip ${_PY_EXE//./}-devel gcc"
+    py_pkg_v=$(echo "$_PY_EXE" | sed -r "s/\.//g")
+    __PACKAGES="${py_pkg_v} ${py_pkg_v}-pip ${py_pkg_v}-devel gcc"
 
     #Install new python version
     __PYTHON_REPO_URL="https://centos${DISTRO_MAJOR_VERSION}.iuscommunity.org/ius-release.rpm"
@@ -3717,7 +3719,7 @@ install_centos_git_deps() {
         __PACKAGES="${__PACKAGES} python-libcloud"
     fi
 
-    if [ "${_INSTALL_PY:='None'}" == "${BS_TRUE}" ]; then
+    if [ "${_INSTALL_PY:='None'}" = "${BS_TRUE}" ]; then
         __install_python_and_deps || return 1
     else
         # shellcheck disable=SC2086
@@ -3736,7 +3738,7 @@ install_centos_git_deps() {
 install_centos_git() {
     if [ "$DISTRO_MAJOR_VERSION" -eq 5 ]; then
         _PYEXE=python2.6
-    elif [[ ${_PY_EXE:='None'} != 'None' ]]; then
+    elif [ ${_PY_EXE:='None'} != 'None' ]; then
         _PYEXE=${_PY_EXE}
         echoinfo "Using the following python version: ${_PY-EXE} to install salt"
     else

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -357,10 +357,13 @@ __usage() {
     -q  Quiet salt installation from git (setup.py install -q)
     -x  Changes the python version used to install a git version of salt. Currently
         this is considered experimental and has only been tested on Centos 6.
-    -y  Installs a different python version on host. Currently this only works
-        with Centos 6 and is considered experimental. This will install the ius
-        repo on the box. This must be used in conjunction with -x <pythonversion>
-        For example: sh bootstrap.sh -y -x python2.7 git v2016.11.3
+    -y  Installs a different python version on host. Currently this has only been
+        tested with Centos 6 and is considered experimental. This will install the
+        ius repo on the box if disable repo is false. This must be used in conjunction
+        with -x <pythonversion>.  For example:
+            sh bootstrap.sh -y -x python2.7 git v2016.11.3
+        The above will install python27 and install the git version of salt using the
+        python2.7 executable.
 
 EOT
 }   # ----------  end of function __usage  ----------

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -363,9 +363,9 @@ __usage() {
         tested with Centos 6 and is considered experimental. This will install the
         ius repo on the box if disable repo is false. This must be used in conjunction
         with -x <pythonversion>.  For example:
-            sh bootstrap.sh -y -x python2.7 git v2016.11.3
+            sh bootstrap.sh -P -y -x python2.7 git v2016.11.3
         The above will install python27 and install the git version of salt using the
-        python2.7 executable. This only works for git installations.
+        python2.7 executable. This only works for git and pip installations.
 
 EOT
 }   # ----------  end of function __usage  ----------

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -3717,7 +3717,7 @@ install_centos_git_deps() {
         __PACKAGES="${__PACKAGES} python-libcloud"
     fi
 
-    if [ "${_INSTALL_PY:='None'}" -eq "${BS_TRUE}" ]; then
+    if [ "${_INSTALL_PY:='None'}" == "${BS_TRUE}" ]; then
         __install_python_and_deps || return 1
     else
         # shellcheck disable=SC2086


### PR DESCRIPTION
### What does this PR do?
This adds two options to the bootstrap script: -x <pythonversion> and -y. Because we are dropping python2.6 support we need an option to install python2.7 for our testing on jenkins for Centos6. These options will install a different version of python and install salt with that python version. This currently only works for a git install of salt.

The user would need to run the following: `salt-bootstrap.sh -y -x python2.7 -q -M git v2016.11.3`. This command will install python27 and use the python2.7 executable to install salt, instead of the system default (python2.6)

I would love to get any feedback to see if this is the right approach.
