### PR TITLE
Add shellcheck test to travis config file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,5 @@
-before_install:
-  - "if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then sudo pip install unittest2; fi"
-  - sudo pip install --use-mirrors --mirrors=http://g.pypi.python.org/ --mirrors=http://c.pypi.python.org/ --mirrors=http://pypi.crate.io/ unittest-xml-reporting
-  - sudo apt-get remove -y -o DPkg::Options::=--force-confold --purge libzmq3
-  - sudo apt-get autoremove -y -o DPkg::Options::=--force-confold --purge
-  - sudo ls -lah /etc/apt/sources.list.d/
-  - sudo rm -f /etc/apt/sources.list.d/travis_ci_zeromq3-source.list
-  - sudo pip install git+https://github.com/saltstack/salt-testing.git#egg=SaltTesting
+language: sh
 
 script:
-  - BS_ECHO_DEBUG=1 sudo -E python tests/runtests.py -vv
+  - shellcheck -s sh -f checkstyle bootstrap-salt.sh | tee checkstyle.xml
 
-notifications:
-  irc:
-    channels: "irc.freenode.org#salt-devel"
-    on_success: change
-    on_failure: change


### PR DESCRIPTION
Remove the other testing lines - travis for bootstrap has been disabled for years. Let's just replace the old set up and use a new one now instead.

I'm not sure if this will work correctly - let's see how this run goes.
