### PR TITLE
Update Fedora support: 25 is EOL, 27 is supported

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -255,7 +255,7 @@ Red Hat family
 - Amazon Linux 2012.3 and later
 - CentOS 6/7
 - Cloud Linux 6/7
-- Fedora 25/26
+- Fedora 26/27
 - Oracle Linux 6/7
 - Red Hat Enterprise Linux 6/7
 - Scientific Linux 6/7

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1544,8 +1544,8 @@ __check_end_of_life_versions() {
             ;;
 
         fedora)
-            # Fedora lower than 25 are no longer supported
-            if [ "$DISTRO_MAJOR_VERSION" -lt 25 ]; then
+            # Fedora lower than 26 are no longer supported
+            if [ "$DISTRO_MAJOR_VERSION" -lt 26 ]; then
                 echoerror "End of life distributions are not supported."
                 echoerror "Please consider upgrading to the next stable. See:"
                 echoerror "    https://fedoraproject.org/wiki/Releases"


### PR DESCRIPTION
- Fedora 25 is EOL and no longer supported.
- Fedora 27 is out and supported, let's update the docs.

