### PR TITLE
Allow powershell bootstrap script to specify PY2 or 3

### DIFF
--- a/bootstrap-salt.ps1
+++ b/bootstrap-salt.ps1
@@ -237,17 +237,18 @@ If ([int]$year -lt 2017) {
 }
 Else {
     If ($pythonVersion -eq "3") {
-        $pythonVersion = "Py3-"
+        $pythonVersion = "-Py3"
     }
     Else {
-        $pythonVersion = "Py2-"
+        $pythonVersion = "-Py2"
     }
 }
+$versionSection = $version + $pythonVersion
 
 #===============================================================================
 # Download minion setup file
 #===============================================================================
-$saltExe = "Salt-Minion-$version-$pythonVersion$arch-Setup.exe"
+$saltExe = "Salt-Minion-$versionSection-$arch-Setup.exe"
 Write-Output "Downloading Salt minion installer $saltExe"
 $webclient = New-Object System.Net.WebClient
 $url = "$repourl/$saltExe"

--- a/bootstrap-salt.ps1
+++ b/bootstrap-salt.ps1
@@ -228,19 +228,20 @@ If (!$version) {
         $returnMatches = $returnMatches | Where {$_ -like "Salt-Minion*AMD64-Setup.exe"}
     }
 
-    $version = $($returnMatches[$returnMatches.Count -1]).Split(("n-","-A","-x"),([System.StringSplitOptions]::RemoveEmptyEntries))[1]
+    $version = $($returnMatches[$returnMatches.Count -1]).Split(("n-","-A","-x","-P"),([System.StringSplitOptions]::RemoveEmptyEntries))[1]
 }
 
-$year = $version.Substring(0, 3)
+$versionSection = $version
+
+$year = $version.Substring(0, 4)
 If ([int]$year -ge 2017) {
     If ($pythonVersion -eq "3") {
-        $pythonVersion = "-Py3"
+        $versionSection = "$version-Py3"
     }
     Else {
-        $pythonVersion = "-Py2"
+        $versionSection = "$version-Py2"
     }
 }
-$versionSection = $version + $pythonVersion
 
 #===============================================================================
 # Download minion setup file

--- a/bootstrap-salt.ps1
+++ b/bootstrap-salt.ps1
@@ -232,10 +232,7 @@ If (!$version) {
 }
 
 $year = $version.Substring(0, 3)
-If ([int]$year -lt 2017) {
-    $pythonVersion = ""
-}
-Else {
+If ([int]$year -ge 2017) {
     If ($pythonVersion -eq "3") {
         $pythonVersion = "-Py3"
     }

--- a/bootstrap-salt.ps1
+++ b/bootstrap-salt.ps1
@@ -13,8 +13,13 @@
     Runs without any parameters. Uses all the default values/settings.
 
 .EXAMPLE
-    ./bootstrap-salt.ps1 -version 2015.4.1-3
+    ./bootstrap-salt.ps1 -version 2017.7.0
     Specifies a particular version of the installer.
+
+.EXAMPLE
+    ./bootstrap-salt.ps1 -pythonVersion 3
+    Specifies the Python version of the installer. Can be "2" or "3". Defaults to "2".
+    Python 3 installers are only available for Salt 2017.7.0 and newer.
 
 .EXAMPLE
     ./bootstrap-salt.ps1 -runservice false
@@ -27,11 +32,17 @@
     installer values of host name for the minion id and "salt" for the master.
 
 .EXAMPLE
-    ./bootstrap-salt.ps1 -minion minion-box -master master-box -version 2015.5.2 -runservice false
+    ./bootstrap-salt.ps1 -minion minion-box -master master-box -version 2017.7.0 -runservice false
     Specifies all the optional parameters in no particular order.
 
 .PARAMETER version
     Default version defined in this script.
+
+.PARAMETER pythonVersion
+    The version of Python the installer should use. Specify either "2" or "3".
+    Beginning with Salt 2017.7.0, Salt will run on either Python 2 or Python 3.
+    The default is Python 2 if not specified. This parameter only works for Salt
+    versions >= 2017.7.0.
 
 .PARAMETER runservice
     Boolean flag to start or stop the minion service. True will start the minion
@@ -68,6 +79,11 @@ Param(
     # Doesn't support versions prior to "YYYY.M.R-B"
     [ValidatePattern('^201\d\.\d{1,2}\.\d{1,2}(\-\d{1})?|(rc\d)$')]
     [string]$version = '',
+
+    [Parameter(Mandatory=$false,ValueFromPipeline=$true)]
+    # Doesn't support versions prior to "2017.7.0"
+    [ValidateSet("2","3")]
+    [string]$pythonVersion = "",
 
     [Parameter(Mandatory=$false,ValueFromPipeline=$true)]
     [ValidateSet("true","false")]
@@ -113,6 +129,7 @@ If (!(Get-IsAdministrator)) {
         If($master -ne "not-specified") {$parameters = "$parameters -master $master"}
         If($runservice -eq $false) {$parameters = "$parameters -runservice false"}
         If($version -ne '') {$parameters = "$parameters -version $version"}
+        If($pythonVersion -ne "") {$parameters = "$parameters -pythonVersion $pythonVersion"}
         $newProcess.Arguments = $myInvocation.MyCommand.Definition, $parameters
 
         # Specify the current working directory
@@ -214,10 +231,23 @@ If (!$version) {
     $version = $($returnMatches[$returnMatches.Count -1]).Split(("n-","-A","-x"),([System.StringSplitOptions]::RemoveEmptyEntries))[1]
 }
 
+$year = $version.Substring(0, 3)
+If ([int]$year -lt 2017) {
+    $pythonVersion = ""
+}
+Else {
+    If ($pythonVersion -eq "3") {
+        $pythonVersion = "Py3-"
+    }
+    Else {
+        $pythonVersion = "Py2-"
+    }
+}
+
 #===============================================================================
 # Download minion setup file
 #===============================================================================
-$saltExe = "Salt-Minion-$version-$arch-Setup.exe"
+$saltExe = "Salt-Minion-$version-$pythonVersion$arch-Setup.exe"
 Write-Output "Downloading Salt minion installer $saltExe"
 $webclient = New-Object System.Net.WebClient
 $url = "$repourl/$saltExe"


### PR DESCRIPTION
### What does this PR do?
This fixes the links for installing 2017.7.0 on Windows. The executor link has changed to include a "Py2" or "Py3" section. It also allows the user to specify if the Py2 or Py3 executor should be used. This option only works for Salt >= 2017.7.0.

Example for Py2 (default behavior):
```
./bootstrap-salt.ps1 -pythonVersion 2
```

Example for Py3:
```
./bootstrap-salt.ps1 -pythonVersion 3
```

### What issues does this PR fix or reference?
Fixes #1119

### Previous Behavior
2017.7.0 installation (which is default stable now) fails because the executor links have changed to include a `Py2` or `Py3` option, and the installation fails.

### New Behavior
The links should be correct now for 2017.7.0 installations moving forward, but should also still have the correct links for Salt versions < 2107.7.0.

@twangboy Can you review this? I am not very good at powershell, nor do I have a box handy to test this on, so I wanted to get your eyes on this.