### PR TITLE
Use tabs consistently in ChangeLog

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -32,47 +32,47 @@ Version 2017.08.17:
     * Declare End-Of-Life for Ubuntu 12.04 LTS (vutny) #1080
 
 Version 2017.05.24:
-	* Use freebsd repo to query for salt dependencies (Ch3LL) #1076
-	* Allow amazon to work with python2.7 on installs over 2016.11 (Ch3LL) #1073
-	* ensure sles12 enables services with stable installs (Ch3LL) #1075
-	* Declare End-of-Life for RHEL 5 and its variants (vutny) #1070
-	* Fix configuring SaltStack's repo URL for RHEL variants (vutny) #1068
-	* Add Manjaro as Arch derivative (luthes) #1063
-	* Add "unmarkComment" option to probot-stale config (rallytime) #1064
-	* Properly detect all supported Debian GNU/Linux derivatives (vutny) #1062
-	* Archlinux must always update (gtmanfred) #1060
-	* Alpine: fix adding, checking and running Salt Syndic in stable mode (vutny) #1059
-	* Add KDE neon... (EHJ-52n) #1058
-	* Update probot-stale message formatting. (rallytime) #1057
-	* Fix `git` bootstrap mode for CentOS (vutny) #1054
-	* update install_freebsd_10_stable to use FreeBSD repo (bytesatwork-xx) #1053
-	* Support OpenBSD 6.1 (eradman) #1048
-	* Update daysUntilStale value in probot-stale config (rallytime) #1055
-	* Add ability to install and use a different python version when installing salt (Ch3LL) #1049
-	* Add non-LTS type support for Ubuntu 17.04 (rallytime) #1051
-	* Allow -R option to work for Debian/Ubuntu (rallytime) #1045
-	* Adjust "daysUntilStale" variable to 190 days. #1047
-	* Reduce the number of days an issue is considered "stale" (rallytime) #1046
-	* Alpine: fix bootstrapping from Git -- install OpenRC initscripts (vutny) #1044
-	* Add probot-stale config file (rallytime) #1042
-	* Shallow cloning and Python setup fix for BSD (amontalban) #1040
-	* Fix not needed quoting for salt/salt-bootstrap#1026 (amontalban) #1039
-	* Update README file with supported release documentation (rallytime) #1034
-	* Remove <<< bashism (The-Loeki) #1032
-	* [-R option] Fix logic error where we trying to enable epel with -R (rallytime) #1033
-	* Alpine: check Salt services have been enabled to start on boot (vutny) #1031
-	* AWS Linux Native Support (bkruger99) #1022
-	* Correct package name for FreeBSD installation (amontalban) #1030
-	* README: describe architectures support for Salt deps on Linux distros (vutny) #1029
-	* This commit addresses some of the issues in salt/salt-bootstrap#996 (amontalban) #1026
-	* Add support for stable installation on Alpine Linux release 3.5 (vutny) #1028
-	* Alpine Linux: fix installation of multiple pkgs ("stable" bootstrap) (vutny) #1027
-	* Add Void Linux support (ndrwdn) #1025
-	* RHEL6: disable stdin to fix shell session hang on killing tee pipe (vutny) #1018
-	* Adding 2016.11 to stable version (ashokrajar) #1017
-	* Update bootstrap-salt.sh (caelor) #1015
-	* Alpine Linux support #1009 (ek9) #1010
-	* Add Table of Contents in README (vutny) #1014
+    * Use freebsd repo to query for salt dependencies (Ch3LL) #1076
+    * Allow amazon to work with python2.7 on installs over 2016.11 (Ch3LL) #1073
+    * ensure sles12 enables services with stable installs (Ch3LL) #1075
+    * Declare End-of-Life for RHEL 5 and its variants (vutny) #1070
+    * Fix configuring SaltStack's repo URL for RHEL variants (vutny) #1068
+    * Add Manjaro as Arch derivative (luthes) #1063
+    * Add "unmarkComment" option to probot-stale config (rallytime) #1064
+    * Properly detect all supported Debian GNU/Linux derivatives (vutny) #1062
+    * Archlinux must always update (gtmanfred) #1060
+    * Alpine: fix adding, checking and running Salt Syndic in stable mode (vutny) #1059
+    * Add KDE neon... (EHJ-52n) #1058
+    * Update probot-stale message formatting. (rallytime) #1057
+    * Fix `git` bootstrap mode for CentOS (vutny) #1054
+    * update install_freebsd_10_stable to use FreeBSD repo (bytesatwork-xx) #1053
+    * Support OpenBSD 6.1 (eradman) #1048
+    * Update daysUntilStale value in probot-stale config (rallytime) #1055
+    * Add ability to install and use a different python version when installing salt (Ch3LL) #1049
+    * Add non-LTS type support for Ubuntu 17.04 (rallytime) #1051
+    * Allow -R option to work for Debian/Ubuntu (rallytime) #1045
+    * Adjust "daysUntilStale" variable to 190 days. #1047
+    * Reduce the number of days an issue is considered "stale" (rallytime) #1046
+    * Alpine: fix bootstrapping from Git -- install OpenRC initscripts (vutny) #1044
+    * Add probot-stale config file (rallytime) #1042
+    * Shallow cloning and Python setup fix for BSD (amontalban) #1040
+    * Fix not needed quoting for salt/salt-bootstrap#1026 (amontalban) #1039
+    * Update README file with supported release documentation (rallytime) #1034
+    * Remove <<< bashism (The-Loeki) #1032
+    * [-R option] Fix logic error where we trying to enable epel with -R (rallytime) #1033
+    * Alpine: check Salt services have been enabled to start on boot (vutny) #1031
+    * AWS Linux Native Support (bkruger99) #1022
+    * Correct package name for FreeBSD installation (amontalban) #1030
+    * README: describe architectures support for Salt deps on Linux distros (vutny) #1029
+    * This commit addresses some of the issues in salt/salt-bootstrap#996 (amontalban) #1026
+    * Add support for stable installation on Alpine Linux release 3.5 (vutny) #1028
+    * Alpine Linux: fix installation of multiple pkgs ("stable" bootstrap) (vutny) #1027
+    * Add Void Linux support (ndrwdn) #1025
+    * RHEL6: disable stdin to fix shell session hang on killing tee pipe (vutny) #1018
+    * Adding 2016.11 to stable version (ashokrajar) #1017
+    * Update bootstrap-salt.sh (caelor) #1015
+    * Alpine Linux support #1009 (ek9) #1010
+    * Add Table of Contents in README (vutny) #1014
 
 Version 2017.01.10:
     * Update AUTHORS.rst with new contributors (rallytime) #1011
@@ -172,486 +172,486 @@ Version 2016.05.10:
     * Fix Amazon Linux EOL check. (vutny) #818
 
 Version 2016.04.18:
-	* Add support for openSUSE Leap. Thanks Roman Inflianskas(rominf). #693
-	* Fix missing deps installation on Debian. Thanks  Steve Groesz(wolfpackmars2). #699
-	* Update SaltStack repo location and latest version for Windows. (brandon099) #711
-	* Better EPEL repository detection on RHEL and CentOS. (vutny) #717
-	* Fix git invocation fail when `man` command is not available. (vutny) #718
-	* Fix `epel-release` package installation on CentOS/RHEL 5. (vutny) #719
-	* Removed deprecated cli option. (abednarik) #705
-	* Remove RHEL optional repo check and enable. (vutny) #720
-	* Remove SaltStack COPR repository configuration for CentOS/RHEL5. (vutny) #721
-	* Add opensuse_Tumbleweed support. (aboe76) #725
-	* Sometimes bootstrap doesn't install zmq. (jtand) #726
-	* Process -s (default sleep for service restarts) in bootstrap-salt.sh. (hipikat) #692
-	* Minion keys and /etc/salt/minion should be overwritten on -C. (cro) #541
-	* Fix for -C (_CONFIG_ONLY). (beaucephus) #544
-	* Fix when using upstream tags. (The-Loeki) #564
-	* COPR project moved. (rmohr) #738
-	* Update license year range. (pra85) #743
-	* Use POSIX-Compliant Command-Exists Test. (kojiromike) #741
-	* Add -f option to force shallow cloning. (eyj) #660
-	* add SLE 12 support, fix OpenSUSE support. (grep4linux) #748
-	* Fix CentOS git setup.py syntax error upon installation. (The-Loeki) #746
-	* Enable shallow cloning for version branches by default, not only tags. (vutny) #750
-	* do not install copr repo on fedora 22+. (toanju) #751
-	* Add support for pegged versions on YUM based OS'ses through repo.saltstack.com. (The-Loeki) #685
-	* fix for FreeBSD 11 CURRENT install functions. (serge-p) #723
-	* Don't add zypp repo if it already exists. (furlongm) #731
-	* switch repositories for suse and sles fixes `#706`_. (aboe76) #734
-	* Reformat and correct usage instructions. (vutny) #755
-	* fixed missing repo for suse 12. (aboe76) #756
-	* fix for Amazon Linux. (shawnbutts) #700
-	* adding support for OpenBSD distribution. (serge-p) #722
-	* fixing syntax errors. (beardedeagle) #760
-	* Import CentOS 7 GPG key on RHEL for installing base dependencies from Salt corp repo. (vutny) #765
-	* Fix multiple lint errors (shellcheck) and make some refactoring. (vutny) #768
-	* Fix sleep time option to recognize a numeric argument. (vutny) #771
-	* Update README. (vutny) #787
-	* get tornado from pip on a fedora git install. (jfindlay) #785
-	* Remove the Saltstack repo's alias. (cro) #794
-	* Ability to change cache dir. (clarkperkins) #761
-	* Add config_freebsd_salt func so freebsd puts cfgs in the right place. (ryanwalder) #779
-	* Allow archive versions. (clarkperkins) #769
-	* Lack of HTTPS for RPM packages. (jaredestroud) #783
-	* Ability to change cache dir. (clarkperkins) #761
-	* Bootstrap on Docker. (vutny) #793
-	* add downstream pkg repo for SUSE. (jfindlay) #791
-	* Fixed use of HTTP over HTTPS for anonscm.debian.org. (gdm85) #788
-	* Bump Salt version to latest stable in PS bootstrap script for Windows. (vutny) #801
-	* Add an -l option to switch https to http links. (rallytime) #795
-	* Virtualenv support for Ubuntu. (l2ol33rt) #666
-	* Lint. (jfindlay) #805
-	* use portable command check. (jfindlay) #806
-	* Update epel-release version number (RuriRyan) #809
+    * Add support for openSUSE Leap. Thanks Roman Inflianskas(rominf). #693
+    * Fix missing deps installation on Debian. Thanks  Steve Groesz(wolfpackmars2). #699
+    * Update SaltStack repo location and latest version for Windows. (brandon099) #711
+    * Better EPEL repository detection on RHEL and CentOS. (vutny) #717
+    * Fix git invocation fail when `man` command is not available. (vutny) #718
+    * Fix `epel-release` package installation on CentOS/RHEL 5. (vutny) #719
+    * Removed deprecated cli option. (abednarik) #705
+    * Remove RHEL optional repo check and enable. (vutny) #720
+    * Remove SaltStack COPR repository configuration for CentOS/RHEL5. (vutny) #721
+    * Add opensuse_Tumbleweed support. (aboe76) #725
+    * Sometimes bootstrap doesn't install zmq. (jtand) #726
+    * Process -s (default sleep for service restarts) in bootstrap-salt.sh. (hipikat) #692
+    * Minion keys and /etc/salt/minion should be overwritten on -C. (cro) #541
+    * Fix for -C (_CONFIG_ONLY). (beaucephus) #544
+    * Fix when using upstream tags. (The-Loeki) #564
+    * COPR project moved. (rmohr) #738
+    * Update license year range. (pra85) #743
+    * Use POSIX-Compliant Command-Exists Test. (kojiromike) #741
+    * Add -f option to force shallow cloning. (eyj) #660
+    * add SLE 12 support, fix OpenSUSE support. (grep4linux) #748
+    * Fix CentOS git setup.py syntax error upon installation. (The-Loeki) #746
+    * Enable shallow cloning for version branches by default, not only tags. (vutny) #750
+    * do not install copr repo on fedora 22+. (toanju) #751
+    * Add support for pegged versions on YUM based OS'ses through repo.saltstack.com. (The-Loeki) #685
+    * fix for FreeBSD 11 CURRENT install functions. (serge-p) #723
+    * Don't add zypp repo if it already exists. (furlongm) #731
+    * switch repositories for suse and sles fixes `#706`_. (aboe76) #734
+    * Reformat and correct usage instructions. (vutny) #755
+    * fixed missing repo for suse 12. (aboe76) #756
+    * fix for Amazon Linux. (shawnbutts) #700
+    * adding support for OpenBSD distribution. (serge-p) #722
+    * fixing syntax errors. (beardedeagle) #760
+    * Import CentOS 7 GPG key on RHEL for installing base dependencies from Salt corp repo. (vutny) #765
+    * Fix multiple lint errors (shellcheck) and make some refactoring. (vutny) #768
+    * Fix sleep time option to recognize a numeric argument. (vutny) #771
+    * Update README. (vutny) #787
+    * get tornado from pip on a fedora git install. (jfindlay) #785
+    * Remove the Saltstack repo's alias. (cro) #794
+    * Ability to change cache dir. (clarkperkins) #761
+    * Add config_freebsd_salt func so freebsd puts cfgs in the right place. (ryanwalder) #779
+    * Allow archive versions. (clarkperkins) #769
+    * Lack of HTTPS for RPM packages. (jaredestroud) #783
+    * Ability to change cache dir. (clarkperkins) #761
+    * Bootstrap on Docker. (vutny) #793
+    * add downstream pkg repo for SUSE. (jfindlay) #791
+    * Fixed use of HTTP over HTTPS for anonscm.debian.org. (gdm85) #788
+    * Bump Salt version to latest stable in PS bootstrap script for Windows. (vutny) #801
+    * Add an -l option to switch https to http links. (rallytime) #795
+    * Virtualenv support for Ubuntu. (l2ol33rt) #666
+    * Lint. (jfindlay) #805
+    * use portable command check. (jfindlay) #806
+    * Update epel-release version number (RuriRyan) #809
 
 
 Version 2015.11.09
-	* Make sure that wget is installed. #868
+    * Make sure that wget is installed. #868
 
 
 Version 2015.11.04:
-	* Allow bypassing dependencies installation. Thanks EYJ. #656.
-	* Add FreeBSD 11 support. Thanks Chris Buechler(cbuechler). #653
-	* Move RHEL installations to use repo.saltstack.com #674
-	* Move Debian 8 installation to use repo.saltstack.com #674
-	* Fix error finding python-jinja2 in RHEL 7. Thanks Rob Eden(hedinfaok). #654
-	* Move Ubuntu 12 and 14 installations to use repo.saltstack.com #674
-	* Move FreeBSD installations to use repo.saltstack.com #674
-	* Use dnf on Fedora 22 and later. Thanks Michele Bologna (mbologna). #665
+    * Allow bypassing dependencies installation. Thanks EYJ. #656.
+    * Add FreeBSD 11 support. Thanks Chris Buechler(cbuechler). #653
+    * Move RHEL installations to use repo.saltstack.com #674
+    * Move Debian 8 installation to use repo.saltstack.com #674
+    * Fix error finding python-jinja2 in RHEL 7. Thanks Rob Eden(hedinfaok). #654
+    * Move Ubuntu 12 and 14 installations to use repo.saltstack.com #674
+    * Move FreeBSD installations to use repo.saltstack.com #674
+    * Use dnf on Fedora 22 and later. Thanks Michele Bologna (mbologna). #665
 
 
 Version 2015.08.06:
-	* Fix python-requests installations for Ubuntu >= 14.04 LTS. #631, #632, #633
-	* Install python-crypto from Chris Lea's PPA for Ubuntu < 14.04
-	* Exit the git checkout directory before deleting it. Thanks Bret Fisher. #634
-	* Use prefix /usr for centos git install. Thanks Stanislav B. #638
-	* Drop Ubuntu EOL versions. All Ubuntu version before 12.04.
-	* Make sure python-dev is installed wheb trying to install tornado from PyPi. #640
+    * Fix python-requests installations for Ubuntu >= 14.04 LTS. #631, #632, #633
+    * Install python-crypto from Chris Lea's PPA for Ubuntu < 14.04
+    * Exit the git checkout directory before deleting it. Thanks Bret Fisher. #634
+    * Use prefix /usr for centos git install. Thanks Stanislav B. #638
+    * Drop Ubuntu EOL versions. All Ubuntu version before 12.04.
+    * Make sure python-dev is installed wheb trying to install tornado from PyPi. #640
 
 
 Version 2015.07.22:
-	* Fix tornado installation in Ubuntu. Thanks Yushi Nakai. #627
-	* Install tornado using pip on Ubuntu for Salt's v2015.8.xx onward stable releases.
-	* Install requests on Ubuntu from Chris Lea's PPA. #630
+    * Fix tornado installation in Ubuntu. Thanks Yushi Nakai. #627
+    * Install tornado using pip on Ubuntu for Salt's v2015.8.xx onward stable releases.
+    * Install requests on Ubuntu from Chris Lea's PPA. #630
 
 Version 2015.07.17:
-	* Make sure setuptools is installed before using it. #598.
-	* `systemd` is only fully supported from 15.04 onwards. #602
-	* Fix debian mirrors issue. Thanks Wolodja Wentland(babilen). #606
-	* Fix python-jinja2 repo move on RHEL6. Thanks lomeroe. #621
-	* Allow skipping services. Thanks denmat. #455
-	* Fix missing Debian init script. #607 saltstack/salt#25270 and saltstack/salt#25456
-	* Fix SmartOS etc path. Thanks Bret Fisher. #624
-	* Fix possible unbound variable in Gentoo. #625
-	* Properly detect the git binary in SmartOS. #611
+    * Make sure setuptools is installed before using it. #598.
+    * `systemd` is only fully supported from 15.04 onwards. #602
+    * Fix debian mirrors issue. Thanks Wolodja Wentland(babilen). #606
+    * Fix python-jinja2 repo move on RHEL6. Thanks lomeroe. #621
+    * Allow skipping services. Thanks denmat. #455
+    * Fix missing Debian init script. #607 saltstack/salt#25270 and saltstack/salt#25456
+    * Fix SmartOS etc path. Thanks Bret Fisher. #624
+    * Fix possible unbound variable in Gentoo. #625
+    * Properly detect the git binary in SmartOS. #611
 
 Version 2015.05.07:
-	* Lower required requests version dependency. Use system requests package where possible.
-	* Allow Ubuntu alternate ppas. Thanks Peter Tripp(notpeter). #563
+    * Lower required requests version dependency. Use system requests package where possible.
+    * Allow Ubuntu alternate ppas. Thanks Peter Tripp(notpeter). #563
 
 Version 2015.05.04:
-	* Fix the configuration path for FreeBSD. #567/#552. Thanks Ronald van Zantvoort(The-Loeki).
-	+ Fix non grouping support in POSIX sed. Thanks Ronald van Zantvoort(The-Loeki).
-	* Add Debian 8 support. Thanks Matt Black(mafrosis)
-	* Improve Debian version parsing. Thanks Mark Lee(malept)
-	* Make sure we update packages list one Chris Lea's PPA repository is added.
-	* Hard code the Debian Squeeze backports to the DE mirror since the main repository is down.  
-	Thanks @panticz. #589.
-	* Only install git if not already installed. #560
-	* Fix openSUSE 13.2 where we need to pass --replaceflags. Thanks Roman Inflianskas(rominf).  
-	#504.
-	* Make sure that a recent enough requests package is installed in Debian/Ubuntu.
-	* Install tornado on git installs for the develop branch if necessary. #580
-	* Add support for Ubuntu 15.04
+    * Fix the configuration path for FreeBSD. #567/#552. Thanks Ronald van Zantvoort(The-Loeki).
+    + Fix non grouping support in POSIX sed. Thanks Ronald van Zantvoort(The-Loeki).
+    * Add Debian 8 support. Thanks Matt Black(mafrosis)
+    * Improve Debian version parsing. Thanks Mark Lee(malept)
+    * Make sure we update packages list one Chris Lea's PPA repository is added.
+    * Hard code the Debian Squeeze backports to the DE mirror since the main repository is down.  
+    Thanks @panticz. #589.
+    * Only install git if not already installed. #560
+    * Fix openSUSE 13.2 where we need to pass --replaceflags. Thanks Roman Inflianskas(rominf).  
+    #504.
+    * Make sure that a recent enough requests package is installed in Debian/Ubuntu.
+    * Install tornado on git installs for the develop branch if necessary. #580
+    * Add support for Ubuntu 15.04
 
 Version 2015.03.15:
-	* Add multi-master support. Thanks Fred Reimer(freimer). #555
+    * Add multi-master support. Thanks Fred Reimer(freimer). #555
 
 Version 2015.03.04:
-	* Fix the salt package selection on Arch stable installs.
+    * Fix the salt package selection on Arch stable installs.
 
 Version 2015.02.28:
-	* Fix Debian backports repository.
+    * Fix Debian backports repository.
 
 Version 2015.02.27:
-	* Try other tools besides wget when downloading the COPR repo file. Thanks Ronald van 
-	Zantvoort(The-Loeki)
-	* No need to install packages from the Unstable repository for debian, use backports. Thanks 
-	Ari Aosved(devaos)
-	* Fix an issue in CentOS where the syndic package wasn't being installed(since it's now a 
-	separate package). Thanks Ronald van Zantvoort(The-Loeki)
-	* Enable the server-optionals repository for RHEL >= 7
-	* RHEL/CentOS 5 now uses the COPR repository. #533
+    * Try other tools besides wget when downloading the COPR repo file. Thanks Ronald van 
+    Zantvoort(The-Loeki)
+    * No need to install packages from the Unstable repository for debian, use backports. Thanks 
+    Ari Aosved(devaos)
+    * Fix an issue in CentOS where the syndic package wasn't being installed(since it's now a 
+    separate package). Thanks Ronald van Zantvoort(The-Loeki)
+    * Enable the server-optionals repository for RHEL >= 7
+    * RHEL/CentOS 5 now uses the COPR repository. #533
 
 Version 2015.01.12:
-	* Add package upgrades support to FreeBSD. Thanks William Eshagh(eshagl).
-	* Make sure wget is installed on debian bare systems.
-	* Make sure the Arch pacman database is up to date
-	* Install `python-hashlib` in CentOS 5 in order to use the COPR repository
+    * Add package upgrades support to FreeBSD. Thanks William Eshagh(eshagl).
+    * Make sure wget is installed on debian bare systems.
+    * Make sure the Arch pacman database is up to date
+    * Install `python-hashlib` in CentOS 5 in order to use the COPR repository
 
 Version 2014.12.11:
-	* Enable binary installations on CentOS 7. Thanks ggillies
-	* Updated the URL for EPEL 7
+    * Enable binary installations on CentOS 7. Thanks ggillies
+    * Updated the URL for EPEL 7
 
 Version 2014.10.30:
-	* Apply the forking patch to openSUSE git installations.
+    * Apply the forking patch to openSUSE git installations.
 
 Version 2014.10.28:
-	* Install the python systemd bindings for Arch and Fedora git installations
-	* Allow cloning from Salt's git repository using HTTPS. #475
+    * Install the python systemd bindings for Arch and Fedora git installations
+    * Allow cloning from Salt's git repository using HTTPS. #475
 
 Version 2014.10.21:
-	* Fix path to python on FreeBSD. Thanks Pavel Snagovsky(paha)
-	* Fix syndic installation on RHEL based installations. Thanks markgaylard
-	* Properly detect the git checkout `basename` directory instead of hard coding it. Thanks
-	  Howard Mei(HowardMei).
-	* Allow installing ZMQ for SaltStack's COPR repository.
-	* Allow installing ZMQ4/PyZMQ14 from Chris Lea's PPA repository.
+    * Fix path to python on FreeBSD. Thanks Pavel Snagovsky(paha)
+    * Fix syndic installation on RHEL based installations. Thanks markgaylard
+    * Properly detect the git checkout `basename` directory instead of hard coding it. Thanks
+      Howard Mei(HowardMei).
+    * Allow installing ZMQ for SaltStack's COPR repository.
+    * Allow installing ZMQ4/PyZMQ14 from Chris Lea's PPA repository.
 
 Version 2014.10.14:
-	* Fixed a regex issue with matching Salt's tags. Match v2014.7 but not 2014.7 as a valid tag
-	* Distro Support Added:
-		* Added Linux Mint 17 support(Thanks Skyler Berg)
-	* Disrto Suuport Fixed:
-		* Init pacman keys if not done so previously
+    * Fixed a regex issue with matching Salt's tags. Match v2014.7 but not 2014.7 as a valid tag
+    * Distro Support Added:
+        * Added Linux Mint 17 support(Thanks Skyler Berg)
+    * Disrto Suuport Fixed:
+        * Init pacman keys if not done so previously
 
 Version 2014.09.25:
-	* Properly detect Amazon AMI's >= 2014.9. #468
+    * Properly detect Amazon AMI's >= 2014.9. #468
 
 Version 2014.09.09:
-	* Distro Support Fixes:
-		* Updated the URL for EPEL 7
-		* PIP based installations on Ubuntu 10.04 need setuptools installed
-		* Arch stopped providing the version information on `/etc/arch-release`
-		* Complete `salt-api` services checking. #450
+    * Distro Support Fixes:
+        * Updated the URL for EPEL 7
+        * PIP based installations on Ubuntu 10.04 need setuptools installed
+        * Arch stopped providing the version information on `/etc/arch-release`
+        * Complete `salt-api` services checking. #450
 
 Version 2014.08.30:
-	* Skip service checks for `salt-api`, since this should be an opt-in service not necessarily 
-	meant to start at boot time.
-	* Distro Support Fixes:
-		* Also install the salt-api service on RHEL based distributions for git based 
-		installations.
-		* Properly detect Arch Linux when lsb-release is available
-		* Updated the URL for EPEL 7
+    * Skip service checks for `salt-api`, since this should be an opt-in service not necessarily 
+    meant to start at boot time.
+    * Distro Support Fixes:
+        * Also install the salt-api service on RHEL based distributions for git based 
+        installations.
+        * Properly detect Arch Linux when lsb-release is available
+        * Updated the URL for EPEL 7
 
 Version 2014.08.23:
-	* Avoid redirect breakage when installing EPEL with rpm on RHEL 5
-	* Ensure python-apt is installed by the bootstrap script for Debian & Ubuntu minions. Thanks 
-	@garethgreenaway.
-	* Don't shallow clone on git versions lower than 1.7.10
-	* Only shallow clone on git tag based installations
-	* Configurable Salt repository clone directory for git based installations
-	* Distro Support Fixed:
-		* Fixed the URL to download EPEL for Cent 5
-		* Use the full path to the `chkconfig` binary when checking for services in SysV init 
-		systems.
-		* Fixed an issue where the default sleep period(3 secs) on Ubuntu would cause a race 
-		condition with upstart wherein the package installation would call an upstart start and 
-		before it could complete, bootstrap would call another. The result was *two* copies of salt 
-		running which ended up causing a most stubborn bug that's documented in 
-		https://github.com/saltstack/salt/issues/12248
+    * Avoid redirect breakage when installing EPEL with rpm on RHEL 5
+    * Ensure python-apt is installed by the bootstrap script for Debian & Ubuntu minions. Thanks 
+    @garethgreenaway.
+    * Don't shallow clone on git versions lower than 1.7.10
+    * Only shallow clone on git tag based installations
+    * Configurable Salt repository clone directory for git based installations
+    * Distro Support Fixed:
+        * Fixed the URL to download EPEL for Cent 5
+        * Use the full path to the `chkconfig` binary when checking for services in SysV init 
+        systems.
+        * Fixed an issue where the default sleep period(3 secs) on Ubuntu would cause a race 
+        condition with upstart wherein the package installation would call an upstart start and 
+        before it could complete, bootstrap would call another. The result was *two* copies of salt 
+        running which ended up causing a most stubborn bug that's documented in 
+        https://github.com/saltstack/salt/issues/12248
 
 Version 2014.07.29:
-	* Shallow clone Salt's repository for speed improvements. In case of failure, resume old 
-	behaviour.
-	* Fixed bug introduced in 0577622 when salt-api service install and checks were added
-	* Distro Support Fixed:
-		* Fixed infinite loop when handling RHEL dependencies. Thanks Dan Mick(@dmick).
+    * Shallow clone Salt's repository for speed improvements. In case of failure, resume old 
+    behaviour.
+    * Fixed bug introduced in 0577622 when salt-api service install and checks were added
+    * Distro Support Fixed:
+        * Fixed infinite loop when handling RHEL dependencies. Thanks Dan Mick(@dmick).
 
 Version 2014.07.27:
-	* Amazon Linux AMI 2010.xx is not explicitly not supported.
-	* Install the `salt-api` scripts if available when the `salt-master` is also installed.
-	* Added support for a configurable sleep time when starting, restarting and checking for 
-	enabled services.
-	* Drop the `tsflags` requirement for RHEL and RHEL based distributions.
-	* When sorting release files, oracle-release has higher priority than redhat-release.
-	* Distro Support Fixed:
-		* Debian >= 7 uses system's python-requests package, not PIP
-		* Install 'python-zypp' in SuSE and openSUSE(required by Salt's zypper module)
-		* Only install EPEL on requiring distributions if not already installed
-		* CentOS 7 now uses systemd and the script now properly handles it
-		* systemd in openSUSE 12.2 complains if service does not contain `.service``
-		* Properly detect openSUSE using `lsb_release
-		* SLES 11 SP3 ships with both python-M2Crypto-0.22.* and python-m2crypto-0.21 and we will 
-		be asked which we want to install, even with --non-interactive. Let's try to install the 
-		higher version first and then the lower one in case of failure.
-		* Allow some extra time on RHEL for the optionals repo check in case the repository 
-		subscription is being managed externally.
+    * Amazon Linux AMI 2010.xx is not explicitly not supported.
+    * Install the `salt-api` scripts if available when the `salt-master` is also installed.
+    * Added support for a configurable sleep time when starting, restarting and checking for 
+    enabled services.
+    * Drop the `tsflags` requirement for RHEL and RHEL based distributions.
+    * When sorting release files, oracle-release has higher priority than redhat-release.
+    * Distro Support Fixed:
+        * Debian >= 7 uses system's python-requests package, not PIP
+        * Install 'python-zypp' in SuSE and openSUSE(required by Salt's zypper module)
+        * Only install EPEL on requiring distributions if not already installed
+        * CentOS 7 now uses systemd and the script now properly handles it
+        * systemd in openSUSE 12.2 complains if service does not contain `.service``
+        * Properly detect openSUSE using `lsb_release
+        * SLES 11 SP3 ships with both python-M2Crypto-0.22.* and python-m2crypto-0.21 and we will 
+        be asked which we want to install, even with --non-interactive. Let's try to install the 
+        higher version first and then the lower one in case of failure.
+        * Allow some extra time on RHEL for the optionals repo check in case the repository 
+        subscription is being managed externally.
 
 Version 2014.06.30:
-	* Distro Support Fixed:
-		* Bump build/maintenance version for epel-release package. Thanks Gregory Meno(GregMeno)
-		* Properly detect Amazon Linux AMI when using `lsb_release`
-		* Fix `tsflags` installation.
+    * Distro Support Fixed:
+        * Bump build/maintenance version for epel-release package. Thanks Gregory Meno(GregMeno)
+        * Properly detect Amazon Linux AMI when using `lsb_release`
+        * Fix `tsflags` installation.
 
 Version 2014.06.28:
-	* Fixed `tsflags` packages detection for RHEL and Oracle Linux 6.5
+    * Fixed `tsflags` packages detection for RHEL and Oracle Linux 6.5
 
 Version 2014.06.21:
-	* Also export the HTTPS proxy environment variable. Thanks Giuseppe Iannello(gianello).
-	* Distro Support Fixed:
-		* Improve Oracle Linux Server detection
-		* Overcome the Oracle Linux awkwardness. `--enablerepo=XYX` disables ALL OTHER REPOS!!!!
-		* Oracle Linux also support testing repositories installation
+    * Also export the HTTPS proxy environment variable. Thanks Giuseppe Iannello(gianello).
+    * Distro Support Fixed:
+        * Improve Oracle Linux Server detection
+        * Overcome the Oracle Linux awkwardness. `--enablerepo=XYX` disables ALL OTHER REPOS!!!!
+        * Oracle Linux also support testing repositories installation
 
 Version 2014.06.19:
-	* Allow passing the master address as an environment variable, `BS_SALT_MASTER_ADDRESS`
-	* Fixed an issue with the keys pre-seed. We were passing absolute paths where we only needed 
-	basenames.
-	* Added HTTP proxy configuration support. Thanks Giuseppe Iannello(gianello),
-	* Distro Support Added:
-		* Elementary OS
-		* RHEL 7 Beta/RC
-		* Kali Linux. Thanks Valentin Bud(valentinbud)
-	* Distro Support Fixed:
-		* Improved RHEL optionals repository detection
+    * Allow passing the master address as an environment variable, `BS_SALT_MASTER_ADDRESS`
+    * Fixed an issue with the keys pre-seed. We were passing absolute paths where we only needed 
+    basenames.
+    * Added HTTP proxy configuration support. Thanks Giuseppe Iannello(gianello),
+    * Distro Support Added:
+        * Elementary OS
+        * RHEL 7 Beta/RC
+        * Kali Linux. Thanks Valentin Bud(valentinbud)
+    * Distro Support Fixed:
+        * Improved RHEL optionals repository detection
 
 Version 2014.04.16:
-	* Fixed a bug for RHEL 6 based distributions where yum-utils was not getting installed.
-	* Added minor version check for RHEL 6 optional channel.
-	* Added quotes around "apache-libcloud>=$_LIBCLOUD_MIN_VERSION" for proper version requirements 
-	handling.
-	* Install the python 'requests' package which is now a hard dependency in Salt.
-	* When installing from a user defined repository add the official one as a remote and fetch 
-	its tags for proper versioning.
-	* Distro Support Fixed:
-		* CentOS netinstall ISO's don't install `chkconfig`
-		* Improved RHEL optional repository detection. This allows user repository usage, which 
-		don't need the optional repository support since they usually provide their packages.
-	* Distro Support Added:
-		* Oracle Linux
-		* Scientific Linux
+    * Fixed a bug for RHEL 6 based distributions where yum-utils was not getting installed.
+    * Added minor version check for RHEL 6 optional channel.
+    * Added quotes around "apache-libcloud>=$_LIBCLOUD_MIN_VERSION" for proper version requirements 
+    handling.
+    * Install the python 'requests' package which is now a hard dependency in Salt.
+    * When installing from a user defined repository add the official one as a remote and fetch 
+    its tags for proper versioning.
+    * Distro Support Fixed:
+        * CentOS netinstall ISO's don't install `chkconfig`
+        * Improved RHEL optional repository detection. This allows user repository usage, which 
+        don't need the optional repository support since they usually provide their packages.
+    * Distro Support Added:
+        * Oracle Linux
+        * Scientific Linux
 
 Version 2014.03.10-1:
-	* Distro Support Fixed:
-		* Fix the Debian services running function
+    * Distro Support Fixed:
+        * Fix the Debian services running function
 
 Version 2014.03.10:
-	* Debian based distributions which don't use upstart now also check if the salt services are 
-	enabled.
-	* Distro Support Fixed:
-		* RedHat based distributions now have a proper services enabled checker.
+    * Debian based distributions which don't use upstart now also check if the salt services are 
+    enabled.
+    * Distro Support Fixed:
+        * RedHat based distributions now have a proper services enabled checker.
 
 Version 2014.02.27:
-	* Fixed a bug on the services enabled function searching logic.
-	* Arch, Fedora, openSUSE and SuSE now check for services enabled, if using systemd
-	* CentOS(and any RedHat based) and Ubuntu now check for services enabled is using upstart
-	* Distro Support Added:
-		* Debian 8. Thank You Boris Feld(Lothiraldan).
+    * Fixed a bug on the services enabled function searching logic.
+    * Arch, Fedora, openSUSE and SuSE now check for services enabled, if using systemd
+    * CentOS(and any RedHat based) and Ubuntu now check for services enabled is using upstart
+    * Distro Support Added:
+        * Debian 8. Thank You Boris Feld(Lothiraldan).
 
 Version 2014.02.19:
-	* Fixed a problem with the quotes of an error message
-	* Arch installations now uses the community repository
-	* Distro Support Fixed:
-		* Fixed Fedora Git based installations(git was not being installed)
+    * Fixed a problem with the quotes of an error message
+    * Arch installations now uses the community repository
+    * Distro Support Fixed:
+        * Fixed Fedora Git based installations(git was not being installed)
 
 Version 2014.02.18:
-	* Debian based distribution now get a warning stating that NOT starting daemons does not work 
-	as supposed, mainly because that's the Debian policy.
-	* Fix bug introduced when implementing the master ip flag. The default minion includes 
-	directory is `minion.d`, not `minion.conf.d`
+    * Debian based distribution now get a warning stating that NOT starting daemons does not work 
+    as supposed, mainly because that's the Debian policy.
+    * Fix bug introduced when implementing the master ip flag. The default minion includes 
+    directory is `minion.d`, not `minion.conf.d`
 
 Version 2014.02.16:
-	* The script now allows setting up the salt-master address as a separate configuration file by 
-	passing `-A` to the script.
-	* Add support to install apache-libcloud by passing the `-L` flag. In some distribution it's 
-	also needed to pass `-P` because the minimal apache-libcloud version is `0.14.0`. This support 
-	is still missing for FreeBSD and SmartOS.
-	* Fixed an issue when copying or moving files. We now test to see if the destination is a 
-	directory and create a full path from that so that the "do not override" logic works as 
-	supposed. #294.
-	* Allow passing additional package names to install while installing Salt's dependencies. #262
-	* Pass the salt configuration directory, default or from environment variable to the setup.py 
-	script for git based installations. #305
-	* Distro Support Fixed:
-		* FreeBSD `fetch` now has a notion of insecure certificates. Handle this properly. Thank 
-		You Mike Carlson(m87carlson).
-		* Arch, openSUSE and SuSE are now upgradable when the `-U` flag is passed.
-		* Force overwrites now works for existing init.d scripts on CentOS git installations. #259
-	* Distro Support Added:
-		* FreeBSD 10 is now also supported. Thank You Mike Carlson(m87carlson).
-		* Red Had Enterprise Workstation is now supported.
+    * The script now allows setting up the salt-master address as a separate configuration file by 
+    passing `-A` to the script.
+    * Add support to install apache-libcloud by passing the `-L` flag. In some distribution it's 
+    also needed to pass `-P` because the minimal apache-libcloud version is `0.14.0`. This support 
+    is still missing for FreeBSD and SmartOS.
+    * Fixed an issue when copying or moving files. We now test to see if the destination is a 
+    directory and create a full path from that so that the "do not override" logic works as 
+    supposed. #294.
+    * Allow passing additional package names to install while installing Salt's dependencies. #262
+    * Pass the salt configuration directory, default or from environment variable to the setup.py 
+    script for git based installations. #305
+    * Distro Support Fixed:
+        * FreeBSD `fetch` now has a notion of insecure certificates. Handle this properly. Thank 
+        You Mike Carlson(m87carlson).
+        * Arch, openSUSE and SuSE are now upgradable when the `-U` flag is passed.
+        * Force overwrites now works for existing init.d scripts on CentOS git installations. #259
+    * Distro Support Added:
+        * FreeBSD 10 is now also supported. Thank You Mike Carlson(m87carlson).
+        * Red Had Enterprise Workstation is now supported.
 
 Version 1.5.11:
-	* Fixed an out of scope variable missed when moving functions around.
+    * Fixed an out of scope variable missed when moving functions around.
 
 Version 1.5.10:
-	* Salt no longer has the master branch in git, install from develop as default.
-	* Installing from Git on Red Hat based distributions now also needs `yum-utils` installed.
-	* Allow the script to use a different git repository to install from.
-	* Fixed a bug where a branch name with dashes would be wrongly detected as an option to the 
-	script.
-	* Default to secure file downloads(if any).
-	* Distro Support Fixed:
-		* Minimal Ubuntu installation might not have upstart installed, fixed.
-		* FreeBSD now uses the official FreeBSD repository. Thank You Paul Brian(lifeisstillgood)!
+    * Salt no longer has the master branch in git, install from develop as default.
+    * Installing from Git on Red Hat based distributions now also needs `yum-utils` installed.
+    * Allow the script to use a different git repository to install from.
+    * Fixed a bug where a branch name with dashes would be wrongly detected as an option to the 
+    script.
+    * Default to secure file downloads(if any).
+    * Distro Support Fixed:
+        * Minimal Ubuntu installation might not have upstart installed, fixed.
+        * FreeBSD now uses the official FreeBSD repository. Thank You Paul Brian(lifeisstillgood)!
 
 Version 1.5.9:
-	* Allow to not start the daemons after bootstrapping salt. This will allow `vagrant-lxc`
-	installations,  `debootstrap*`, etc, to finish properly. Thanks Henrik Holmboe (holmboe).
-	* Distro Support Fixed:
-		* Salt >= 0.17 requires ElementTree which is on the python standard library after python 
-		2.6 but openSUSE split that into a separate package.
-		* Fixed a logic preventing proper Ubuntu bootstrapping on some situations.
+    * Allow to not start the daemons after bootstrapping salt. This will allow `vagrant-lxc`
+    installations,  `debootstrap*`, etc, to finish properly. Thanks Henrik Holmboe (holmboe).
+    * Distro Support Fixed:
+        * Salt >= 0.17 requires ElementTree which is on the python standard library after python 
+        2.6 but openSUSE split that into a separate package.
+        * Fixed a logic preventing proper Ubuntu bootstrapping on some situations.
 
 Version 1.5.8:
-	* Fixed an Ubuntu regression. `add-apt-repository` is only available on 
-	`software-properties-common` after 12.10, inclusive. Thanks Diego Woitasen(diegows)
+    * Fixed an Ubuntu regression. `add-apt-repository` is only available on 
+    `software-properties-common` after 12.10, inclusive. Thanks Diego Woitasen(diegows)
 
 Version 1.5.7:
-	* For RedHat based distributions which rely on `epel`, the user can now pass `testing` to the 
-	script and `epel-testing` shall be used to bootstrap salt and it's dependencies.
-	* No full system upgrades, if optional by the distribution, shall be done unless `-U` is passed 
-	to the bootstrap script(required upgrade procedures must exist on the script, currently Debian 
-	and RedHat based distributions support system upgrades).
-	* Fixed an issue where passing BS_KEEP_TEMP_FILES=1 to the script was causing an error. #206.
-	* Switched FreeBSD default packages repository to PCBSD(http://www.pcbsd.org) and added 
-	multiple repository support to install salt from the SaltStack's FreeBSD repository.  Thanks 
-	Christer Edwards(cedwards).
-	* Improved Gentoo Support. Thanks Elias Probst(eliasp).
-	* Stop execution soon for end of life distributions or non supported distribution versions.
-	* Distro Support Fixed:
-		* Fixed an unbound variable while bootstraping Gentoo.
-		* Fixed CentOS/RHEL 5.
-		* Fixed crypto++ compilation. Thanks Kenneth Wilke(KennethWilke)!
-		* Fixed FreeBSD git installations not pointing to the proper salt configuration directory, 
-		which on FreeBSD is '/usr/local/etc/salt'.
-		* Fixed testing installation for Red Hat based distributions. Thanks Jeff Strunk(jstrunk)
-		* Fixed wrong package name on Arch. Thanks Niels Abspoel(aboe76)
-		* Make sure the Ubuntu universe repository is enabled. Thanks Karl Grzeszczak(karlgrz).
-		* Fixed SmartOS installation. Thanks Matthieu Guegan(mguegan).
+    * For RedHat based distributions which rely on `epel`, the user can now pass `testing` to the 
+    script and `epel-testing` shall be used to bootstrap salt and it's dependencies.
+    * No full system upgrades, if optional by the distribution, shall be done unless `-U` is passed 
+    to the bootstrap script(required upgrade procedures must exist on the script, currently Debian 
+    and RedHat based distributions support system upgrades).
+    * Fixed an issue where passing BS_KEEP_TEMP_FILES=1 to the script was causing an error. #206.
+    * Switched FreeBSD default packages repository to PCBSD(http://www.pcbsd.org) and added 
+    multiple repository support to install salt from the SaltStack's FreeBSD repository.  Thanks 
+    Christer Edwards(cedwards).
+    * Improved Gentoo Support. Thanks Elias Probst(eliasp).
+    * Stop execution soon for end of life distributions or non supported distribution versions.
+    * Distro Support Fixed:
+        * Fixed an unbound variable while bootstraping Gentoo.
+        * Fixed CentOS/RHEL 5.
+        * Fixed crypto++ compilation. Thanks Kenneth Wilke(KennethWilke)!
+        * Fixed FreeBSD git installations not pointing to the proper salt configuration directory, 
+        which on FreeBSD is '/usr/local/etc/salt'.
+        * Fixed testing installation for Red Hat based distributions. Thanks Jeff Strunk(jstrunk)
+        * Fixed wrong package name on Arch. Thanks Niels Abspoel(aboe76)
+        * Make sure the Ubuntu universe repository is enabled. Thanks Karl Grzeszczak(karlgrz).
+        * Fixed SmartOS installation. Thanks Matthieu Guegan(mguegan).
 
 Version 1.5.6:
-	* If there's a `grains` file on the provided temporary configuration directory, move it to the 
-	proper place while moving the minion configuration file.
-	* Gentoo bootstraps can now use a bin host to provide binary packages, just set the 
-	`BS_GENTOO_USE_BINHOST` environment variable.
-	* If `BS_KEEP_TEMP_FILES=1` is found on the environment, the script will copy the files instead 
-	of moving them.
-	* There were still some `mv` and `cp` occurrences which were not using their `{move,copy}file` 
-	replacements which ended up on now respecting the "Do not override existing configuration" 
-	feature.
-	* Distro Support Fixed:
-		* Arch now upgrades it's system package properly as suggested on their mailing list.
-		* Arch now moves back any configuration files provided by the user renamed by pacman on the 
-		installation process.
-		* Fixed SmartOS detection(was being detected as Solaris) and bootstrapping. Fixed SmartOS 
-		different gcc package names for different package sets.
-		* Fixed FreeBSD git based installations(no rc.d scripts were available).
-		* Fixed FreeBSD not re-evaluating the `PKI_DIR` variable since the `SALT_ETC_DIR` was 
-		redefined.
-	* Distro Support Added:
-		* Linux Mint. Thanks Alex Van't Hof(alexvh)!
-		* Linaro.
+    * If there's a `grains` file on the provided temporary configuration directory, move it to the 
+    proper place while moving the minion configuration file.
+    * Gentoo bootstraps can now use a bin host to provide binary packages, just set the 
+    `BS_GENTOO_USE_BINHOST` environment variable.
+    * If `BS_KEEP_TEMP_FILES=1` is found on the environment, the script will copy the files instead 
+    of moving them.
+    * There were still some `mv` and `cp` occurrences which were not using their `{move,copy}file` 
+    replacements which ended up on now respecting the "Do not override existing configuration" 
+    feature.
+    * Distro Support Fixed:
+        * Arch now upgrades it's system package properly as suggested on their mailing list.
+        * Arch now moves back any configuration files provided by the user renamed by pacman on the 
+        installation process.
+        * Fixed SmartOS detection(was being detected as Solaris) and bootstrapping. Fixed SmartOS 
+        different gcc package names for different package sets.
+        * Fixed FreeBSD git based installations(no rc.d scripts were available).
+        * Fixed FreeBSD not re-evaluating the `PKI_DIR` variable since the `SALT_ETC_DIR` was 
+        redefined.
+    * Distro Support Added:
+        * Linux Mint. Thanks Alex Van't Hof(alexvh)!
+        * Linaro.
 
 
 Version 1.5.5:
-	* Fixed a variable error in the new pre-seed feature.
-	* Fixed the destination path to where the pre-seed minions keys should be copied.
-	* Debian installations now use SaltStack's repository.
-	* Configuration files can now be passed as an URL to a compressed file. Thanks Geoff Garside!
-	* Distro Support Fixed:
-		* Debian's optional ZMQ3 support was fixed (libzmq3 has moved from experimental to 
-		unstable).
-		* Ubuntu Lucid Daily PPA
-		* SmartOS no longer ignores $SALT_ETC_DIR. Matthieu Guegan!
-		* FreeBSD no longer ignores $SALT_ETC_DIR. Thanks Geoff Garside!
-		* FreeBSD does not try to install pkgng if pkg is installed. Thanks Geoff Garside!
-		* SunOS (Make use of XPG4 binaries on SunOS). Thanks Matthieu Guegan!
-		* openSUSE (Don't fail if only one of the repositories failed to update)
-		* Arch (Fixed the GPG issues for git installations)
-	* Distro Support Added:
-		* Gentoo. Thanks kaithar!
+    * Fixed a variable error in the new pre-seed feature.
+    * Fixed the destination path to where the pre-seed minions keys should be copied.
+    * Debian installations now use SaltStack's repository.
+    * Configuration files can now be passed as an URL to a compressed file. Thanks Geoff Garside!
+    * Distro Support Fixed:
+        * Debian's optional ZMQ3 support was fixed (libzmq3 has moved from experimental to 
+        unstable).
+        * Ubuntu Lucid Daily PPA
+        * SmartOS no longer ignores $SALT_ETC_DIR. Matthieu Guegan!
+        * FreeBSD no longer ignores $SALT_ETC_DIR. Thanks Geoff Garside!
+        * FreeBSD does not try to install pkgng if pkg is installed. Thanks Geoff Garside!
+        * SunOS (Make use of XPG4 binaries on SunOS). Thanks Matthieu Guegan!
+        * openSUSE (Don't fail if only one of the repositories failed to update)
+        * Arch (Fixed the GPG issues for git installations)
+    * Distro Support Added:
+        * Gentoo. Thanks kaithar!
 
 
 Version 1.5.4:
-	* Fixed an issue we had when /proc/cpuinfo had more than one CPU. Detected on AMD CPUs.
-	* OpenSUSE 12.3 uses lsb_release. Fix the returned distro name "openSUSE project" to "openSUSE" 
-	which the script handles.
-	* Added an custom move function which will only override if required and if we permit it.
-	* Implemented the necessary function to pre-seed minion keys on a salt master as an optional 
-	argument.
-	* Distro Support Fixed:
-		* FreeBSD (Don't let the script fail if PACKAGESITE is not set)
-		* Debian Stable installations (the function search was not working as supposed)
-	* Distro Support Added:
-		* Ubuntu 13.04 (Was disabled because of a bad beta1. Fixed in beta2)
+    * Fixed an issue we had when /proc/cpuinfo had more than one CPU. Detected on AMD CPUs.
+    * OpenSUSE 12.3 uses lsb_release. Fix the returned distro name "openSUSE project" to "openSUSE" 
+    which the script handles.
+    * Added an custom move function which will only override if required and if we permit it.
+    * Implemented the necessary function to pre-seed minion keys on a salt master as an optional 
+    argument.
+    * Distro Support Fixed:
+        * FreeBSD (Don't let the script fail if PACKAGESITE is not set)
+        * Debian Stable installations (the function search was not working as supposed)
+    * Distro Support Added:
+        * Ubuntu 13.04 (Was disabled because of a bad beta1. Fixed in beta2)
 
 
 Version 1.5.3:
-	* Return 0 or 1 from functions
-	* Convert several pipes into a single awk call
-	* Fixed `/etc/os-release` parsing
-	* Fixed `config_salt()`
-	* Distro Support Fixed:
-		* EPEL-based installations (CentOS, Amazon Linux, RedHat)
-		* SuSE/OpenSUSE (problem running the script twice, ie, existing `devel_languages_python` 
-		repository)
-		* SuSE 11 SP1 (pip based install and config trigger)
-	* Distro Support Added:
-		* Debian 7 (Only git installations at the moment)
+    * Return 0 or 1 from functions
+    * Convert several pipes into a single awk call
+    * Fixed `/etc/os-release` parsing
+    * Fixed `config_salt()`
+    * Distro Support Fixed:
+        * EPEL-based installations (CentOS, Amazon Linux, RedHat)
+        * SuSE/OpenSUSE (problem running the script twice, ie, existing `devel_languages_python` 
+        repository)
+        * SuSE 11 SP1 (pip based install and config trigger)
+    * Distro Support Added:
+        * Debian 7 (Only git installations at the moment)
 
 
 Version 1.5.2:
-	* Fix issue with Travis testing (it installs it's own ZeroMQ3 lib
-	* Allow setting the debug output from an environment variable
-	* Fix an escape issue in the `printf` calls used in our echo calls
-	* Don't overwrite files (`config`, `init.d`, etc). Use a specific flag to force overwrites.
-	* Distro Support Fixed:
-		* Ubuntu daily installs.
-	* Distro Support Added:
-		* Trisquel 6.0 (Ubuntu 12.04)
+    * Fix issue with Travis testing (it installs it's own ZeroMQ3 lib
+    * Allow setting the debug output from an environment variable
+    * Fix an escape issue in the `printf` calls used in our echo calls
+    * Don't overwrite files (`config`, `init.d`, etc). Use a specific flag to force overwrites.
+    * Distro Support Fixed:
+        * Ubuntu daily installs.
+    * Distro Support Added:
+        * Trisquel 6.0 (Ubuntu 12.04)
 
 
 Version 1.5.1:
-	* Improved unittesting.
-	* Starting daemons.
-	* Make sure that daemons are really running.
-	* For the users to make the choice if installing from PIP (if required since there aren't system 
-	pacakges).
-	* Fixed salt's git cloning when the salt git tree is already present on the system.
-	* Distro Support Fixed:
-		* Debian 6
-		* Ubuntu 12.10
-		* CentOS
-	* Distro Support Added:
-		* SuSE 11 SP1/11 SP2
-		* OpenSUSE 12.x
+    * Improved unittesting.
+    * Starting daemons.
+    * Make sure that daemons are really running.
+    * For the users to make the choice if installing from PIP (if required since there aren't system 
+    pacakges).
+    * Fixed salt's git cloning when the salt git tree is already present on the system.
+    * Distro Support Fixed:
+        * Debian 6
+        * Ubuntu 12.10
+        * CentOS
+    * Distro Support Added:
+        * SuSE 11 SP1/11 SP2
+        * OpenSUSE 12.x
 
 
 Version 1.5:
-	* First stable version of the script
-	* Support for:
-		* Ubuntu 10.x/11.x/12.x
-		* Debian 6.x
-		* CentOS 5/6
-		* Red Hat 5/6
-		* Red Hat Enterprise 5/6
-		* Fedora
-		* Arch
-		* SmartOS
-		* FreeBSD 9.0
+    * First stable version of the script
+    * Support for:
+        * Ubuntu 10.x/11.x/12.x
+        * Debian 6.x
+        * CentOS 5/6
+        * Red Hat 5/6
+        * Red Hat Enterprise 5/6
+        * Fedora
+        * Arch
+        * SmartOS
+        * FreeBSD 9.0
 
 
 # Don't remove the line below.


### PR DESCRIPTION
### What does this PR do?

Convert mix of indentation to tabs. This appears to be the original intent based on the vim parameter `ts=4`, But use spaces to align with the formatting of the README

~~Add vim option `noexpandtab` to keep this more constant in the future~~