### PR TITLE
Fix #1142: allow git install on Raspbian 9

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -206,7 +206,7 @@ listed on the official supported operating systems document, the level of suppor
 Since Salt is written in Python, the packages available from `SaltStack's corporate repository`_
 are CPU architecture independent and could be installed on any hardware supported by Linux kernel.
 However, SaltStack does package Salt's binary dependencies only for ``x86_64`` (``amd64``) and
-``AArch32`` (``armhf``), which is limited for Debian/Raspbian 8 platforms.
+``AArch32`` (``armhf``). The latter is available only for Debian/Raspbian 8 platforms.
 
 It is recommended to use ``git`` bootstrap mode as described above to install Salt on other
 architectures, such as ``x86`` (``i386``), ``AArch64`` (``arm64``) or ``ARM EABI`` (``armel``).
@@ -232,7 +232,7 @@ Debian and derivatives
 - Debian GNU/Linux 7/8/9
 - Linux Mint Debian Edition 1 (based on Debian 8)
 - Kali Linux 1.0 (based on Debian 7)
-- Raspbian 8 (``armhf``)
+- Raspbian 8 (``armhf`` packages) and 9 (using ``git`` installation mode only)
 
 Debian Best Effort Support: Testing Release
 *******************************************

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1408,6 +1408,7 @@ __debian_derivatives_translation() {
     kali_1_debian_base="7.0"
     linuxmint_1_debian_base="8.0"
     raspbian_8_debian_base="8.0"
+    raspbian_9_debian_base="9.0"
 
     # Translate Debian derivatives to their base Debian version
     match=$(echo "$DISTRO_NAME_L" | egrep ${DEBIAN_DERIVATIVES})
@@ -1432,7 +1433,7 @@ __debian_derivatives_translation() {
                 ;;
         esac
 
-        _debian_version=$(eval echo "\$${_debian_derivative}_${_major}_debian_base")
+        _debian_version=$(eval echo "\$${_debian_derivative}_${_major}_debian_base" 2>/dev/null)
 
         if [ "$_debian_version" != "" ]; then
             echodebug "Detected Debian $_debian_version derivative"


### PR DESCRIPTION
### What does this PR do?
It enables Salt bootstrapping on Raspbian 9 "stretch" using `git` installation mode. 

### What issues does this PR fix or reference?
#1142 

### Previous Behavior
Raspbian 9 was not detected as variant of Debian.

### New Behavior
It is now possible to bootstrap Raspbian 9 using:
```sh
sh bootstrap-salt.sh -r -P git 2017.7
```
