### PR TITLE
Shellcheck fixes found when running latest version

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -400,7 +400,7 @@ EOT
 }   # ----------  end of function __usage  ----------
 
 
-while getopts ':hvnDc:g:Gyx:wk:s:MSNXCPFUKIA:i:Lp:dH:ZbflV:J:j:rR:aq' opt
+while getopts ':hvnDc:g:Gyx:wk:s:MSNXCPFUKIA:i:Lp:dH:bflV:J:j:rR:aq' opt
 do
   case "${opt}" in
 

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -6656,8 +6656,8 @@ fi
 # Drop the master address if passed
 if [ "$_SALT_MASTER_ADDRESS" != "null" ]; then
     [ ! -d "$_SALT_ETC_DIR/minion.d" ] && mkdir -p "$_SALT_ETC_DIR/minion.d"
-    cat <<_eof > $_SALT_ETC_DIR/minion.d/99-master-address.conf
-master: $_SALT_MASTER_ADDRESS
+    cat <<_eof > "$_SALT_ETC_DIR/minion.d/99-master-address.conf
+master: $_SALT_MASTER_ADDRESS"
 _eof
 fi
 

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -61,11 +61,11 @@ __DEFAULT_SLEEP=3
 _COLORS=${BS_COLORS:-$(tput colors 2>/dev/null || echo 0)}
 __detect_color_support() {
     if [ $? -eq 0 ] && [ "$_COLORS" -gt 2 ]; then
-        RC="\033[1;31m"
-        GC="\033[1;32m"
-        BC="\033[1;34m"
-        YC="\033[1;33m"
-        EC="\033[0m"
+        RC="\\033[1;31m"
+        GC="\\033[1;32m"
+        BC="\\033[1;34m"
+        YC="\\033[1;33m"
+        EC="\\033[0m"
     else
         RC=""
         GC=""
@@ -82,7 +82,7 @@ __detect_color_support
 #   DESCRIPTION:  Echo errors to stderr.
 #----------------------------------------------------------------------------------------------------------------------
 echoerror() {
-    printf "${RC} * ERROR${EC}: %s\n" "$@" 1>&2;
+    printf "${RC} * ERROR${EC}: %s\\n" "$@" 1>&2;
 }
 
 #---  FUNCTION  -------------------------------------------------------------------------------------------------------
@@ -90,7 +90,7 @@ echoerror() {
 #   DESCRIPTION:  Echo information to stdout.
 #----------------------------------------------------------------------------------------------------------------------
 echoinfo() {
-    printf "${GC} *  INFO${EC}: %s\n" "$@";
+    printf "${GC} *  INFO${EC}: %s\\n" "$@";
 }
 
 #---  FUNCTION  -------------------------------------------------------------------------------------------------------
@@ -98,7 +98,7 @@ echoinfo() {
 #   DESCRIPTION:  Echo warning information to stdout.
 #----------------------------------------------------------------------------------------------------------------------
 echowarn() {
-    printf "${YC} *  WARN${EC}: %s\n" "$@";
+    printf "${YC} *  WARN${EC}: %s\\n" "$@";
 }
 
 #---  FUNCTION  -------------------------------------------------------------------------------------------------------
@@ -107,7 +107,7 @@ echowarn() {
 #----------------------------------------------------------------------------------------------------------------------
 echodebug() {
     if [ "$_ECHO_DEBUG" -eq $BS_TRUE ]; then
-        printf "${BC} * DEBUG${EC}: %s\n" "$@";
+        printf "${BC} * DEBUG${EC}: %s\\n" "$@";
     fi
 }
 
@@ -891,6 +891,7 @@ __derive_debian_numeric_version() {
 #   DESCRIPTION:  Strip single or double quotes from the provided string.
 #----------------------------------------------------------------------------------------------------------------------
 __unquote_string() {
+    # shellcheck disable=SC1117
     echo "$*" | sed -e "s/^\([\"\']\)\(.*\)\1\$/\2/g"
 }
 
@@ -935,14 +936,14 @@ __sort_release_files() {
     max_prio="redhat-release centos-release oracle-release fedora-release"
     for entry in $max_prio; do
         if [ "$(echo "${primary_release_files}" | grep "$entry")" != "" ]; then
-            primary_release_files=$(echo "${primary_release_files}" | sed -e "s:\(.*\)\($entry\)\(.*\):\2 \1 \3:g")
+            primary_release_files=$(echo "${primary_release_files}" | sed -e "s:\\(.*\\)\\($entry\\)\\(.*\\):\\2 \\1 \\3:g")
         fi
     done
     # Now, least important goes last in the min_prio list
     min_prio="lsb-release"
     for entry in $min_prio; do
         if [ "$(echo "${primary_release_files}" | grep "$entry")" != "" ]; then
-            primary_release_files=$(echo "${primary_release_files}" | sed -e "s:\(.*\)\($entry\)\(.*\):\1 \3 \2:g")
+            primary_release_files=$(echo "${primary_release_files}" | sed -e "s:\\(.*\\)\\($entry\\)\\(.*\\):\\1 \\3 \\2:g")
         fi
     done
 
@@ -1159,17 +1160,17 @@ __gather_sunos_system_info() {
             case "$line" in
                 *OpenIndiana*oi_[0-9]*)
                     DISTRO_NAME="OpenIndiana"
-                    DISTRO_VERSION=$(echo "$line" | sed -nr "s/OpenIndiana(.*)oi_([[:digit:]]+)(.*)/\2/p")
+                    DISTRO_VERSION=$(echo "$line" | sed -nr "s/OpenIndiana(.*)oi_([[:digit:]]+)(.*)/\\2/p")
                     break
                     ;;
                 *OpenSolaris*snv_[0-9]*)
                     DISTRO_NAME="OpenSolaris"
-                    DISTRO_VERSION=$(echo "$line" | sed -nr "s/OpenSolaris(.*)snv_([[:digit:]]+)(.*)/\2/p")
+                    DISTRO_VERSION=$(echo "$line" | sed -nr "s/OpenSolaris(.*)snv_([[:digit:]]+)(.*)/\\2/p")
                     break
                     ;;
                 *Oracle*Solaris*[0-9]*)
                     DISTRO_NAME="Oracle Solaris"
-                    DISTRO_VERSION=$(echo "$line" | sed -nr "s/(Oracle Solaris) ([[:digit:]]+)(.*)/\2/p")
+                    DISTRO_VERSION=$(echo "$line" | sed -nr "s/(Oracle Solaris) ([[:digit:]]+)(.*)/\\2/p")
                     break
                     ;;
                 *Solaris*)
@@ -2204,7 +2205,7 @@ __overwriteconfig() {
     fi
 
     # Convert json string to a yaml string and write it to config file. Output is dumped into tempfile.
-    $good_python -c "import json; import yaml; jsn=json.loads('$json'); yml=yaml.safe_dump(jsn, line_break='\n', default_flow_style=False); config_file=open('$target', 'w'); config_file.write(yml); config_file.close();" 2>$tempfile
+    "$good_python" -c "import json; import yaml; jsn=json.loads('$json'); yml=yaml.safe_dump(jsn, line_break='\\n', default_flow_style=False); config_file=open('$target', 'w'); config_file.write(yml); config_file.close();" 2>$tempfile
 
     # No python errors output to the tempfile
     if [ ! -s "$tempfile" ]; then
@@ -2294,7 +2295,7 @@ __check_services_sysvinit() {
     servicename=$1
     echodebug "Checking if service ${servicename} is enabled"
 
-    if [ "$(LC_ALL=C /sbin/chkconfig --list | grep "\<${servicename}\>" | grep '[2-5]:on')" != "" ]; then
+    if [ "$(LC_ALL=C /sbin/chkconfig --list | grep "\\<${servicename}\\>" | grep '[2-5]:on')" != "" ]; then
         echodebug "Service ${servicename} is enabled"
         return 0
     else
@@ -2374,7 +2375,7 @@ __check_services_alpine() {
     echodebug "Checking if service ${servicename} is enabled"
 
     # shellcheck disable=SC2086,SC2046,SC2144
-    if rc-status $(rc-status -r) | tail -n +2 | grep -q "\<$servicename\>"; then
+    if rc-status $(rc-status -r) | tail -n +2 | grep -q "\\<$servicename\\>"; then
         echodebug "Service ${servicename} is enabled"
         return 0
     else
@@ -2428,7 +2429,7 @@ __activate_virtualenv() {
 __install_pip_pkgs() {
     _pip_pkgs="$1"
     _py_exe="$2"
-    _py_pkg=$(echo "$_py_exe" | sed -r "s/\.//g")
+    _py_pkg=$(echo "$_py_exe" | sed -r "s/\\.//g")
     _pip_cmd="${_py_exe} -m pip"
 
     if [ "${_py_exe}" = "" ]; then
@@ -3570,7 +3571,7 @@ __install_epel_repository() {
     fi
 
     # Check if epel repo is already enabled and flag it accordingly
-    yum repolist | grep -q "^[!]\?${_EPEL_REPO}/"
+    yum repolist | grep -q "^[!]\\?${_EPEL_REPO}/"
     if [ $? -eq 0 ]; then
         _EPEL_REPOS_INSTALLED=$BS_TRUE
         return 0
@@ -5004,7 +5005,7 @@ install_freebsd_git_deps() {
     if [ ! -f salt/syspaths.py ]; then
         # We still can't provide the system paths, salt 0.16.x
         # Let's patch salt's source and adapt paths to what's expected on FreeBSD
-        echodebug "Replacing occurrences of '/etc/salt' with \'${_SALT_ETC_DIR}\'"
+        echodebug "Replacing occurrences of '/etc/salt' with ${_SALT_ETC_DIR}"
         # The list of files was taken from Salt's BSD port Makefile
         for file in conf/minion conf/master salt/config.py salt/client.py \
                     salt/modules/mysql.py salt/utils/parsers.py salt/modules/tls.py \

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -61,11 +61,11 @@ __DEFAULT_SLEEP=3
 _COLORS=${BS_COLORS:-$(tput colors 2>/dev/null || echo 0)}
 __detect_color_support() {
     if [ $? -eq 0 ] && [ "$_COLORS" -gt 2 ]; then
-        RC="\\033[1;31m"
-        GC="\\033[1;32m"
-        BC="\\033[1;34m"
-        YC="\\033[1;33m"
-        EC="\\033[0m"
+        RC='\033[1;31m'
+        GC='\033[1;32m'
+        BC='\033[1;34m'
+        YC='\033[1;33m'
+        EC='\033[0m'
     else
         RC=""
         GC=""
@@ -6656,8 +6656,8 @@ fi
 # Drop the master address if passed
 if [ "$_SALT_MASTER_ADDRESS" != "null" ]; then
     [ ! -d "$_SALT_ETC_DIR/minion.d" ] && mkdir -p "$_SALT_ETC_DIR/minion.d"
-    cat <<_eof > "$_SALT_ETC_DIR/minion.d/99-master-address.conf
-master: $_SALT_MASTER_ADDRESS"
+    cat <<_eof > "$_SALT_ETC_DIR/minion.d/99-master-address.conf"
+master: $_SALT_MASTER_ADDRESS
 _eof
 fi
 

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -567,7 +567,7 @@ if [ "$#" -gt 0 ];then
 fi
 
 # Check installation type
-if [ "$(echo "$ITYPE" | egrep '(stable|testing|daily|git)')" = "" ]; then
+if [ "$(echo "$ITYPE" | grep -E '(stable|testing|daily|git)')" = "" ]; then
     echoerror "Installation type \"$ITYPE\" is not known..."
     exit 1
 fi
@@ -589,10 +589,10 @@ elif [ "$ITYPE" = "stable" ]; then
     if [ "$#" -eq 0 ];then
         STABLE_REV="latest"
     else
-        if [ "$(echo "$1" | egrep '^(latest|1\.6|1\.7|2014\.1|2014\.7|2015\.5|2015\.8|2016\.3|2016\.11|2017\.7|2018\.3)$')" != "" ]; then
+        if [ "$(echo "$1" | grep -E '^(latest|1\.6|1\.7|2014\.1|2014\.7|2015\.5|2015\.8|2016\.3|2016\.11|2017\.7|2018\.3)$')" != "" ]; then
             STABLE_REV="$1"
             shift
-        elif [ "$(echo "$1" | egrep '^([0-9]*\.[0-9]*\.[0-9]*)$')" != "" ]; then
+        elif [ "$(echo "$1" | grep -E '^([0-9]*\.[0-9]*\.[0-9]*)$')" != "" ]; then
             STABLE_REV="archive/$1"
             shift
         else
@@ -923,7 +923,7 @@ __sort_release_files() {
     secondary_release_files=""
     # Sort know VS un-known files first
     for release_file in $(echo "${@}" | sed -r 's:[[:space:]]:\n:g' | sort -f | uniq); do
-        match=$(echo "$release_file" | egrep -i "${KNOWN_RELEASE_FILES}")
+        match=$(echo "$release_file" | grep -E -i "${KNOWN_RELEASE_FILES}")
         if [ "${match}" != "" ]; then
             primary_release_files="${primary_release_files} ${release_file}"
         else
@@ -1031,11 +1031,11 @@ __gather_linux_system_info() {
         v=$(__parse_version_string "$rv")
         case $shortname in
             redhat             )
-                if [ "$(egrep 'CentOS' /etc/${rsource})" != "" ]; then
+                if [ "$(grep -E 'CentOS' /etc/${rsource})" != "" ]; then
                     n="CentOS"
-                elif [ "$(egrep 'Scientific' /etc/${rsource})" != "" ]; then
+                elif [ "$(grep -E 'Scientific' /etc/${rsource})" != "" ]; then
                     n="Scientific Linux"
-                elif [ "$(egrep 'Red Hat Enterprise Linux' /etc/${rsource})" != "" ]; then
+                elif [ "$(grep -E 'Red Hat Enterprise Linux' /etc/${rsource})" != "" ]; then
                     n="<R>ed <H>at <E>nterprise <L>inux"
                 else
                     n="<R>ed <H>at <L>inux"
@@ -1272,7 +1272,7 @@ __ubuntu_derivatives_translation() {
     neon_16_ubuntu_base="16.04"
 
     # Translate Ubuntu derivatives to their base Ubuntu version
-    match=$(echo "$DISTRO_NAME_L" | egrep ${UBUNTU_DERIVATIVES})
+    match=$(echo "$DISTRO_NAME_L" | grep -E ${UBUNTU_DERIVATIVES})
 
     if [ "${match}" != "" ]; then
         case $match in
@@ -1417,7 +1417,7 @@ __debian_derivatives_translation() {
     raspbian_9_debian_base="9.0"
 
     # Translate Debian derivatives to their base Debian version
-    match=$(echo "$DISTRO_NAME_L" | egrep ${DEBIAN_DERIVATIVES})
+    match=$(echo "$DISTRO_NAME_L" | grep -E ${DEBIAN_DERIVATIVES})
 
     if [ "${match}" != "" ]; then
         case $match in
@@ -1728,14 +1728,14 @@ fi
 if ([ "${DISTRO_NAME_L}" != "ubuntu" ] && [ "$ITYPE" = "daily" ]); then
     echoerror "${DISTRO_NAME} does not have daily packages support"
     exit 1
-elif ([ "$(echo "${DISTRO_NAME_L}" | egrep '(debian|ubuntu|centos|red_hat|oracle|scientific|amazon)')" = "" ] && [ "$ITYPE" = "stable" ] && [ "$STABLE_REV" != "latest" ]); then
+elif ([ "$(echo "${DISTRO_NAME_L}" | grep -E '(debian|ubuntu|centos|red_hat|oracle|scientific|amazon)')" = "" ] && [ "$ITYPE" = "stable" ] && [ "$STABLE_REV" != "latest" ]); then
     echoerror "${DISTRO_NAME} does not have major version pegged packages support"
     exit 1
 fi
 
 # Only RedHat based distros have testing support
 if [ "${ITYPE}" = "testing" ]; then
-    if [ "$(echo "${DISTRO_NAME_L}" | egrep '(centos|red_hat|amazon|oracle)')" = "" ]; then
+    if [ "$(echo "${DISTRO_NAME_L}" | grep -E '(centos|red_hat|amazon|oracle)')" = "" ]; then
         echoerror "${DISTRO_NAME} does not have testing packages support"
         exit 1
     fi
@@ -4474,13 +4474,13 @@ install_amazon_linux_ami_deps() {
         repo_rev="latest"
     fi
 
-    if echo $repo_rev | egrep -q '^archive'; then
+    if echo $repo_rev | grep -E -q '^archive'; then
         year=$(echo "$repo_rev" | cut -d '/' -f 2 | cut -c1-4)
     else
         year=$(echo "$repo_rev" | cut -c1-4)
     fi
 
-    if echo "$repo_rev" | egrep -q '^(latest|2016\.11)$' || \
+    if echo "$repo_rev" | grep -E -q '^(latest|2016\.11)$' || \
             [ "$year" -gt 2016 ]; then
        _USEAWS=$BS_TRUE
        pkg_append="python27"


### PR DESCRIPTION
### What does this PR do?
Fixes a bunch of shellcheck errors found when running the latest version of shellcheck:
```
shellcheck --version
ShellCheck - shell script analysis tool
version: 0.4.7
license: GNU General Public License, version 3
website: http://www.shellcheck.net
```

Fixes the following error types:
- SC2196: egrep is non-standard and deprecated. Use grep -E instead.
- SC1117: Backslash is literal in "\n". Prefer explicit escaping: "\\n".
- SC2086: Double quote to prevent globbing and word splitting.
- SC2213: getopts specified -Z, but it's not handled by this 'case'.

### What issues does this PR fix or reference?
This is needed as part of #1207, since we'll have a newer versions of shellcheck on the new test runs.

TODO: There is still one major shellcheck error to take care of before a clean run is possible. But this PR is a good first step. Another PR will be needed to clean up the `SC2181: Check exit code directly with e.g. 'if mycmd;', not indirectly with $?.` errors as there are many.

@vutny Can you look over this one as well?