### PR TITLE
Use stack to get a newer shellcheck

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -72,7 +72,7 @@ node ('bootstrap') {
         echo "${env.CHANGE_URL}"
     }
     stage('shellcheck') {
-        sh 'shellcheck -s sh -f checkstyle bootstrap-salt.sh | tee checkstyle.xml'
+        sh 'stack exec -- shellcheck -s sh -f checkstyle bootstrap-salt.sh | tee checkstyle.xml'
         checkstyle pattern: '**/checkstyle.xml'
         archiveArtifacts artifacts: '**/checkstyle.xml'
     }


### PR DESCRIPTION
Uses stack on the bootstrap server instead of the installed shellcheck (takes us from version 0.3.5 to 0.4.7, soon we'll get moved to 0.5.0 hopefully).

@rallytime  this should make some of your fixes actually mean something to shellcheck. 