### PR TITLE
Update probot-stale message formatting.

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -16,12 +16,9 @@ staleLabel: stale
 
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: |
-  This issue has been automatically marked as stale because it has not had
-  recent activity. It will be closed if no further activity occurs. Thank you
-  for your contributions.
+  This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions.
 
-  If this issue is closed prematurely, please leave a comment and we will
-  gladly reopen the issue.
+  If this issue is closed prematurely, please leave a comment and we will gladly reopen the issue.
 
 # Comment to post when closing a stale issue. Set to `false` to disable
 closeComment: false


### PR DESCRIPTION
The line breaks in the stale.yml file don't look nice when the bot posts the comment on issues. This change avoids the formatting issues and line breaks.