### PR TITLE
Declare EOL for openSUSE releases earlier and including 13.X

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -261,7 +261,6 @@ Red Hat family
 SUSE family
 ~~~~~~~~~~~
 
-- openSUSE 12/13
 - openSUSE Leap 42
 - openSUSE Tumbleweed 2015
 - SUSE Linux Enterprise Server 11 SP1/11 SP2/11 SP3/12

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1517,8 +1517,8 @@ __check_end_of_life_versions() {
         opensuse)
             # openSUSE versions not supported
             #
-            #  <= 12.1
-            if ([ "$DISTRO_MAJOR_VERSION" -eq 12 ] && [ "$DISTRO_MINOR_VERSION" -eq 1 ]) || [ "$DISTRO_MAJOR_VERSION" -lt 12 ]; then
+            #  <= 13.X
+            if [ "$DISTRO_MAJOR_VERSION" -le 13 ]; then
                 echoerror "End of life distributions are not supported."
                 echoerror "Please consider upgrading to the next stable. See:"
                 echoerror "    http://en.opensuse.org/Lifetime"


### PR DESCRIPTION
Upstream support for openSUSE release 13.2 has been discontinued at Jan 17th 2017.