### PR TITLE
Fix yum repo on AWS Linux

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -4423,7 +4423,7 @@ install_amazon_linux_ami_deps() {
     repo_rev="$(echo "${STABLE_REV}"  | sed 's|.*\/||g')"
 
     if echo "$repo_rev" | egrep -q '^(latest|2016\.11)$' || \
-           ( echo "$repo_rev" | egrep -q '^[0-9]+$' && [ "$(echo "$repo_rev" | cut -c1-4)" -gt 2016 ] ); then
+            [ "$(echo "$repo_rev" | cut -c1-4)" -gt 2016 ]; then
        _USEAWS=$BS_TRUE
        pkg_append="python27"
     fi


### PR DESCRIPTION
If I understand the logic here the new(ish) aws repo url would only be
used in these two cases - when repo_rev:

* starts with latest or 2016.11
* starts with 0-9 and the year string is greater than 2016

If I'm reading this correct, the second case is wrong so I've removed
the check for "starts with 0-9".

### What does this PR do?
Fixes the yum repo URL on aws linux

### What issues does this PR fix or reference?
Fixes #1159 

### Previous Behavior
`baseurl=https://repo.saltstack.com/yum/redhat/6/$basearch/2017.7/`

### New Behavior
`baseurl=https://repo.saltstack.com/yum/amazon/latest/$basearch/2017.7/`
