### PR TITLE
priority sort fedora-release

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -920,7 +920,7 @@ __sort_release_files() {
     done
 
     # Now let's sort by know files importance, max important goes last in the max_prio list
-    max_prio="redhat-release centos-release oracle-release"
+    max_prio="redhat-release centos-release oracle-release fedora-release"
     for entry in $max_prio; do
         if [ "$(echo "${primary_release_files}" | grep "$entry")" != "" ]; then
             primary_release_files=$(echo "${primary_release_files}" | sed -e "s:\(.*\)\($entry\)\(.*\):\2 \1 \3:g")


### PR DESCRIPTION
During __sort_release_files release files are sorted. Fedora is
currently identified as redhat-release. This PR adds fedora-release
to the max_prio list to priorize this higher than redhat-release.