### PR TITLE
Declare End-of-Life for RHEL 5 and its variants

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -235,12 +235,13 @@ Debian and derivatives
 Red Hat family
 ~~~~~~~~~~~~~~
 
-- Amazon Linux
-- CentOS 5/6/7
+- Amazon Linux 2012.3 and later
+- CentOS 6/7
+- Cloud Linux 6/7
 - Fedora 23/24/25
-- Oracle Linux 5/6/7
-- Red Hat Enterprise Linux 5/6/7
-- Scientific Linux 5/6/7
+- Oracle Linux 6/7
+- Red Hat Enterprise Linux 6/7
+- Scientific Linux 6/7
 
 
 SUSE family

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1840,7 +1840,7 @@ __check_end_of_life_versions() {
 
         centos)
             # CentOS versions lower than 5 are no longer supported
-            if [ "$DISTRO_MAJOR_VERSION" -lt 5 ]; then
+            if [ "$DISTRO_MAJOR_VERSION" -lt 6 ]; then
                 echoerror "End of life distributions are not supported."
                 echoerror "Please consider upgrading to the next stable. See:"
                 echoerror "    http://wiki.centos.org/Download"
@@ -1850,10 +1850,40 @@ __check_end_of_life_versions() {
 
         red_hat*linux)
             # Red Hat (Enterprise) Linux versions lower than 5 are no longer supported
-            if [ "$DISTRO_MAJOR_VERSION" -lt 5 ]; then
+            if [ "$DISTRO_MAJOR_VERSION" -lt 6 ]; then
                 echoerror "End of life distributions are not supported."
                 echoerror "Please consider upgrading to the next stable. See:"
                 echoerror "    https://access.redhat.com/support/policy/updates/errata/"
+                exit 1
+            fi
+            ;;
+
+        oracle*linux)
+            # Oracle Linux versions lower than 5 are no longer supported
+            if [ "$DISTRO_MAJOR_VERSION" -lt 6 ]; then
+                echoerror "End of life distributions are not supported."
+                echoerror "Please consider upgrading to the next stable. See:"
+                echoerror "    http://www.oracle.com/us/support/library/elsp-lifetime-069338.pdf"
+                exit 1
+            fi
+            ;;
+
+        scientific*linux)
+            # Scientific Linux versions lower than 5 are no longer supported
+            if [ "$DISTRO_MAJOR_VERSION" -lt 6 ]; then
+                echoerror "End of life distributions are not supported."
+                echoerror "Please consider upgrading to the next stable. See:"
+                echoerror "    https://www.scientificlinux.org/downloads/sl-versions/"
+                exit 1
+            fi
+            ;;
+
+        cloud*linux)
+            # Cloud Linux versions lower than 5 are no longer supported
+            if [ "$DISTRO_MAJOR_VERSION" -lt 6 ]; then
+                echoerror "End of life distributions are not supported."
+                echoerror "Please consider upgrading to the next stable. See:"
+                echoerror "    https://docs.cloudlinux.com/index.html?cloudlinux_life-cycle.html"
                 exit 1
             fi
             ;;


### PR DESCRIPTION
### What does this PR do?
It disables bootstrapping on RHEL/CentOS/CL/OL/SL **5** distros and removes workarounds used to get Salt running on them. The README has been updated as well.

### What issues does this PR fix or reference?
The upstream RHEL release 5 reached EOL on March 31, 2017. The issue has been raised in #1065.

### Previous Behavior
Attempt to install Salt on RHEL 5 fails due to missing EPEL support.

### New Behavior
The error message about EOL policy will be displayed when the script would be executed on RHEL 5.

