### PR TITLE
Use freebsd repo to query for salt dependencies

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -4909,6 +4909,8 @@ __configure_freebsd_pkg_details() {
 
     ## ensure future ports builds use pkgng
     echo "WITH_PKGNG=   yes" >> /etc/make.conf
+
+    /usr/local/sbin/pkg update -f || return 1
 }
 
 install_freebsd_9_stable_deps() {
@@ -4965,7 +4967,7 @@ install_freebsd_git_deps() {
     install_freebsd_9_stable_deps || return 1
 
     # shellcheck disable=SC2086
-    SALT_DEPENDENCIES=$(/usr/local/sbin/pkg search ${FROM_SALTSTACK} -R -d sysutils/py-salt | grep -i origin | sed -e 's/^[[:space:]]*//' | tail -n +2 | awk -F\" '{print $2}' | tr '\n' ' ')
+    SALT_DEPENDENCIES=$(/usr/local/sbin/pkg search ${FROM_FREEBSD} -R -d sysutils/py-salt | grep -i origin | sed -e 's/^[[:space:]]*//' | tail -n +2 | awk -F\" '{print $2}' | tr '\n' ' ')
     # shellcheck disable=SC2086
     /usr/local/sbin/pkg install ${FROM_FREEBSD} -y ${SALT_DEPENDENCIES} || return 1
 


### PR DESCRIPTION
### What does this PR do?
Uses the FreeBSD repo instead of the Saltstack Repo to grab dependencies since the saltstack repo is not up to date all the time. Also runs pkg update after the repos are added. Thanks to @amontalban for this fix :)

### What issues does this PR fix or reference?
Fixes https://github.com/saltstack/salt-bootstrap/issues/1072


