### PR TITLE
Fix 1105

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,7 +10,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # please see the online documentation at vagrantup.com.
 
   # Every Vagrant virtual environment requires a box to build off of.
-  config.vm.box = "ubuntu/precise64"
+  config.vm.box = "ubuntu/xenial64"
 
   # The url from where the 'config.vm.box' box will be fetched if it
   # doesn't already exist on the user's system.

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -6341,12 +6341,12 @@ config_salt() {
 
         # Copy the minion's keys if found
         if [ -f "$_TEMP_CONFIG_DIR/minion.pem" ]; then
-            __movefile "$_TEMP_CONFIG_DIR/minion.pem" "$_PKI_DIR/minion/" "$_CONFIG_ONLY" || return 1
+            __movefile "$_TEMP_CONFIG_DIR/minion.pem" "$_PKI_DIR/minion/" "$_FORCE_OVERWRITE" || return 1
             chmod 400 "$_PKI_DIR/minion/minion.pem" || return 1
             CONFIGURED_ANYTHING=$BS_TRUE
         fi
         if [ -f "$_TEMP_CONFIG_DIR/minion.pub" ]; then
-            __movefile "$_TEMP_CONFIG_DIR/minion.pub" "$_PKI_DIR/minion/" "$_CONFIG_ONLY" || return 1
+            __movefile "$_TEMP_CONFIG_DIR/minion.pub" "$_PKI_DIR/minion/" "$_FORCE_OVERWRITE" || return 1
             chmod 664 "$_PKI_DIR/minion/minion.pub" || return 1
             CONFIGURED_ANYTHING=$BS_TRUE
         fi


### PR DESCRIPTION
### What does this PR do?
- Completes the correction of #848 
- update the Ubuntu version in the Vagrantfile to a supported release.

### What issues does this PR fix or reference?
#1105 

### Previous Behavior

`salt-bootstrap.sh -F` caused overwrite of the minion config, but not the keys.

sh salt-bootstrap.sh failed with 
```
 $ sudo sh salt-bootstrap.sh -A salt.2txt.us -i sb1
 *  INFO: Running version: 2017.05.24
 *  INFO: Executed by: sh
 *  INFO: Command line: 'salt-bootstrap.sh -A salt.2txt.us -i sb1'
 *  WARN: Running the unstable version of bootstrap-salt.sh

 *  INFO: System Information:
 *  INFO:   CPU:          GenuineIntel
 *  INFO:   CPU Arch:     x86_64
 *  INFO:   OS Name:      Linux
 *  INFO:   OS Version:   3.2.0-126-virtual
 *  INFO:   Distribution: Ubuntu 12.04

 * ERROR: End of life distributions are not supported.
 * ERROR: Please consider upgrading to the next stable. See:
 * ERROR:     https://wiki.ubuntu.com/Releases
```

### New Behavior
- Key files will be replaced, too.
- Can actually test using Vagrant
