### PR TITLE
Allow amazon to work with python2.7 on installs over 2016.11

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -4539,8 +4539,10 @@ install_amazon_linux_ami_git_deps() {
     fi
 
     PIP_EXE='pip'
-    if [ $(command -v python2.7) ]; then
-        [ $(which pip2.7) ] || /usr/bin/easy_install-2.7 pip || return 1
+    if __check_command_exists python2.7; then
+        if ! __check_command_exists pip2.7; then
+            /usr/bin/easy_install-2.7 pip || return 1
+        fi
         PIP_EXE='/usr/local/bin/pip2.7'
         _PY_EXE='python2.7'
     fi

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -4461,11 +4461,7 @@ install_amazon_linux_ami_deps() {
     # Shim to figure out if we're using old (rhel) or new (aws) rpms.
     _USEAWS=$BS_FALSE
 
-    if [ "$ITYPE" = "stable" ]; then
-        repo_rev="$(echo "${STABLE_REV}"  | sed 's|.*\/||g')"
-    else
-        repo_rev="latest"
-    fi
+    repo_rev="$(echo "${STABLE_REV}"  | sed 's|.*\/||g')"
 
     if echo "$repo_rev" | egrep -q '^(latest|2016\.11)$'; then
        _USEAWS=$BS_TRUE
@@ -4543,8 +4539,8 @@ install_amazon_linux_ami_git_deps() {
     fi
 
     PIP_EXE='pip'
-    if [ "$(echo "$GIT_REV" | egrep -o '2[0-9]{3}')" -ge 2016 ]; then
-        [ $(which pip2.7) ] || /usr/bin/easy_install-2.7 pip || echoerror "Could not install pip2.7"
+    if [ $(command -v python2.7) ]; then
+        [ $(which pip2.7) ] || /usr/bin/easy_install-2.7 pip || return 1
         PIP_EXE='/usr/local/bin/pip2.7'
         _PY_EXE='python2.7'
     fi


### PR DESCRIPTION
### What does this PR do?

- Fixes issue https://github.com/saltstack/salt-bootstrap/issues/1071
- Also now uses python2.7 when version is above 2016.11, which is the same behavior with the new amazon packages in 2016.11 and above in repo.saltstack.com.
- Changes the default repo to latest if not stable install. I believe this is the approach currently to take since its the same behavior in others ares of the bootstrap script. 