### PR TITLE
Ensure pipe is absent before mkfifo/mknod

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -457,6 +457,8 @@ shift $((OPTIND-1))
 # Define our logging file and pipe paths
 LOGFILE="/tmp/$( echo "$__ScriptName" | sed s/.sh/.log/g )"
 LOGPIPE="/tmp/$( echo "$__ScriptName" | sed s/.sh/.logpipe/g )"
+# Ensure no residual pipe exists
+rm "$LOGPIPE" 2>/dev/null
 
 # Create our logging pipe
 # On FreeBSD we have to use mkfifo instead of mknod


### PR DESCRIPTION
### What does this PR do?

Before invoking `mknod/mkfifo`  ensure `pipe` is absent on the file system.

### What issues does this PR fix or reference?

When `bootstrap-salt.sh` script terminates abnormally (SIGKILL, kernel crash, etc), subsequent runs could fail - in my case, a FreeBSD VM crash (caused by a [ACPI kernel bug](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=209222))
```
kernel: ACPI Error No installed handler for fixed event - P_Timer, disabling
kernel: ACPI Error No installed handler for fixed event - Realtimeclock, disabling
kernel: ACPI Error No installed handler for fixed event - GPE 0
etc ... <fatal kernel crash>
``` 
### Previous Behavior

Execution Error:
```
root@:~ # sh bootstrap_salt.sh
 * ERROR: Failed to create the named pipe required to log
root@:~ # sh bootstrap_salt.sh -D
 * ERROR: Failed to create the named pipe required to log
```

### New Behavior

The error is gone.

