### PR TITLE
Fix #1138: git install on Debian/Ubuntu various arches

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2641,9 +2641,8 @@ install_ubuntu_stable_deps() {
         __apt_get_upgrade_noinput || return 1
     fi
 
-    __check_dpkg_architecture || return 1
-
     if [ "$_DISABLE_REPOS" -eq "$BS_FALSE" ] || [ "$_CUSTOM_REPO_URL" != "null" ]; then
+        __check_dpkg_architecture || return 1
         __install_saltstack_ubuntu_repository || return 1
     fi
 
@@ -2971,8 +2970,6 @@ install_debian_deps() {
         __apt_get_upgrade_noinput || return 1
     fi
 
-    __check_dpkg_architecture || return 1
-
     # Additionally install procps and pciutils which allows for Docker bootstraps. See 366#issuecomment-39666813
     __PACKAGES='procps pciutils'
 
@@ -2988,6 +2985,7 @@ install_debian_deps() {
     __apt_get_install_noinput ${__PACKAGES} || return 1
 
     if [ "$_DISABLE_REPOS" -eq "$BS_FALSE" ] || [ "$_CUSTOM_REPO_URL" != "null" ]; then
+        __check_dpkg_architecture || return 1
         __install_saltstack_debian_repository || return 1
     fi
 


### PR DESCRIPTION
### What does this PR do?
It allows `git` installation mode to work on any architectures across Debian, Ubuntu and their derivatives.

### What issues does this PR fix or reference?
Fixes #1138

### Previous Behavior
The scripts always tries to guess proper packages compiled for target system architecture.

### New Behavior
The script detects architecture only when installation from SaltStack's repo is enabled (which is default) or when custom repo URL provided.

