### PR TITLE
Follow symlinks when parsing distro release files

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1002,7 +1002,6 @@ __gather_linux_system_info() {
             echo redhat-release lsb-release
             )"); do
 
-        [ -L "/etc/${rsource}" ] && continue        # Don't follow symlinks
         [ ! -f "/etc/${rsource}" ] && continue      # Does not exist
 
         n=$(echo "${rsource}" | sed -e 's/[_-]release$//' -e 's/[_-]version$//')


### PR DESCRIPTION
### What does this PR do?
It enables `__gather_linux_system_info()` function to follow symlinks while it parses distribution release files to extract necessary information.
This is required because some distros (spotted on Debian 9) and their multiple derivatives have at least `/etc/os-release` file symlinked to `../usr/lib/os-release`.

### Previous Behavior
The script ignored data from release file which are symlinks.

### New Behavior
The script gathers distro data correctly.

