### PR TITLE
use versions specified in base.txt when doing pip installs

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1131,7 +1131,7 @@ __install_python_and_deps() {
     _PIP_PACKAGES="tornado PyYAML msgpack-python jinja2 pycrypto zmq"
     if [ -f "${_SALT_GIT_CHECKOUT_DIR}/requirements/base.txt" ]; then
         for SINGLE_PACKAGE in $_PIP_PACKAGES; do
-            __REQUIRED_VERSION="$(grep ${SINGLE_PACKAGE} "${_SALT_GIT_CHECKOUT_DIR}/requirements/base.txt")"
+            __REQUIRED_VERSION="$(grep "${SINGLE_PACKAGE}" "${_SALT_GIT_CHECKOUT_DIR}/requirements/base.txt")"
             if [ "${__REQUIRED_VERSION}" != "" ]; then
                 _PIP_PACKAGES=$(echo "$_PIP_PACKAGES" | sed "s/${SINGLE_PACKAGE}/${__REQUIRED_VERSION}/")
             fi

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1129,6 +1129,14 @@ __install_python_and_deps() {
     __yum_install_noinput "${__PACKAGES}" || return 1
 
     _PIP_PACKAGES="tornado PyYAML msgpack-python jinja2 pycrypto zmq"
+    if [ -f "${_SALT_GIT_CHECKOUT_DIR}/requirements/base.txt" ]; then
+        for SINGLE_PACKAGE in $_PIP_PACKAGES; do
+            __REQUIRED_VERSION="$(grep ${SINGLE_PACKAGE} "${_SALT_GIT_CHECKOUT_DIR}/requirements/base.txt")"
+            if [ "${__REQUIRED_VERSION}" != "" ]; then
+                _PIP_PACKAGES="${_PIP_PACKAGES/$SINGLE_PACKAGE/$__REQUIRED_VERSION}"
+            fi
+        done
+    fi
     if [ "$_INSTALL_CLOUD" -eq $BS_TRUE ]; then
         _PIP_PACKAGES="${_PIP_PACKAGES} apache-libcloud"
     fi

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1133,7 +1133,7 @@ __install_python_and_deps() {
         for SINGLE_PACKAGE in $_PIP_PACKAGES; do
             __REQUIRED_VERSION="$(grep ${SINGLE_PACKAGE} "${_SALT_GIT_CHECKOUT_DIR}/requirements/base.txt")"
             if [ "${__REQUIRED_VERSION}" != "" ]; then
-                _PIP_PACKAGES="${_PIP_PACKAGES/$SINGLE_PACKAGE/$__REQUIRED_VERSION}"
+                _PIP_PACKAGES=$(echo "$_PIP_PACKAGES" | sed "s/${SINGLE_PACKAGE}/${__REQUIRED_VERSION}/")
             fi
         done
     fi


### PR DESCRIPTION
### What does this PR do?
when doing pip installs it checks the requirements/base.txt to make sure it's installing the correct version

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-bootstrap/issues/1115 was the reference, but it doesn't fix it entirely.

### Previous Behavior
pip install would just install a version, not necessarily the version specified.

