### PR TITLE
Fix the -R option on Debian/Ubuntu 

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2886,7 +2886,7 @@ install_ubuntu_check_services() {
 #
 #   Debian Install Functions
 #
-__install_saltstack_debain_repository() {
+__install_saltstack_debian_repository() {
     if [ "$DISTRO_MAJOR_VERSION" -eq 7 ]; then
         DEBIAN_CODENAME="wheezy"
     else

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1315,7 +1315,7 @@ __check_dpkg_architecture() {
             error_msg=""
             ;;
         "armhf")
-            if [ "$DISTRO_NAME_L" == "ubuntu" ] || [ "$DISTRO_MAJOR_VERSION" -lt 8 ]; then
+            if [ "$DISTRO_NAME_L" = "ubuntu" ] || [ "$DISTRO_MAJOR_VERSION" -lt 8 ]; then
                 error_msg="Support for armhf packages at $_REPO_URL is limited to Debian/Raspbian 8 platforms."
                 __return_code=1
             else
@@ -1337,7 +1337,12 @@ __check_dpkg_architecture() {
             echoerror "    sh ${__ScriptName} -r -P git v2016.11.5"
         fi
     fi
-    return __return_code
+
+    if [ "${__return_code}" -eq 0 ]; then
+        return 0
+    else
+        return 1
+    fi
 }
 
 
@@ -6170,6 +6175,7 @@ __gentoo_post_dep() {
         echoinfo "Installing the following extra packages as requested: ${_EXTRA_PACKAGES}"
         # shellcheck disable=SC2086
         __autounmask ${_EXTRA_PACKAGES} || return 1
+        # shellcheck disable=SC2086
         __emerge -v ${_EXTRA_PACKAGES} || return 1
     fi
 }

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1275,8 +1275,8 @@ __check_dpkg_architecture() {
             ;;
     esac
 
-    if [ ${error_msg} != "" ]; then
-        echoerror ${error_msg}
+    if [ "${error_msg}" != "" ]; then
+        echoerror "${error_msg}"
         if [ "$ITYPE" != "git" ]; then
             echoerror "You can try git installation mode, i.e.: sh ${__ScriptName} git v2016.11.5."
             echoerror "It may be necessary to use git installation mode with pip and disable the SaltStack apt repository."

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1303,7 +1303,7 @@ __check_dpkg_architecture() {
     fi
 
     __REPO_ARCH="$DPKG_ARCHITECTURE"
-    __return_code=${BS_TRUE}
+    __return_code=0
 
     case $DPKG_ARCHITECTURE in
         "i386")
@@ -1317,14 +1317,14 @@ __check_dpkg_architecture() {
         "armhf")
             if [ "$DISTRO_NAME_L" == "ubuntu" ] || [ "$DISTRO_MAJOR_VERSION" -lt 8 ]; then
                 error_msg="Support for armhf packages at $_REPO_URL is limited to Debian/Raspbian 8 platforms."
-                __return_code=${BS_FALSE}
+                __return_code=1
             else
                 error_msg=""
             fi
             ;;
         *)
             error_msg="$_REPO_URL doesn't have packages for your system architecture: $DPKG_ARCHITECTURE."
-            __return_code=${BS_TRUE}
+            __return_code=1
             ;;
     esac
 

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2508,7 +2508,7 @@ __install_saltstack_ubuntu_repository() {
         echowarn "Non-LTS Ubuntu detected, but stable packages requested. Trying packages from latest LTS release. You may experience problems."
         UBUNTU_VERSION=16.04
         UBUNTU_CODENAME="xenial"
-    els
+    else
         UBUNTU_VERSION=$DISTRO_VERSION
         UBUNTU_CODENAME=$DISTRO_CODENAME
     fi

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1258,24 +1258,30 @@ __check_dpkg_architecture() {
 
     __REPO_ARCH="$DPKG_ARCHITECTURE"
 
-    if [ "$DPKG_ARCHITECTURE" = "i386" ]; then
-        echoerror "$_REPO_URL likely doesn't have all required 32-bit packages for Ubuntu $DISTRO_MAJOR_VERSION (yet?)."
+    case $DPKG_ARCHITECTURE in
+        "i386")
+            error_msg="$_REPO_URL likely doesn't have all required 32-bit packages for $DISTRO_NAME $DISTRO_MAJOR_VERSION."
+            # amd64 is just a part of repository URI, 32-bit pkgs are hosted under the same location
+            __REPO_ARCH="amd64"
+            ;;
+        "amd64")
+            error_msg=""
+            ;;
+        "armhf")
+            error_msg=""
+            ;;
+        *)
+            error_msg="$_REPO_URL doesn't have packages for your system architecture: $DPKG_ARCHITECTURE."
+            ;;
+    esac
 
+    if [ ${error_msg} != "" ]; then
+        echoerror ${error_msg}
         if [ "$ITYPE" != "git" ]; then
-            echoerror "You can try git installation mode, i.e.: sh ${__ScriptName} git v2016.11.5"
-        fi
-
-        # amd64 is just a part of repository URI, 32-bit pkgs are hosted under the same location
-        __REPO_ARCH="amd64"
-
-    elif [ "$DPKG_ARCHITECTURE" != "amd64" ]; then
-        echoerror "$_REPO_URL doesn't have packages for your system architecture: $DPKG_ARCHITECTURE."
-
-        if [ "$DPKG_ARCHITECTURE" != "armhf" ]; then
-            echoerror "Try git installation mode with pip and disable SaltStack apt repository, for example:"
+            echoerror "You can try git installation mode, i.e.: sh ${__ScriptName} git v2016.11.5."
+            echoerror "It may be necessary to use git installation mode with pip and disable the SaltStack apt repository."
+            echoerror "For example:"
             echoerror "    sh ${__ScriptName} -r -P git v2016.11.5"
-        elif [ "$ITYPE" != "git" ]; then
-            echoerror "You can try git installation mode, i.e.: sh ${__ScriptName} git v2016.11.5"
         fi
     fi
 }


### PR DESCRIPTION
### What does this PR do?
When the `-R` option was originally implemented for Debian/Ubuntu, I must not have been testing the right thing because I am not sure how that ever could have worked. This PR reworks some of those `-R` checks and sets up the repositories correctly.

### What issues does this PR fix or reference?
Fixes #1081

### Previous Behavior
The `-R` option wouldn't set up any repo, and would install the default old packages in apt, which is version 0.17. :(

### New Behavior
-R option works well!

```
root@ubuntu:~# sh test.sh -R repo.saltstack.com/staging
<snipped>
root@ubuntu:~# salt-minion --version
salt-minion 2016.11.5 (Carbon)
root@ubuntu:~# cat /etc/apt/sources.list.d/saltstack.list
deb https://repo.saltstack.com/staging/apt/ubuntu/14.04/amd64/latest trusty main
```

I also did a bunch of clean up in this PR that I have been wanting to do for a while. Namely: 
- I moved all of the duplicated warnings about the checking for the correct DPKG_ARCHITECTURE values into a single function
- I created an `install_saltstack_ubuntu_repository` function and moved the saltstack repo set up (and also will work with the `-R` setting with the `_REPO_URL` value) there. This is similar to the way the RHEL distros gate and set up the saltstack repo.
- I created an `install_saltstack_debian_repository` function and moved the saltstack repo set up for BOTH debian 7 and debian 8 into one function. This also works with `-R`, just like the ubuntu repo set up function.
- In these two new functions, I also removed the checks for which "stable" version the user is installing. The packages located on saltstack's repo have been around long enough for now and the old repos are not getting updates any longer.