### PR TITLE
Adding support for minor release pinning on AWS Linux

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -4433,7 +4433,7 @@ install_amazon_linux_ami_deps() {
         repo_rev="latest"
     fi
 
-    if [[ $repo_rev =~ ^archive ]]; then
+    if echo $repo_rev | egrep -q '^archive'; then
         year=$(echo "$repo_rev" | cut -d '/' -f 2 | cut -c1-4)
     else
         year=$(echo "$repo_rev" | cut -c1-4)

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -4427,10 +4427,20 @@ install_amazon_linux_ami_deps() {
     _USEAWS=$BS_FALSE
     pkg_append="python"
 
-    repo_rev="$(echo "${STABLE_REV}"  | sed 's|.*\/||g')"
+    if [ "$ITYPE" = "stable" ]; then
+        repo_rev="$STABLE_REV"
+    else
+        repo_rev="latest"
+    fi
+
+    if [[ $repo_rev =~ ^archive ]]; then
+        year=$(echo "$repo_rev" | cut -d '/' -f 2 | cut -c1-4)
+    else
+        year=$(echo "$repo_rev" | cut -c1-4)
+    fi
 
     if echo "$repo_rev" | egrep -q '^(latest|2016\.11)$' || \
-            [ "$(echo "$repo_rev" | cut -c1-4)" -gt 2016 ]; then
+            [ "$year" -gt 2016 ]; then
        _USEAWS=$BS_TRUE
        pkg_append="python27"
     fi


### PR DESCRIPTION
Currently Salt 2017.7.2 has a critical bug that has broke disk
formatting for me:

saltstack/salt#44029

That left me looking for a way to pin AWS Linux hosts launched from
salt-cloud to an older release. With this change script args
`stable 2017.7.1` now works with AWS Linux based on the "Pin to Minor
Release" instructions listed at https://repo.saltstack.com/#amzn.

As noted in the comments below this change, we should probably refactor
to use `__install_saltstack_rhel_repository()`... in fact I've copied more
code from that function... but I don't understand all the cases for all
the other RedHat varients, so I'm just putting in the work for AWS
Linux.

### What does this PR do?
See above

### What issues does this PR fix or reference?
Related to https://github.com/saltstack/salt/issues/33458.

### Previous Behavior
Script args `stable 2017.7.1` fails with a yum 404.

### New Behavior
Script args `stable 2017.7.1` works as expected.
