### PR TITLE
Wait for zypper processes to finish before calling zypper again

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -5456,6 +5456,13 @@ __version_lte() {
 }
 
 __zypper() {
+    # Check if any zypper process is running before calling zypper again.
+    # This is useful when a zypper call is part of a boot process and will
+    # wait until the zypper process is finished, such as on AWS AMIs.
+    while pgrep -l zypper; do
+        sleep 1
+    done
+
     zypper --non-interactive "${@}"; return $?
 }
 


### PR DESCRIPTION
Fixes an issue where the bootstrap script bails out if there is a zypper process running already on the machine to be bootstrapped. This can happen when a machine has been modified to use zypper in a boot command. We need to wait for the process to finish before calling the next zypper command.

Otherwise, the following error occurs:
```
System management is locked by the application with pid <pid#> (zypper).
```

