### PR TITLE
Respect disable repos (-r) option on OpenBSD

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -5122,10 +5122,12 @@ __choose_openbsd_mirror() {
 }
 
 install_openbsd_deps() {
-    __choose_openbsd_mirror || return 1
-    echoinfo "setting package repository to $OPENBSD_REPO with ping time of $MINTIME"
-    [ -n "$OPENBSD_REPO" ] || return 1
-    echo "${OPENBSD_REPO}" >>/etc/installurl || return 1
+    if [ $_DISABLE_REPOS -eq $BS_FALSE ]; then
+        __choose_openbsd_mirror || return 1
+        echoinfo "setting package repository to $OPENBSD_REPO with ping time of $MINTIME"
+        [ -n "$OPENBSD_REPO" ] || return 1
+        echo "${OPENBSD_REPO}" >>/etc/installurl || return 1
+    fi
 
     if [ "${_EXTRA_PACKAGES}" != "" ]; then
         echoinfo "Installing the following extra packages as requested: ${_EXTRA_PACKAGES}"


### PR DESCRIPTION
### What does this PR do?

Fix `-r` option on OpenBSD

### Previous Behavior

Mirror ping and selection occurred even if `_DISABLE_REPOS` was true

### New Behavior

Packages are fetched using the existing setting in `/etc/installurl`

