### PR TITLE
Use suse repo to install packages, rather than defining them

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -5425,7 +5425,7 @@ __set_suse_pkg_repo() {
 
 __check_and_refresh_suse_pkg_repo() {
     # Check to see if systemsmanagement_saltstack exists
-    __zypper repos | grep systemsmanagement_saltstack >/dev/null 2>&1
+    __zypper repos | grep -q systemsmanagement_saltstack
 
     if [ $? -eq 1 ]; then
         # zypper does not yet know anything about systemsmanagement_saltstack


### PR DESCRIPTION
### What does this PR do?
Refactors much of the SLES and SUSE support to follow some of the more established distro install paradigms.

Since we're setting up suse's package repo above, we should rely on that instead of defining each package explicitly in the `stable` installation functions.

The git installation functions however, still have those packages defined as is customary in other distributions' git install funcs. The relevant packages that weren't already installed with the `stable` function installs have been moved to the `git` install functions.

This change builds on the work done in #1156, #1150, and #1143.

### What issues does this PR fix or reference?
Fixes #714
Refs #1066

### Previous Behavior
Support for SLES 11 wasn't working, and SLES 12 support was only partially working

### New Behavior
SLES 11 SP 4 and SLES 12 SP 2 now work correctly and the code is much cleaner.

Tested on:
- SLES 11 SP4 (stable & git)
- SLES 12 SP2 (stable & git)
- Leap 42.2 (stable & git)