### PR TITLE
Declare EOL for SUSE Linux Enterprise Server releases

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -264,7 +264,7 @@ SUSE family
 
 - openSUSE Leap 42.2/42.3
 - openSUSE Tumbleweed 2015
-- SUSE Linux Enterprise Server 11 SP1/11 SP2/11 SP3/12
+- SUSE Linux Enterprise Server 11 SP4/12
 
 
 Ubuntu and derivatives

--- a/README.rst
+++ b/README.rst
@@ -264,7 +264,7 @@ SUSE family
 
 - openSUSE Leap 42.2/42.3
 - openSUSE Tumbleweed 2015
-- SUSE Linux Enterprise Server 11 SP4/12
+- SUSE Linux Enterprise Server 11 SP4/12 SP2
 
 
 Ubuntu and derivatives

--- a/README.rst
+++ b/README.rst
@@ -264,7 +264,7 @@ SUSE family
 
 - openSUSE Leap 42.2/42.3
 - openSUSE Tumbleweed 2015
-- SUSE Linux Enterprise Server 11 SP4/12 SP2
+- SUSE Linux Enterprise Server 11 SP4, 12 SP2
 
 
 Ubuntu and derivatives

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1531,6 +1531,7 @@ __check_end_of_life_versions() {
                 ([ "$DISTRO_MAJOR_VERSION" -eq 12 ] && [ "$SUSE_PATCHLEVEL" -lt 02 ]); then
                 echoerror "Versions lower than SuSE 11 SP4 or 12 SP2 are not supported."
                 echoerror "Please consider upgrading to the next stable"
+                echoerror "    https://www.suse.com/lifecycle/"
                 exit 1
             fi
             ;;

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1520,13 +1520,13 @@ __check_end_of_life_versions() {
         suse)
             # SuSE versions not supported
             #
-            # < 11 SP2
+            # < 11 SP4
             SUSE_PATCHLEVEL=$(awk '/PATCHLEVEL/ {print $3}' /etc/SuSE-release )
             if [ "${SUSE_PATCHLEVEL}" = "" ]; then
                 SUSE_PATCHLEVEL="00"
             fi
-            if ([ "$DISTRO_MAJOR_VERSION" -eq 11 ] && [ "$SUSE_PATCHLEVEL" -lt 02 ]) || [ "$DISTRO_MAJOR_VERSION" -lt 11 ]; then
-                echoerror "Versions lower than SuSE 11 SP2 are not supported."
+            if ([ "$DISTRO_MAJOR_VERSION" -eq 11 ] && [ "$SUSE_PATCHLEVEL" -lt 04 ]) || [ "$DISTRO_MAJOR_VERSION" -lt 11 ]; then
+                echoerror "Versions lower than SuSE 11 SP4 are not supported."
                 echoerror "Please consider upgrading to the next stable"
                 exit 1
             fi

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1521,12 +1521,15 @@ __check_end_of_life_versions() {
             # SuSE versions not supported
             #
             # < 11 SP4
+            # < 12 SP2
             SUSE_PATCHLEVEL=$(awk '/PATCHLEVEL/ {print $3}' /etc/SuSE-release )
             if [ "${SUSE_PATCHLEVEL}" = "" ]; then
                 SUSE_PATCHLEVEL="00"
             fi
-            if ([ "$DISTRO_MAJOR_VERSION" -eq 11 ] && [ "$SUSE_PATCHLEVEL" -lt 04 ]) || [ "$DISTRO_MAJOR_VERSION" -lt 11 ]; then
-                echoerror "Versions lower than SuSE 11 SP4 are not supported."
+            if [ "$DISTRO_MAJOR_VERSION" -lt 11 ] || \
+                ([ "$DISTRO_MAJOR_VERSION" -eq 11 ] && [ "$SUSE_PATCHLEVEL" -lt 04 ]) || \
+                ([ "$DISTRO_MAJOR_VERSION" -eq 12 ] && [ "$SUSE_PATCHLEVEL" -lt 02 ]); then
+                echoerror "Versions lower than SuSE 11 SP4 or 12 SP2 are not supported."
                 echoerror "Please consider upgrading to the next stable"
                 exit 1
             fi


### PR DESCRIPTION
### What does this PR do?
It drops support for SUSE versions less than **11 SP4** and for release 12 everything below SP2.