### PR TITLE
Properly detect all supported Debian GNU/Linux derivatives

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -225,6 +225,7 @@ You also may need to disable repository configuration and allow ``pip`` installa
 Debian and derivatives
 ~~~~~~~~~~~~~~~~~~~~~~
 
+- Cumulus Linux 2/3
 - Debian GNU/Linux 7/8
 - Linux Mint Debian Edition 1 (based on Debian 8)
 - Kali Linux 1.0 (based on Debian 7)
@@ -255,11 +256,11 @@ Ubuntu and derivatives
 ~~~~~~~~~~~~~~~~~~~~~~
 
 - Elementary OS 0.2 (based on Ubuntu 12.04)
+- KDE neon (based on Ubuntu 16.04)
 - Linaro 12.04
 - Linux Mint 13/17/18
 - Trisquel GNU/Linux 6 (based on Ubuntu 12.04)
-- Ubuntu 12.04/14.04/16.04
-- KDE neon 
+- Ubuntu 12.04/14.04/16.04 and subsequent non-TLS releases (see below)
 
 Ubuntu Best Effort Support: Non-LTS Releases 
 ********************************************

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -975,10 +975,6 @@ __gather_linux_system_info() {
         elif [ "${DISTRO_NAME}" = "Arch" ]; then
             DISTRO_NAME="Arch Linux"
             return
-        elif [ "${DISTRO_NAME}" = "Raspbian" ]; then
-           DISTRO_NAME="Debian"
-        elif [ "${DISTRO_NAME}" = "Cumulus Linux" ]; then
-            DISTRO_NAME="Debian"
         fi
         rv=$(lsb_release -sr)
         [ "${rv}" != "" ] && DISTRO_VERSION=$(__parse_version_string "$rv")
@@ -1088,6 +1084,7 @@ __gather_linux_system_info() {
         break
     done
 }
+
 
 #---  FUNCTION  -------------------------------------------------------------------------------------------------------
 #          NAME:  __install_python_and_deps()
@@ -1243,6 +1240,7 @@ __gather_system_info() {
 
 }
 
+
 #---  FUNCTION  -------------------------------------------------------------------------------------------------------
 #          NAME:  __get_dpkg_architecture
 #   DESCRIPTION:  Determine primary architecture for packages to install on Debian and derivatives
@@ -1257,6 +1255,7 @@ __get_dpkg_architecture() {
 
     return 0
 }
+
 
 #---  FUNCTION  -------------------------------------------------------------------------------------------------------
 #          NAME:  __ubuntu_derivatives_translation
@@ -1303,6 +1302,7 @@ __ubuntu_derivatives_translation() {
     fi
 }
 
+
 #---  FUNCTION  -------------------------------------------------------------------------------------------------------
 #          NAME:  __ubuntu_codename_translation
 #   DESCRIPTION:  Map Ubuntu major versions to their corresponding codenames
@@ -1346,6 +1346,7 @@ __ubuntu_codename_translation() {
     esac
 }
 
+
 #---  FUNCTION  -------------------------------------------------------------------------------------------------------
 #          NAME:  __debian_derivatives_translation
 #   DESCRIPTION:  Map Debian derivatives to their Debian base versions.
@@ -1354,25 +1355,26 @@ __ubuntu_codename_translation() {
 #----------------------------------------------------------------------------------------------------------------------
 # shellcheck disable=SC2034
 __debian_derivatives_translation() {
-
     # If the file does not exist, return
     [ ! -f /etc/os-release ] && return
 
-    DEBIAN_DERIVATIVES="(kali|linuxmint|cumulus-linux)"
+    DEBIAN_DERIVATIVES="(cumulus_.+|kali|linuxmint|raspbian)"
     # Mappings
-    kali_1_debian_base="7.0"
-    linuxmint_1_debian_base="8.0"
     cumulus_2_debian_base="7.0"
     cumulus_3_debian_base="8.0"
-
-    # Detect derivates, Cumulus Linux, Kali and LinuxMint *only* for now
-    rv=$(grep ^ID= /etc/os-release | sed -e 's/.*=//')
+    kali_1_debian_base="7.0"
+    linuxmint_1_debian_base="8.0"
+    raspbian_8_debian_base="8.0"
 
     # Translate Debian derivatives to their base Debian version
-    match=$(echo "$rv" | egrep ${DEBIAN_DERIVATIVES})
+    match=$(echo "$DISTRO_NAME_L" | egrep ${DEBIAN_DERIVATIVES})
 
     if [ "${match}" != "" ]; then
         case $match in
+            cumulus_*)
+                _major=$(echo "$DISTRO_VERSION" | sed 's/^\([0-9]*\).*/\1/g')
+                _debian_derivative="cumulus"
+                ;;
             kali)
                 _major=$(echo "$DISTRO_VERSION" | sed 's/^\([0-9]*\).*/\1/g')
                 _debian_derivative="kali"
@@ -1381,9 +1383,9 @@ __debian_derivatives_translation() {
                 _major=$(echo "$DISTRO_VERSION" | sed 's/^\([0-9]*\).*/\1/g')
                 _debian_derivative="linuxmint"
                 ;;
-            cumulus-linux)
+            raspbian)
                 _major=$(echo "$DISTRO_VERSION" | sed 's/^\([0-9]*\).*/\1/g')
-                _debian_derivative="cumulus"
+                _debian_derivative="raspbian"
                 ;;
         esac
 
@@ -1412,6 +1414,7 @@ __check_and_refresh_suse_pkg_repo() {
         __zypper addrepo --refresh "${SUSE_PKG_URL}" || return 1
     fi
 }
+
 
 __gather_system_info
 


### PR DESCRIPTION
### What does this PR do?
It fixes detection mechanism for Debian OS derivatives and properly outputs distribution.  Updated README.

### What issues does this PR fix or reference?
The issue has been raised in #1050.

### Previous Behavior
The script reports it runs on "pure" Debian in case of Cumulus and Raspbian.

### New Behavior
The script reports real distribution name and uses appropriate repo URL for base Debian version.

