### PR TITLE
Disable shell error about unbound variable during daily install

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -584,6 +584,10 @@ if [ "$ITYPE" = "git" ]; then
     # Disable shell warning about unbound variable during git install
     STABLE_REV="latest"
 
+elif [ "$ITYPE" = "daily" ]; then
+    # Disable shell error about unbound variable during daily install
+    STABLE_REV="latest"
+
 # If doing stable install, check if version specified
 elif [ "$ITYPE" = "stable" ]; then
     if [ "$#" -eq 0 ];then


### PR DESCRIPTION
### What does this PR do?

Disable shell error about unbound variable during daily install

### What issues does this PR fix or reference?

When using with `daily` option on `ubuntu` system, the `bootstraps` fails due to `shell` error

```
./bootstrap-salt.sh: 2598: ./bootstrap-salt.sh: STABLE_REV: parameter not set
```

### Previous Behavior

The bootstrap fails with `daily` option on Ubuntu system.

### New Behavior

The bootstrap continues with `daily` option on Ubuntu system.
