### PR TITLE
fedora: use dnf-utils for F26 and above

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -3319,7 +3319,13 @@ install_fedora_deps() {
         __install_saltstack_copr_salt_repository || return 1
     fi
 
-    __PACKAGES="yum-utils PyYAML libyaml python-crypto python-jinja2 python-zmq python2-msgpack python2-requests"
+    __PACKAGES="PyYAML libyaml python-crypto python-jinja2 python-zmq python2-msgpack python2-requests"
+
+    if [ "$DISTRO_MAJOR_VERSION" -lt 26 ]; then
+        __PACKAGES="${__PACKAGES} yum-utils"
+    else
+        __PACKAGES="${__PACKAGES} dnf-utils"
+    fi
 
     # shellcheck disable=SC2086
     dnf install -y ${__PACKAGES} || return 1


### PR DESCRIPTION
### What does this PR do?
install dnf-utils instead of yum-utils for Fedora 26 and above

### What issues does this PR fix or reference?
dnf-utils is mandatory for installation of salt* 2017* otherwise currently an older version gets installed

### Previous Behavior
older version of salt is installed

### New Behavior
latest version is installed

