### PR TITLE
fix for opensuse15 if no lsb_release pkg

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1089,8 +1089,12 @@ __gather_linux_system_info() {
                         n="Debian"
                         v=$(__derive_debian_numeric_version "$v")
                         ;;
-                    sles|opensuse  )
+                    sles  )
                         n="SUSE"
+                        v="${rv}"
+                        ;;
+                    opensuse-leap  )
+                        n="opensuse"
                         v="${rv}"
                         ;;
                     *           )


### PR DESCRIPTION
### What does this PR do?
If `lsb-release` is not found on OpenSuse Leap 15.0 then bootstrap fails. 

However, OpenSUSE now ships an`/etc/os-release` file so can be used instead.


### What issues does this PR fix or reference?
Fixes #1254  and compliments #1244 (merged)

### Previous Behavior
Remove this section if not relevant

### New Behavior

```
vagrant@vagrant-openSUSE-Leap:~> sudo sh bootstrap-salt.sh git develop
 *  INFO: Running version: 2018.04.25
 *  INFO: Executed by: sh
 *  INFO: Command line: 'bootstrap-salt.sh git develop'
 *  WARN: Running the unstable version of bootstrap-salt.sh

 *  INFO: System Information:
 *  INFO:   CPU:          GenuineIntel
 *  INFO:   CPU Arch:     x86_64
 *  INFO:   OS Name:      Linux
 *  INFO:   OS Version:   4.12.14-lp150.12.4-default
 *  INFO:   Distribution: opensuse 15.0

 *  INFO: Installing minion
 *  INFO: Found function install_opensuse_git_deps
 *  INFO: Found function config_salt
 *  INFO: Found function preseed_master
 *  INFO: Found function install_opensuse_git
 *  INFO: Found function install_opensuse_git_post
 *  INFO: Found function install_opensuse_restart_daemons
 *  INFO: Found function daemons_running
 *  INFO: Found function install_opensuse_check_services
 *  INFO: Running install_opensuse_git_deps()
File '/opensuse/openSUSE_Leap_15.0/systemsmanagement:saltstack:products.repo' not found on medium 'https://repo.saltstack.com/'
Abort, retry, ignore? [a/r/i/...? shows all options] (a): a
Abort, retry, ignore? [a/r/i/...? shows all options] (a): a
Problem encountered while trying to read the file at the specified URI:
ABORT request: Aborting requested by user
Repository 'openSUSE Non-OSS' is up to date.
Retrieving repository 'openSUSE OSS' metadata [..^C
Download (curl) error for 'http://download.opensuse.org/distribution/leap/15.0/repo/oss/repodata/repomd.xml':
Error code: User abort
Error message: Callback aborted

Abort, retry, ignore? [a/r/i/...? shows all options] (a): a
error]
Repository 'openSUSE OSS' is invalid.
```

