### PR TITLE
Introductory support for Debian 10 (Buster)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -274,6 +274,17 @@ release instead.
 For example, when installing Salt on Ubuntu 16.10, the bootstrap script will setup the repository 
 for Ubuntu 16.04 from `SaltStack's Ubuntu repository`_ and install the 16.04 packages.
 
+Debian Best Effort Suppot: Testing Release
+******************************************
+
+This script provides best-effort support for the upcoming Debian testing release. Package
+repositories are not provided on `SaltStack's Debian repository`_ for Debian testing releases.
+However, the bootstrap script will attempt to install the packages for the current stable
+version of Debian.
+
+For example, when installing Salt on Debian 10 (Buster), the bootstrap script will setup the
+repository for Debian 9 (Stretch) from `SaltStack's Debian repository`_ and install the
+Debian 9 packages.
 
 Other Linux distro
 ~~~~~~~~~~~~~~~~~~
@@ -565,6 +576,7 @@ Salt is ready and working in the Docker container with Minion authenticated on M
 .. _`Salt`: https://saltstack.com/community/
 .. _`Salt's Supported Operating Systems`: http://saltstack.com/wp-content/uploads/2016/08/SaltStack-Supported-Operating-Systems.pdf
 .. _`SaltStack's corporate repository`: https://repo.saltstack.com/
+.. _`SaltStack's Debian repository`: http://repo.saltstack.com/#debian
 .. _`SaltStack's Ubuntu repository`: http://repo.saltstack.com/#ubuntu
 .. _Vagrant: http://www.vagrantup.com
 


### PR DESCRIPTION
This support relies on installing packages for Debian 9, similarly to what the non-LTS Ubuntu versions by installing LTS Ubuntu packages.

