### PR TITLE
Add M2Crypto to python27 centos 6 bootstrap install

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -3748,8 +3748,7 @@ install_centos_git_deps() {
 
         # install swig and openssl on cent6
         if [ "$DISTRO_MAJOR_VERSION" -eq 6 ]; then
-            __M2C_DEPS="openssl-devel swig"
-            __yum_install_noinput ${__M2C_DEPS} || return 1
+            __yum_install_noinput openssl-devel swig || return 1
         fi
 
         if [ -f "${_SALT_GIT_CHECKOUT_DIR}/requirements/base.txt" ]; then

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -3744,7 +3744,13 @@ install_centos_git_deps() {
 
     if [ "${_PY_EXE}" != "" ]; then
         # If "-x" is defined, install dependencies with pip based on the Python version given.
-        _PIP_PACKAGES="jinja2 msgpack-python pycrypto PyYAML tornado zmq"
+        _PIP_PACKAGES="m2crypto jinja2 msgpack-python pycrypto PyYAML tornado zmq"
+
+        # install swig and openssl on cent6
+        if [ "$DISTRO_MAJOR_VERSION" -eq 6 ]; then
+            __M2C_DEPS="openssl-devel swig"
+            __yum_install_noinput ${__M2C_DEPS} || return 1
+        fi
 
         if [ -f "${_SALT_GIT_CHECKOUT_DIR}/requirements/base.txt" ]; then
             for SINGLE_PACKAGE in $_PIP_PACKAGES; do


### PR DESCRIPTION
### What does this PR do?
Adds upon this PR https://github.com/saltstack/salt-bootstrap/pull/1198 but adds the m2crypto install for centos6 python27 bootstrap installs. 