### PR TITLE
Install py-tornado4 for FreeBSD.

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -4946,7 +4946,7 @@ install_freebsd_git_deps() {
         # We're on the develop branch, install whichever tornado is on the requirements file
         __REQUIRED_TORNADO="$(grep tornado "${_SALT_GIT_CHECKOUT_DIR}/requirements/base.txt")"
         if [ "${__REQUIRED_TORNADO}" != "" ]; then
-             /usr/local/sbin/pkg install -y www/py-tornado || return 1
+             /usr/local/sbin/pkg install -y www/py-tornado4 || return 1
         fi
     fi
 


### PR DESCRIPTION
### What does this PR do?

Install py-tornado4

### What issues does this PR fix or reference?

See https://github.com/saltstack/salt/issues/45790

### Previous Behavior

Salt fails to run, because tornado 5 is not yet supported

### New Behavior

Salt works just fine
