### PR TITLE
OpenBSD has a cdn which handles selecting the best mirror

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -5147,35 +5147,11 @@ install_freebsd_restart_daemons() {
 #   OpenBSD Install Functions
 #
 
-__choose_openbsd_mirror() {
-    OPENBSD_REPO=''
-    MINTIME=''
-    MIRROR_LIST=$(ftp -w 15 -Vao - 'https://ftp.openbsd.org/cgi-bin/ftplist.cgi?dbversion=1' | awk '/^http/ {print $1}')
-
-    for MIRROR in $MIRROR_LIST; do
-        MIRROR_HOST=$(echo "$MIRROR" | sed -e 's|.*//||' -e 's|+*/.*$||')
-        TIME=$(ping -c 1 -w 1 -q "$MIRROR_HOST" | awk -F/ '/round-trip/ { print $5 }')
-        [ -z "$TIME" ] && continue
-
-        echodebug "ping time for $MIRROR_HOST is $TIME"
-        if [ -z "$MINTIME" ]; then
-            FASTER_MIRROR=1
-        else
-            FASTER_MIRROR=$(echo "$TIME < $MINTIME" | bc)
-        fi
-        if [ "$FASTER_MIRROR" -eq 1 ]; then
-            MINTIME=$TIME
-            OPENBSD_REPO="$MIRROR"
-        fi
-    done
-}
-
 install_openbsd_deps() {
     if [ $_DISABLE_REPOS -eq $BS_FALSE ]; then
-        __choose_openbsd_mirror || return 1
-        echoinfo "setting package repository to $OPENBSD_REPO with ping time of $MINTIME"
-        [ -n "$OPENBSD_REPO" ] || return 1
-        echo "${OPENBSD_REPO}" >>/etc/installurl || return 1
+        OPENBSD_REPO='https://cdn.openbsd.org/pub/OpenBSD'
+        echoinfo "setting package repository to $OPENBSD_REPO"
+        echo "${OPENBSD_REPO}" >/etc/installurl || return 1
     fi
 
     if [ "${_EXTRA_PACKAGES}" != "" ]; then


### PR DESCRIPTION
### What does this PR do?

Set the mirror by overwriting the installurl file which can only
contain a single line so the original behaviour of appending
might not have worked reliably.
The user can pass '-r' to disable setting the repos already to
opt-out of this behaviour.

### Previous Behavior

It went through a process of selecting a mirror based on ping times.

### New Behavior

Use the OpenBSD CDN and offload best-mirror selection to it.

This was tested on OpenBSD 6.2.
