### PR TITLE
Return immediately if apt-get fails

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2621,7 +2621,7 @@ __install_saltstack_ubuntu_repository() {
     __apt_key_fetch "$SALTSTACK_UBUNTU_URL/SALTSTACK-GPG-KEY.pub" || return 1
 
     __wait_for_apt
-    apt-get update
+    apt-get update || return 1
 }
 
 install_ubuntu_deps() {
@@ -2634,7 +2634,7 @@ install_ubuntu_deps() {
         __enable_universe_repository || return 1
 
         __wait_for_apt
-        apt-get update
+        apt-get update || return 1
     fi
 
     __PACKAGES=''
@@ -2691,12 +2691,12 @@ install_ubuntu_stable_deps() {
     export DEBIAN_FRONTEND=noninteractive
 
     __wait_for_apt
-    apt-get update
+    apt-get update || return 1
 
     if [ "${_UPGRADE_SYS}" -eq $BS_TRUE ]; then
         if [ "${_INSECURE_DL}" -eq $BS_TRUE ]; then
             __apt_get_install_noinput --allow-unauthenticated debian-archive-keyring &&
-                apt-key update && apt-get update
+                apt-key update && apt-get update || return 1
         fi
 
         __apt_get_upgrade_noinput || return 1
@@ -2718,7 +2718,7 @@ install_ubuntu_daily_deps() {
         __enable_universe_repository || return 1
 
         add-apt-repository -y ppa:saltstack/salt-daily || return 1
-        apt-get update
+        apt-get update || return 1
     fi
 
     if [ "$_UPGRADE_SYS" -eq $BS_TRUE ]; then
@@ -2730,7 +2730,7 @@ install_ubuntu_daily_deps() {
 
 install_ubuntu_git_deps() {
     __wait_for_apt
-    apt-get update
+    apt-get update || return 1
 
     if ! __check_command_exists git; then
         __apt_get_install_noinput git-core || return 1
@@ -3045,7 +3045,7 @@ __install_saltstack_debian_repository() {
     __apt_key_fetch "$SALTSTACK_DEBIAN_URL/SALTSTACK-GPG-KEY.pub" || return 1
 
     __wait_for_apt
-    apt-get update
+    apt-get update || return 1
 }
 
 install_debian_deps() {
@@ -3057,13 +3057,13 @@ install_debian_deps() {
     export DEBIAN_FRONTEND=noninteractive
 
     __wait_for_apt
-    apt-get update
+    apt-get update || return 1
 
     if [ "${_UPGRADE_SYS}" -eq $BS_TRUE ]; then
         # Try to update GPG keys first if allowed
         if [ "${_INSECURE_DL}" -eq $BS_TRUE ]; then
             __apt_get_install_noinput --allow-unauthenticated debian-archive-keyring &&
-                apt-key update && apt-get update
+                apt-key update && apt-get update || return 1
         fi
 
         __apt_get_upgrade_noinput || return 1


### PR DESCRIPTION
### What does this PR do?

Return immediately if `apt-get update` fails

### What issues does this PR fix or reference?

If `apt-get update` fails for any reason (due to `salt` nor not, see also #1245), system administrator may need to fix the issue before going further. By returning quickly the script can save quite a lot of time.

### Previous Behavior

The bootstrap continues with a few execution of `apt-get update` even they fail.

### New Behavior

The bootstrap returns quickly after any failure of `apt-get update` command.