### PR TITLE
Remove support for Ubuntu 17.10

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -286,8 +286,8 @@ repositories are not provided on `SaltStack's Ubuntu repository`_ for the non-LT
 bootstrap script will attempt to install the packages for the most closely related LTS Ubuntu
 release instead.
 
-For example, when installing Salt on Ubuntu 17.10, the bootstrap script will setup the repository
-for Ubuntu 16.04 from `SaltStack's Ubuntu repository`_ and install the 16.04 packages.
+For example, when installing Salt on Ubuntu 18.10, the bootstrap script will setup the repository
+for Ubuntu 18.04 from `SaltStack's Ubuntu repository`_ and install the 18.04 packages.
 
 Non-LTS Ubuntu releases are not supported once the release reaches End-of-Life as defined by
 `Ubuntu's release schedule`_.

--- a/README.rst
+++ b/README.rst
@@ -289,6 +289,9 @@ release instead.
 For example, when installing Salt on Ubuntu 17.10, the bootstrap script will setup the repository
 for Ubuntu 16.04 from `SaltStack's Ubuntu repository`_ and install the 16.04 packages.
 
+Non-LTS Ubuntu releases are not supported once the release reaches End-of-Life as defined by
+`Ubuntu's release schedule`_.
+
 
 Other Linux distributions
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -401,6 +404,7 @@ Salt components, custom configurations, and even `pre-accepted Minion keys`_ alr
 .. _`SaltStack's corporate repository`: https://repo.saltstack.com/
 .. _`SaltStack's Debian repository`: http://repo.saltstack.com/#debian
 .. _`SaltStack's Ubuntu repository`: http://repo.saltstack.com/#ubuntu
+.. _`Ubuntu's release schedule`: https://wiki.ubuntu.com/Releases
 .. _Vagrant: http://www.vagrantup.com
 
 

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1382,9 +1382,6 @@ __ubuntu_codename_translation() {
         "16")
             DISTRO_CODENAME="xenial"
             ;;
-        "17")
-            DISTRO_CODENAME="artful"
-            ;;
         "18")
             DISTRO_CODENAME="bionic"
             ;;
@@ -1506,11 +1503,11 @@ __check_end_of_life_versions() {
             #  = 14.10
             #  = 15.04, 15.10
             #  = 16.10
-            #  = 17.04
+            #  = 17.04, 17.10
             if [ "$DISTRO_MAJOR_VERSION" -lt 14 ] || \
                 [ "$DISTRO_MAJOR_VERSION" -eq 15 ] || \
-                { [ "$DISTRO_MAJOR_VERSION" -eq 17 ] && [ "$DISTRO_MINOR_VERSION" -eq 04 ]; } || \
-                { [ "$DISTRO_MAJOR_VERSION" -lt 17 ] && [ "$DISTRO_MINOR_VERSION" -eq 10 ]; }; then
+                [ "$DISTRO_MAJOR_VERSION" -eq 17 ] || \
+                { [ "$DISTRO_MAJOR_VERSION" -eq 16 ] && [ "$DISTRO_MINOR_VERSION" -eq 10 ]; }; then
                 echoerror "End of life distributions are not supported."
                 echoerror "Please consider upgrading to the next stable. See:"
                 echoerror "    https://wiki.ubuntu.com/Releases"
@@ -2576,11 +2573,7 @@ __enable_universe_repository() {
 
 __install_saltstack_ubuntu_repository() {
     # Workaround for latest non-LTS ubuntu
-    if [ "$DISTRO_MAJOR_VERSION" -eq 17 ]; then
-        echowarn "Non-LTS Ubuntu detected, but stable packages requested. Trying packages for 16.04 LTS release. You may experience problems."
-        UBUNTU_VERSION=16.04
-        UBUNTU_CODENAME="xenial"
-    elif [ "$DISTRO_MAJOR_VERSION" -gt 18 ]; then
+    if [ "$DISTRO_MAJOR_VERSION" -gt 18 ]; then
         echowarn "Non-LTS Ubuntu detected, but stable packages requested. Trying packages for latest LTS release. You may experience problems."
         UBUNTU_VERSION=18.04
         UBUNTU_CODENAME="bionic"

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2573,7 +2573,7 @@ __enable_universe_repository() {
 
 __install_saltstack_ubuntu_repository() {
     # Workaround for latest non-LTS ubuntu
-    if [ "$DISTRO_MAJOR_VERSION" -gt 18 ]; then
+    if [ "$DISTRO_MAJOR_VERSION" -gt 18 ] || [ "${DISTRO_VERSION}" -eq "18.10" ]; then
         echowarn "Non-LTS Ubuntu detected, but stable packages requested. Trying packages for latest LTS release. You may experience problems."
         UBUNTU_VERSION=18.04
         UBUNTU_CODENAME="bionic"


### PR DESCRIPTION
Ubuntu 17.10 will be EOL any day now, as Ubuntu's release calendar says support will end in July 2018.

This commit removes support for the 17.10 (non-LTS) release. The README file was also updated to clarify when support for non-LTS releases will be removed from bootstrap.

**DO NOT MERGE UNTIL 17.10 IS OFFICIALLY EOL**

Release schedule: https://wiki.ubuntu.com/Releases


