### PR TITLE
Install swig30 as freebsd dep instead of swig.

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -4898,9 +4898,9 @@ install_freebsd_9_stable_deps() {
         __configure_freebsd_pkg_details || return 1
     fi
 
-    # Now install swig
+    # Now install swig30
     # shellcheck disable=SC2086
-    /usr/local/sbin/pkg install ${FROM_FREEBSD} -y swig || return 1
+    /usr/local/sbin/pkg install ${FROM_FREEBSD} -y swig30 || return 1
 
     # YAML module is used for generating custom master/minion configs
     # shellcheck disable=SC2086


### PR DESCRIPTION
Looks like swig was removed from FreeBSD Ports. See https://www.freshports.org/commit.php?category=devel&port=swig13&files=yes&message_id=201712201528.vBKFSwpR091538@repo.freebsd.org

### What does this PR do?

Install swig30 package instead of swig

### What issues does this PR fix or reference?

No

### Previous Behavior

Salt fails to install in FreeBSD 

```
       pkg: No packages available to install matching 'swig' have been found in the repositories

        * ERROR: Failed to run install_freebsd_git_deps()!!!

       salt-call: not found

       No salt-minion installed, install must have failed!!

       salt_install = bootstrap

       salt_url = http://bootstrap.saltstack.org
```

### New Behavior

Salt installs just fine
