### PR TITLE
Remove the test that checks if the EPEL RPM was installed

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -3496,13 +3496,6 @@ __install_epel_repository() {
         return 0
     fi
 
-    # Check if epel-release is already installed and flag it accordingly
-    rpm --nodigest --nosignature -q epel-release > /dev/null 2>&1
-    if [ $? -eq 0 ]; then
-        _EPEL_REPOS_INSTALLED=$BS_TRUE
-        return 0
-    fi
-
     # Download latest 'epel-release' package for the distro version directly
     epel_repo_url="${HTTP_VAL}://dl.fedoraproject.org/pub/epel/epel-release-latest-${DISTRO_MAJOR_VERSION}.noarch.rpm"
     rpm -Uvh --force "$epel_repo_url" || return 1


### PR DESCRIPTION
### What does this PR do?
Remove the test that checks if the EPEL RPM was installed.

### What issues does this PR fix or reference?
Bootstrap would fail if the EPEL RPM had previously been installed, but the .repo files had been later deleted manually.

### Previous Behavior
The `__install_epel_repository()` function would check if the EPEL repos were configured.
If they were not, it would then check if the EPEL RPM had been installed.
If the RPM had previously been installed, the script would assume that the repos were configured properly and fail to install them.

The problem with this behavior is that the RPM could be installed, and the .repo files deleted. The script would then skip the EPEL configuration and the bootstrap would fail as a result.

### New Behavior
There is no benefit in checking if the EPEL RPM was installed or not. Checking if the repos are configured if sufficient to determine whether EPEL needs to be installed or not. This covers all cases:
 - EPEL installed from RPM
 - EPEL repos configured manually
 - EPEL not installed
 - EPEL installed from RPM, but .repo files removed manually
