### PR TITLE
 Add Python3 package support for Ubuntu 16.04

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -278,6 +278,7 @@ Ubuntu and derivatives
 - Linux Mint 17/18
 - Ubuntu 14.04/16.04 and subsequent non-TLS releases (see below)
 - Python3 (see ``-x`` option):
+
   - Ubuntu 16.04
 
 Ubuntu Best Effort Support: Non-LTS Releases

--- a/README.rst
+++ b/README.rst
@@ -277,6 +277,8 @@ Ubuntu and derivatives
 - KDE neon (based on Ubuntu 16.04)
 - Linux Mint 17/18
 - Ubuntu 14.04/16.04 and subsequent non-TLS releases (see below)
+- Python3 (see ``-x`` option):
+  - Ubuntu 16.04
 
 Ubuntu Best Effort Support: Non-LTS Releases
 ********************************************

--- a/README.rst
+++ b/README.rst
@@ -277,9 +277,6 @@ Ubuntu and derivatives
 - KDE neon (based on Ubuntu 16.04)
 - Linux Mint 17/18
 - Ubuntu 14.04/16.04 and subsequent non-TLS releases (see below)
-- Python3 (see ``-x`` option):
-
-  - Ubuntu 16.04
 
 Ubuntu Best Effort Support: Non-LTS Releases
 ********************************************
@@ -313,8 +310,8 @@ UNIX systems
 
 - SmartOS
 
-Unsupported Distro
-------------------
+Unsupported Distributions
+-------------------------
 
 If you are running a Linux distribution that is not supported yet or is not correctly identified,
 please run the following commands and report their output when creating an issue:
@@ -326,6 +323,22 @@ please run the following commands and report their output when creating an issue
 
 For information on how to add support for a currently unsupported distribution, please refer to the
 `Contributing Guidelines`_.
+
+Python 3 Support
+----------------
+
+Some distributions support installing Salt to use Python 3 instead of Python 2. The availability of
+this offering, while limited, is as follows:
+
+- Ubuntu 16.04
+
+Installing the Python 3 packages for Salt is done via the ``-x`` option:
+
+.. code:: console
+
+    sh bootstrap-salt.sh -x python3
+
+See the ``-x`` option for more information.
 
 Testing
 -------


### PR DESCRIPTION
### What does this PR do?
Adds support to bootstrap to install Salt's Python 3 packages for Ubuntu 16.04 using the `-x` option:
```
sh bootstrap-salt.sh -x python3
```

### What issues does this PR fix or reference?
Refs #1127

### Previous Behavior
Could not install Salt with Python 3 packages.

### New Behavior
Can now install Salt with Python 3 packages

@vutny Can you review this one?