### PR TITLE
Update Fedora support: 23 is EOL now.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -238,7 +238,7 @@ Red Hat family
 - Amazon Linux 2012.3 and later
 - CentOS 6/7
 - Cloud Linux 6/7
-- Fedora 23/24/25
+- Fedora 24/25
 - Oracle Linux 6/7
 - Red Hat Enterprise Linux 6/7
 - Scientific Linux 6/7

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1462,8 +1462,8 @@ __check_end_of_life_versions() {
             ;;
 
         fedora)
-            # Fedora lower than 23 are no longer supported
-            if [ "$DISTRO_MAJOR_VERSION" -lt 23 ]; then
+            # Fedora lower than 24 are no longer supported
+            if [ "$DISTRO_MAJOR_VERSION" -lt 24 ]; then
                 echoerror "End of life distributions are not supported."
                 echoerror "Please consider upgrading to the next stable. See:"
                 echoerror "    https://fedoraproject.org/wiki/Releases"


### PR DESCRIPTION
Fedora 23 reached EOL in December of 2016, so this just updates the script and README to match that support.

FYI @vutny I grabbed this really quickly today while I was waiting for some other tests to run. :)

