### PR TITLE
Add non-LTS type support for Ubuntu 17.04

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1276,6 +1276,11 @@ __ubuntu_codename_translation() {
                 DISTRO_CODENAME="yakkety"
             fi
             ;;
+        "17")
+            if [ "$_april" ]; then
+                DISTRO_CODENAME="zesty"
+            fi
+            ;;
         *)
             DISTRO_CODENAME="trusty"
             ;;
@@ -2454,10 +2459,10 @@ install_ubuntu_stable_deps() {
         # Versions starting with 2015.5.6, 2015.8.1 and 2016.3.0 are hosted at repo.saltstack.com
         if [ "$(echo "$STABLE_REV" | egrep '^(2015\.5|2015\.8|2016\.3|2016\.11|latest|archive\/)')" != "" ]; then
             # Workaround for latest non-LTS ubuntu
-            if [ "$DISTRO_VERSION" = "16.10" ]; then
+            if [ "$DISTRO_VERSION" = "16.10" ] || [ "$DISTRO_VERSION" = "17.04" ]; then
                 echowarn "Non-LTS Ubuntu detected, but stable packages requested. Trying packages from latest LTS release. You may experience problems."
                 UBUNTU_VERSION=16.04
-                UBUNTU_CODENAME=xenial
+                UBUNTU_CODENAME="xenial"
             else
                 UBUNTU_VERSION=$DISTRO_VERSION
                 UBUNTU_CODENAME=$DISTRO_CODENAME

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1468,7 +1468,7 @@ fi
 
 # Starting from Ubuntu 16.10, gnupg-curl has been renamed to gnupg1-curl.
 GNUPG_CURL="gnupg-curl"
-if ([ "${DISTRO_NAME_L}" = "ubuntu" ] && [ "${DISTRO_VERSION}" = "16.10" ]); then
+if ([ "${DISTRO_NAME_L}" = "ubuntu" ] && ([ "${DISTRO_VERSION}" = "16.10" ] || [ "$DISTRO_MAJOR_VERSION" -gt 16 ])); then
     GNUPG_CURL="gnupg1-curl"
 fi
 

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1468,8 +1468,10 @@ fi
 
 # Starting from Ubuntu 16.10, gnupg-curl has been renamed to gnupg1-curl.
 GNUPG_CURL="gnupg-curl"
-if ([ "${DISTRO_NAME_L}" = "ubuntu" ] && ([ "${DISTRO_VERSION}" = "16.10" ] || [ "$DISTRO_MAJOR_VERSION" -gt 16 ])); then
-    GNUPG_CURL="gnupg1-curl"
+if [ "${DISTRO_NAME_L}" = "ubuntu" ]; then
+    if [ "${DISTRO_VERSION}" = "16.10" ] || [ "$DISTRO_MAJOR_VERSION" -gt 16 ]; then
+        GNUPG_CURL="gnupg1-curl"
+    fi
 fi
 
 
@@ -2459,7 +2461,7 @@ install_ubuntu_stable_deps() {
         # Versions starting with 2015.5.6, 2015.8.1 and 2016.3.0 are hosted at repo.saltstack.com
         if [ "$(echo "$STABLE_REV" | egrep '^(2015\.5|2015\.8|2016\.3|2016\.11|latest|archive\/)')" != "" ]; then
             # Workaround for latest non-LTS ubuntu
-            if [ "$DISTRO_VERSION" = "16.10" ] || [ "$DISTRO_VERSION" = "17.04" ]; then
+            if [ "$DISTRO_VERSION" = "16.10" ] || [ "$DISTRO_MAJOR_VERSION" -gt 16 ]; then
                 echowarn "Non-LTS Ubuntu detected, but stable packages requested. Trying packages from latest LTS release. You may experience problems."
                 UBUNTU_VERSION=16.04
                 UBUNTU_CODENAME="xenial"


### PR DESCRIPTION
### What does this PR do?
Adds support for installing salt on Ubuntu 17.04 by using the xenial packages hosted at repo.saltstack.com. This is the same method we use for installing 16.10 as well.

```
# salt-call --versions
Salt Version:
           Salt: 2016.11.3

Dependency Versions:
           cffi: Not Installed
       cherrypy: Not Installed
       dateutil: 2.5.3
          gitdb: Not Installed
      gitpython: Not Installed
          ioflo: Not Installed
         Jinja2: 2.9.5
        libgit2: Not Installed
        libnacl: Not Installed
       M2Crypto: Not Installed
           Mako: 1.0.6
   msgpack-pure: Not Installed
 msgpack-python: 0.4.8
   mysql-python: Not Installed
      pycparser: Not Installed
       pycrypto: 2.6.1
         pygit2: Not Installed
         Python: 2.7.13 (default, Jan 19 2017, 14:48:08)
   python-gnupg: Not Installed
         PyYAML: 3.12
          PyZMQ: 16.0.2
           RAET: Not Installed
          smmap: Not Installed
        timelib: Not Installed
        Tornado: 4.4.2
            ZMQ: 4.2.1

System Versions:
           dist: Ubuntu 17.04 zesty
        machine: x86_64
        release: 4.9.15-x86_64-linode81
         system: Linux
        version: Ubuntu 17.04 zesty
```

