### PR TITLE
Workaround gnupg2 not being proxy friendly, refs #1137

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1793,7 +1793,7 @@ __apt_key_fetch() {
     url=$1
 
     # shellcheck disable=SC2086
-    apt-key adv ${_GPG_ARGS} --fetch-keys "$url"; return $?
+    curl ${_CURL_ARGS} -f -s -S -L "$url" | apt-key add - ; return $?
 }   # ----------  end of function __apt_key_fetch  ----------
 
 
@@ -2557,7 +2557,7 @@ __install_saltstack_ubuntu_repository() {
 
     # Install downloader backend for GPG keys fetching
     if [ "$DISTRO_VERSION" = "16.10" ] || [ "$DISTRO_MAJOR_VERSION" -gt 16 ]; then
-        __PACKAGES="${__PACKAGES} gnupg2 dirmngr"
+        __PACKAGES="${__PACKAGES} gnupg2 dirmngr curl"
     else
         __PACKAGES="${__PACKAGES} gnupg-curl"
     fi
@@ -2954,7 +2954,7 @@ __install_saltstack_debian_repository() {
 
     # Install downloader backend for GPG keys fetching
     if [ "$DISTRO_MAJOR_VERSION" -ge 9 ]; then
-        __PACKAGES="${__PACKAGES} gnupg2 dirmngr"
+        __PACKAGES="${__PACKAGES} gnupg2 dirmngr curl"
     else
         __PACKAGES="${__PACKAGES} gnupg-curl"
     fi


### PR DESCRIPTION
GnuPG2 does not support proxies using the CONNECT method which means only
transparent proxies are supported for encrypted traffic or one must degrade
security by disabling encryption during provisioning.

This commit switches back to curl piped to apt-key which is found on several software projects homepage, even salstack as a matter of fact: https://repo.saltstack.com/#debian, and works for all cases.

### What does this PR do?

Workaround GnuPG2 limitations when used behind proxies.

### What issues does this PR fix or reference?

Issue originally reported as #1137.
