### PR TITLE
Fix ubuntu 16.04 LTS installation

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1705,11 +1705,13 @@ if [ $_START_DAEMONS -eq $BS_FALSE ]; then
     echoinfo "Daemons will not be started"
 fi
 
-# For ubuntu versions, obtain the codename from the release version
-__ubuntu_codename_translation
-
-# For debian versions, obtain the codename from the release version
-__debian_codename_translation
+if [ "${DISTRO_NAME_L}" = "ubuntu" ]; then
+  # For ubuntu versions, obtain the codename from the release version
+  __ubuntu_codename_translation
+elif [ "${DISTRO_NAME_L}" = "debian" ]; then
+  # For debian versions, obtain the codename from the release version
+  __debian_codename_translation
+fi
 
 # Only Ubuntu has daily packages, let's let users know about that
 if ([ "${DISTRO_NAME_L}" != "ubuntu" ] && [ "$ITYPE" = "daily" ]); then


### PR DESCRIPTION


### What does this PR do?
This PR fixes an error when bootstrapping salt on the docker image ubuntu:16.04 . It would use ppa's with codename `jessie` (debian) rather than the correct name `xenial` (ubuntu)

### What issues does this PR fix or reference?
error was 
```
18:24:59 Hit:1 http://archive.ubuntu.com/ubuntu xenial InRelease
18:24:59 Hit:2 http://security.ubuntu.com/ubuntu xenial-security InRelease

18:24:59 Hit:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease
18:24:59 Hit:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease
18:24:59 Ign:5 https://repo.saltstack.com/apt/ubuntu/16.04/amd64/2015.8 jessie InRelease
18:24:59 Ign:6 https://repo.saltstack.com/apt/ubuntu/16.04/amd64/2015.8 jessie Release
18:24:59 Ign:7 https://repo.saltstack.com/apt/ubuntu/16.04/amd64/2015.8 jessie/main amd64 Packages
18:24:59 Ign:8 https://repo.saltstack.com/apt/ubuntu/16.04/amd64/2015.8 jessie/main all Packages
18:24:59 Ign:7 https://repo.saltstack.com/apt/ubuntu/16.04/amd64/2015.8 jessie/main amd64 Packages
18:24:59 Ign:8 https://repo.saltstack.com/apt/ubuntu/16.04/amd64/2015.8 jessie/main all Packages
18:24:59 Ign:7 https://repo.saltstack.com/apt/ubuntu/16.04/amd64/2015.8 jessie/main amd64 Packages
18:25:00 Ign:8 https://repo.saltstack.com/apt/ubuntu/16.04/amd64/2015.8 jessie/main all Packages
18:25:00 Ign:7 https://repo.saltstack.com/apt/ubuntu/16.04/amd64/2015.8 jessie/main amd64 Packages
18:25:00 Ign:8 https://repo.saltstack.com/apt/ubuntu/16.04/amd64/2015.8 jessie/main all Packages
18:25:00 Ign:7 https://repo.saltstack.com/apt/ubuntu/16.04/amd64/2015.8 jessie/main amd64 Packages
18:25:00 Ign:8 https://repo.saltstack.com/apt/ubuntu/16.04/amd64/2015.8 jessie/main all Packages
18:25:00 Err:7 https://repo.saltstack.com/apt/ubuntu/16.04/amd64/2015.8 jessie/main amd64 Packages
18:25:00   404  Not Found
18:25:00 Ign:8 https://repo.saltstack.com/apt/ubuntu/16.04/amd64/2015.8 jessie/main all Packages

18:25:01 Reading package lists...
18:25:01 W: The repository 'https://repo.saltstack.com/apt/ubuntu/16.04/amd64/2015.8 jessie Release' does not have a Release file.
18:25:01 E: Failed to fetch https://repo.saltstack.com/apt/ubuntu/16.04/amd64/2015.8/dists/jessie/main/binary-amd64/Packages  404  Not Found
18:25:01 E: Some index files failed to download. They have been ignored, or old ones used instead.
18:25:01  * ERROR: Failed to run install_ubuntu_stable_deps()!!!
```

### Previous Behavior
`apt-get update` would sometimes fail due to the bad codename

### New Behavior
`apt-get update` should succeed consistently

