### PR TITLE
Fix the variable ref from #803

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2394,7 +2394,7 @@ __create_virtualenv() {
 __activate_virtualenv() {
     set +o nounset
     # Is virtualenv empty
-    if [ -z "$VIRTUAL_ENV" ]; then
+    if [ -z "$_VIRTUALENV_DIR" ]; then
         __create_virtualenv || return 1
         # shellcheck source=/dev/null
         . "${_VIRTUALENV_DIR}/bin/activate" || return 1


### PR DESCRIPTION
The version of shellcheck that was previously running on bootstrap PRs was out of date and not catching the fact that the VIRTUAL_ENV variable didn't exist. That variable should be _VIRTUALENV_DIR instead.

Refs #803 

