### PR TITLE
Add "unmarkComment" option to probot-stale config

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -20,6 +20,10 @@ markComment: |
 
   If this issue is closed prematurely, please leave a comment and we will gladly reopen the issue.
 
+# Comment to post when removing the stale label. Set to `false` to disable
+unmarkComment: |
+  Thank you for updating this issue. It is no longer marked as stale.
+
 # Comment to post when closing a stale issue. Set to `false` to disable
 closeComment: false
 


### PR DESCRIPTION
### What does this PR do?
Adds the "unmarkComment" text to the probot-stale config so that the bot will comment when an issue is no longer marked as stale.

### What issues does this PR fix or reference?
https://github.com/probot/stale/pull/21
