### PR TITLE
update install_freebsd_10_stable to use FreeBSD repo

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -4960,7 +4960,9 @@ install_freebsd_9_stable() {
 }
 
 install_freebsd_10_stable() {
+    # shellcheck disable=SC2086
     /usr/local/sbin/pkg install ${FROM_FREEBSD} -y sysutils/py-salt || return 1
+    return 0
 }
 
 install_freebsd_11_stable() {

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -4960,7 +4960,7 @@ install_freebsd_9_stable() {
 }
 
 install_freebsd_10_stable() {
-    install_freebsd_9_stable
+    /usr/local/sbin/pkg install ${FROM_FREEBSD} -y sysutils/py-salt || return 1
 }
 
 install_freebsd_11_stable() {


### PR DESCRIPTION
### What does this PR do?
Changes the behavior of install_freebsd_10_stable() to use the default FreeBSD repo.

### What issues does this PR fix or reference?
Short reason to change this: 
Currently, bootstrap-salt.sh fails on install_freebsd_10_stable because the package py27-setuptools-32.1.0_1 installed from the base (install_freebsd_10_stable_deps) is "newer" than the one provided by the saltstack repo, which is py27-setuptools-32.1.0.

Longer reason to change this:
As of FreeBSD 10.1 and later, using the saltstack repo is not required, as salt is well supported and present. Moreover, it can cause conflicts:
- When admins are using the "quarterly" packages (default since 10.2), which might be slightly older than the packages in the saltstack repo, but more importantly, 
- When a package in the _deps is more current than the one provided by the saltstack repo. Current example: see above. 

### Previous Behavior
Used to install salt from the saltstack repository

### New Behavior
Installs salt from the FreeBSD repository

