### PR TITLE
Add Manjaro as Arch derivative

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -972,6 +972,8 @@ __gather_linux_system_info() {
             DISTRO_NAME="Oracle Linux"
         elif [ "${DISTRO_NAME}" = "AmazonAMI" ]; then
             DISTRO_NAME="Amazon Linux AMI"
+        elif [ "${DISTRO_NAME}" = "ManjaroLinux" ]; then
+            DISTRO_NAME="Arch Linux"
         elif [ "${DISTRO_NAME}" = "Arch" ]; then
             DISTRO_NAME="Arch Linux"
             return


### PR DESCRIPTION
### What does this PR do?
Simple fix that allows the bootstrap to run on Manjaro.

### What issues does this PR fix or reference?
Issue #778 

### Previous Behavior
Bootstrap failed to recognize lsb_release -si "ManjaroLinux", exited.

### New Behavior
Bootstrap recognizes "ManjaroLinux" as "Arch Linux", and installs the salt minion.

