### PR TITLE
FEAT: add support for OS X in bootstrap script.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -293,6 +293,9 @@ UNIX systems
 
 - SmartOS
 
+**MacOS**:
+
+- 10.9 and above, as long as the underlying installer supports it.
 
 Unsupported Distro
 ------------------

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1229,8 +1229,8 @@ __gather_darwin_system_info() {
     DISTRO_NAME=${OS_NAME}
     DISTRO_VERSION=$(sw_vers | grep ProductVersion |  cut -f 2 -d: | tr -d ' \t')
 
-    DISTRO_MAJOR_VERSION=$(echo ${DISTRO_VERSION} | cut -d. -f 1)
-    DISTRO_MINOR_VERSION=$(echo ${DISTRO_VERSION} | cut -d. -f 2)
+    DISTRO_MAJOR_VERSION=$(echo "${DISTRO_VERSION}" | cut -d. -f 1)
+    DISTRO_MINOR_VERSION=$(echo "${DISTRO_VERSION}" | cut -d. -f 2)
 
     if [ "${DISTRO_MAJOR_VERSION}" -ne "10" ]; then
         echoerror "${DISTRO_NAME} ${DISTRO_VERSION} not supported.";
@@ -5222,7 +5222,7 @@ install_darwin_stable() {
 
     actual_md5=$(md5 -q "${target}")
     if [ "$actual_md5" = "$expected_md5" ]; then
-        installer -pkg ${target} -target / || return 1
+        installer -pkg "${target}" -target / || return 1
     else
         echoerror "Wrong checksum for installer"
         exit 1


### PR DESCRIPTION
### What does this PR do?

Add support for bootstrapping salt minions on OS X

While the PR adds support for 10.9 upward, since the latest installer only supports 10.11 upward, this effectively supports 10.11 and above only. If the salt minion package is built with https://github.com/saltstack/salt/pull/37858, then the bootstrap script will effectively support 10.9 and above.