### PR TITLE
Add python 3 support for Ubuntu 18

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -333,6 +333,7 @@ this offering, while limited, is as follows:
 - CentOS 7
 - Debian 9
 - Ubuntu 16.04
+- Ubuntu 18.04
 
 Installing the Python 3 packages for Salt is done via the ``-x`` option:
 

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2774,6 +2774,8 @@ install_ubuntu_git_deps() {
 
         if [ -n "$_PY_EXE" ] && [ "$_PY_MAJOR_VERSION" -eq 3 ]; then
             PY_PKG_VER=3
+
+            __PACKAGES="${__PACKAGES} python3-setuptools"
         else
             PY_PKG_VER=""
 


### PR DESCRIPTION
Stable installs work fine, but git installs need an additional package to be installed (python3-setuptools). Otherwise, the script fails with the following error:

```
*  INFO: Running install_ubuntu_git()
Traceback (most recent call last):
  File "setup.py", line 24, in <module>
    import distutils.dist
ModuleNotFoundError: No module named 'distutils.dist'
```

