### PR TITLE
Add KDE neon...

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -259,6 +259,7 @@ Ubuntu and derivatives
 - Linux Mint 13/17/18
 - Trisquel GNU/Linux 6 (based on Ubuntu 12.04)
 - Ubuntu 12.04/14.04/16.04
+- KDE neon 
 
 Ubuntu Best Effort Support: Non-LTS Releases 
 ********************************************

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1266,7 +1266,7 @@ __get_dpkg_architecture() {
 #----------------------------------------------------------------------------------------------------------------------
 # shellcheck disable=SC2034
 __ubuntu_derivatives_translation() {
-    UBUNTU_DERIVATIVES="(trisquel|linuxmint|linaro|elementary_os)"
+    UBUNTU_DERIVATIVES="(trisquel|linuxmint|linaro|elementary_os|neon)"
     # Mappings
     trisquel_6_ubuntu_base="12.04"
     linuxmint_13_ubuntu_base="12.04"
@@ -1274,6 +1274,7 @@ __ubuntu_derivatives_translation() {
     linuxmint_18_ubuntu_base="16.04"
     linaro_12_ubuntu_base="12.04"
     elementary_os_02_ubuntu_base="12.04"
+    neon_16_ubuntu_base="16.04"
 
     # Translate Ubuntu derivatives to their base Ubuntu version
     match=$(echo "$DISTRO_NAME_L" | egrep ${UBUNTU_DERIVATIVES})


### PR DESCRIPTION
### What does this PR do?
Add support for KDE neon to `__ubuntu_derivatives_translation()`

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-bootstrap/issues/1050 Cannot install standalone minion on kde neon

### Previous Behavior
Salt could *not* be installed on kde neon.

### New Behavior
Salt can be installed on kde neon.

