### PR TITLE
Only install Python version if "-y" is defined

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -3697,7 +3697,8 @@ install_centos_git_deps() {
 
         __install_pip_pkgs "${_PIP_PACKAGES}" "${_PY_EXE}" || return 1
     else
-        __yum_install_noinput "${__PACKAGES}" || return 1
+        # shellcheck disable=SC2086
+        __yum_install_noinput ${__PACKAGES} || return 1
     fi
 
     # Let's trigger config_salt()


### PR DESCRIPTION
### What does this PR do?
Allows the `-x` option to be used _without_ the `-y` option. This is useful in situations where the ius-community repo and related Python version is already installed, but the pip packages still need to be installed.

Previously, both the `-x` and `-y` options were both required to run the Python installation and the pip dependency installation. This PR splits out the `-y` option requirement when `-x` is passed. That way, the `-y` option can be left off if the required python version and ius repo is already installed. Note that for the `-y` option being passed, `-x` is still required.

### What issues does this PR fix or reference?
Fixes #1121

### Previous Behavior
If the IUS repo was already installed (from a previous bootstrap run, or otherwise), the bootstrap script would error out on the next run:
```
INFO: Cloning Salt's git repository succeeded
INFO: Attempting to install a repo to help provide a separate python package
INFO: centos
INFO: Installing IUS repo
Loaded plugins: fastestmirror
Setting up Install Process
Examining /var/tmp/yum-root-WwmIVv/ius-release.rpm: ius-release-1.0-15.ius.centos6.noarch
/var/tmp/yum-root-WwmIVv/ius-release.rpm: does not update installed package.
Error: Nothing to do
ERROR: Failed to run install_centos_git_deps()!!!
DEBUG: Cleaning up the Salt Temporary Git Repository
DEBUG: Removing the logging pipe /tmp/bootstrap-salt.logpipe
```

### New Behavior
The `-y` option is no longer required to trigger the pip installation using the python version defined with `-x`.

Example to install Python:
```
./bootstrap-salt.sh -y -x Python2.7 git v2017.7.0
```
Example to install pip dependencies where Python2.7 already exists on the VM:
```
./bootstrap-salt.sh -x Python2.7 git v2017.7.0
```

@Ch3LL Can you review this PR since this touches code that you added recently?