### PR TITLE
Remove daily install option on Ubuntu system

### DIFF
--- a/tests/bootstrap/test_install.py
+++ b/tests/bootstrap/test_install.py
@@ -270,39 +270,6 @@ class InstallationTestCase(BootstrapTestCase):
             )
         )
 
-    def test_install_daily(self):
-        args = []
-        if requires_pip_based_installations():
-            args.append('-P')
-
-        args.append('daily')
-
-        rc, out, err = self.run_script(
-            args=args, timeout=15 * 60, stream_stds=True
-        )
-        if GRAINS['os'] in ('Ubuntu', 'Trisquel', 'Mint'):
-            self.assert_script_result(
-                'Failed to install daily',
-                0, (rc, out, err)
-            )
-
-            # Try to get the versions report
-            self.assert_script_result(
-                'Failed to get the versions report (\'--versions-report\')',
-                0,
-                self.run_script(
-                    script=None,
-                    args=('salt-minion', '--versions-report'),
-                    timeout=15 * 60,
-                    stream_stds=True
-                )
-            )
-        else:
-            self.assert_script_result(
-                'Although system is not Ubuntu, we managed to install',
-                1, (rc, out, err)
-            )
-
     def test_install_testing(self):
         args = []
         if requires_pip_based_installations():


### PR DESCRIPTION
### What does this PR do?

Remove `daily` install option on Ubuntu system as the repository on Launchpad is not actively maintained.

### What issues does this PR fix or reference?

* https://github.com/saltstack/salt-bootstrap/issues/1245
* https://github.com/saltstack/salt-pack/issues/562

### Previous Behavior

On Ubuntu system, system administrator can invoke `bootstrap-salt.sh daily`  to configure ppa repository (http://ppa.launchpad.net/saltstack/salt-daily/ubuntu) however `apt-get update` will get error as the remote ppa repository is not actively maintained.

### New Behavior

`daily` option is not valid on Ubuntu system. Related code and tests are removed.
