### PR TITLE
ensure sles12 enables services with stable installs

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -5889,7 +5889,6 @@ install_suse_12_stable_post() {
                 # shellcheck disable=SC2086
                 curl $_CURL_ARGS -L "https://github.com/saltstack/salt/raw/develop/pkg/salt-$fname.service" \
                     -o "/usr/lib/systemd/system/salt-$fname.service" || return 1
-                continue
             fi
 
             # Skip salt-api since the service should be opt-in and not necessarily started on boot


### PR DESCRIPTION
### What does this PR do?
Fixes https://github.com/saltstack/salt-bootstrap/issues/1074

This continue made sure it did not continue later into the code to enable the services. This is why it was failing on the next step: `install_suse_check_services()` because it did not see the service as being enabled. Tested this and it is working now.