### PR TITLE
Fix installing salt-cloud package on Arch Linux

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -4522,7 +4522,7 @@ install_arch_linux_stable_deps() {
     pacman -Su --noconfirm --needed python2-yaml
 
     if [ "$_INSTALL_CLOUD" -eq $BS_TRUE ]; then
-        pacman -Su --noconfirm --needed apache-libcloud || return 1
+        pacman -Su --noconfirm --needed python2-apache-libcloud || return 1
     fi
 
     if [ "${_EXTRA_PACKAGES}" != "" ]; then


### PR DESCRIPTION
When passing the ``-L`` option to the bootstrap script to install the salt-cloud package, the ``apache-libcloud`` package must be installed.

However, on Arch Linux this packages is named ``python2-apache-libcloud``.

This commit updates the name of the libcloud package to be installed on Arch Linux so that the ``-L`` option can be executed successfully.

Fixes #1090

