### PR TITLE
Remove support for Fedora 26

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -257,7 +257,7 @@ Red Hat family
 - Amazon Linux 2012.3 and later
 - CentOS 6/7
 - Cloud Linux 6/7
-- Fedora 26/27/28 (install latest stable from standard repositories)
+- Fedora 27/28 (install latest stable from standard repositories)
 - Oracle Linux 6/7
 - Red Hat Enterprise Linux 6/7
 - Scientific Linux 6/7

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1552,8 +1552,8 @@ __check_end_of_life_versions() {
             ;;
 
         fedora)
-            # Fedora lower than 26 are no longer supported
-            if [ "$DISTRO_MAJOR_VERSION" -lt 26 ]; then
+            # Fedora lower than 27 are no longer supported
+            if [ "$DISTRO_MAJOR_VERSION" -lt 27 ]; then
                 echoerror "End of life distributions are not supported."
                 echoerror "Please consider upgrading to the next stable. See:"
                 echoerror "    https://fedoraproject.org/wiki/Releases"
@@ -3400,14 +3400,8 @@ install_debian_check_services() {
 
 install_fedora_deps() {
 
-    __PACKAGES="libyaml m2crypto PyYAML python-crypto python-jinja2"
+    __PACKAGES="dnf-utils libyaml m2crypto PyYAML python-crypto python-jinja2"
     __PACKAGES="${__PACKAGES} python2-msgpack python2-requests python-zmq"
-
-    if [ "$DISTRO_MAJOR_VERSION" -lt 26 ]; then
-        __PACKAGES="${__PACKAGES} yum-utils"
-    else
-        __PACKAGES="${__PACKAGES} dnf-utils"
-    fi
 
     # shellcheck disable=SC2086
     dnf install -y ${__PACKAGES} || return 1


### PR DESCRIPTION
Fedora 26 is EOL as of the end of May, therefore the bootstrap script no longer needs to support it.

