### PR TITLE
Change gnupg2 pacakge to gnupg for non-LTS versions of Ubuntu

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -284,7 +284,7 @@ repositories are not provided on `SaltStack's Ubuntu repository`_ for the non-LT
 bootstrap script will attempt to install the packages for the most closely related LTS Ubuntu
 release instead.
 
-For example, when installing Salt on Ubuntu 16.10, the bootstrap script will setup the repository 
+For example, when installing Salt on Ubuntu 17.10, the bootstrap script will setup the repository
 for Ubuntu 16.04 from `SaltStack's Ubuntu repository`_ and install the 16.04 packages.
 
 

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1372,16 +1372,10 @@ __ubuntu_codename_translation() {
             DISTRO_CODENAME="trusty"
             ;;
         "16")
-            if [ "$_april" ]; then
-                DISTRO_CODENAME="xenial"
-            else
-                DISTRO_CODENAME="yakkety"
-            fi
+            DISTRO_CODENAME="xenial"
             ;;
         "17")
-            if [ "$_april" ]; then
-                DISTRO_CODENAME="zesty"
-            fi
+            DISTRO_CODENAME="artful"
             ;;
         *)
             DISTRO_CODENAME="trusty"
@@ -1500,9 +1494,12 @@ __check_end_of_life_versions() {
             #  < 14.04
             #  = 14.10
             #  = 15.04, 15.10
+            #  = 16.10
+            #  = 17.04
             if [ "$DISTRO_MAJOR_VERSION" -lt 14 ] || \
                 [ "$DISTRO_MAJOR_VERSION" -eq 15 ] || \
-                ([ "$DISTRO_MAJOR_VERSION" -lt 16 ] && [ "$DISTRO_MINOR_VERSION" -eq 10 ]); then
+                ([ "$DISTRO_MAJOR_VERSION" -eq 17 ] && [ "$DISTRO_MINOR_VERSION" -eq 04 ]) || \
+                ([ "$DISTRO_MAJOR_VERSION" -lt 17 ] && [ "$DISTRO_MINOR_VERSION" -eq 10 ]); then
                 echoerror "End of life distributions are not supported."
                 echoerror "Please consider upgrading to the next stable. See:"
                 echoerror "    https://wiki.ubuntu.com/Releases"
@@ -2575,7 +2572,7 @@ __enable_universe_repository() {
 
 __install_saltstack_ubuntu_repository() {
     # Workaround for latest non-LTS ubuntu
-    if [ "$DISTRO_VERSION" = "16.10" ] || [ "$DISTRO_MAJOR_VERSION" -gt 16 ]; then
+    if [ "$DISTRO_MAJOR_VERSION" -gt 16 ]; then
         echowarn "Non-LTS Ubuntu detected, but stable packages requested. Trying packages from latest LTS release. You may experience problems."
         UBUNTU_VERSION=16.04
         UBUNTU_CODENAME="xenial"
@@ -2587,8 +2584,8 @@ __install_saltstack_ubuntu_repository() {
     __PACKAGES=''
 
     # Install downloader backend for GPG keys fetching
-    if [ "$DISTRO_VERSION" = "16.10" ] || [ "$DISTRO_MAJOR_VERSION" -gt 16 ]; then
-        __PACKAGES="${__PACKAGES} gnupg2 dirmngr"
+    if [ "$DISTRO_MAJOR_VERSION" -gt 16 ]; then
+        __PACKAGES="${__PACKAGES} gnupg dirmngr"
     else
         __PACKAGES="${__PACKAGES} gnupg-curl"
     fi


### PR DESCRIPTION
### What does this PR do?
The gnupg2 package has been removed as it is just a dummy translation package. We need to be installing gnupg instead.

This also adds best-effort support for the "Artful Aardvark" (17.10) version and removes support for "Zesty Zapus" (17.04) and "Yakkety Yak" (16.10). Both releases are EOL.

### What issues does this PR fix or reference?
Fixes #1193

### Previous Behavior
Salt installation works on 17.10.

### New Behavior
Doesn't try to install Salt on Ubuntu 17.04. It prints an error with the EOL information.

