### PR TITLE
Removes faulty explicit version ordering

### DIFF
--- a/bootstrap-salt.ps1
+++ b/bootstrap-salt.ps1
@@ -211,7 +211,7 @@ If (!$version) {
         $returnMatches = $returnMatches | Where {$_ -like "Salt-Minion*AMD64-Setup.exe"}
     }
 
-    $version = $(($returnMatches | Sort-Object -Descending)[0]).Split(("n-","-A","-x"),([System.StringSplitOptions]::RemoveEmptyEntries))[1]
+    $version = $($returnMatches[$returnMatches.Count -1]).Split(("n-","-A","-x"),([System.StringSplitOptions]::RemoveEmptyEntries))[1]
 }
 
 #===============================================================================


### PR DESCRIPTION
### What does this PR do?
Changes the version ordering to rely on the correct ordering already present in the repo, and selects the last (Most recent) version. This removes the explicit ordering done with `Select-Object -Descending` as this works alphabetically and does not correctly order versions (eg. `.11` comes before `.2`).

### What issues does this PR fix or reference?

#1094 

### Previous Behavior
Not passing `-version` would fetch the wrong version, where it should fetch the latest.

### New Behavior
Now correctly fetches latest version.

