### PR TITLE
Add opensuse 15 specific installation functions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -266,9 +266,18 @@ Red Hat family
 SUSE family
 ~~~~~~~~~~~
 
+- openSUSE Leap 15 (see note below)
 - openSUSE Leap 42.3
 - openSUSE Tumbleweed 2015
 - SUSE Linux Enterprise Server 11 SP4, 12 SP2
+
+**NOTE:** Leap 15 installs Python 3 Salt packages by default. Salt is packaged by SUSE, and
+Leap 15 ships with Python 3. Salt with Python 2 can be installed using the the ``-x`` option
+in combination with the ``git`` installation method.
+
+.. code:: console
+
+    sh bootstrap-salt.sh -x python2 git v2018.3.2
 
 
 Ubuntu and derivatives


### PR DESCRIPTION
### What does this PR do?
Adds more robust support for installing Salt on openSUSE Leap 15.

Currently, SUSE has packaged version 2018.3.0. The simplest way to install this using bootstrap is:
```
sh bootstrap-salt.sh -w
```
(This uses their upstream repo.)

If a newer version is necessary, use the `git` installation method:
```
sh bootstrap-salt.sh git v2018.3.2
```

Please note that Leap 15 ships only with Python 3. Therefore, the Salt packages that will install are the Python 3 versions. This is different from most distributions in bootstrap as the default installation is Python 2 for everything else.

I have added support for installing Salt with Python 2 by doing the following:
```
sh bootstrap-salt.sh -x python2 git v2018.3.2
```

However, I have run into issues as it seems there is a bug somewhere is this approach as the cryptography layer is not working correctly:
```
localhost:~ # salt-call --versions
Traceback (most recent call last):
  File "/usr/bin/salt-call", line 11, in <module>
    salt_call()
  File "/usr/lib/python2.7/site-packages/salt/scripts.py", line 391, in salt_call
    import salt.cli.call
  File "/usr/lib/python2.7/site-packages/salt/cli/call.py", line 9, in <module>
    import salt.cli.caller
  File "/usr/lib/python2.7/site-packages/salt/cli/caller.py", line 18, in <module>
    import salt.loader
  File "/usr/lib/python2.7/site-packages/salt/loader.py", line 28, in <module>
    import salt.utils.event
  File "/usr/lib/python2.7/site-packages/salt/utils/event.py", line 74, in <module>
    import salt.payload
  File "/usr/lib/python2.7/site-packages/salt/payload.py", line 17, in <module>
    import salt.crypt
  File "/usr/lib/python2.7/site-packages/salt/crypt.py", line 55, in <module>
    import salt.utils.rsax931
  File "/usr/lib/python2.7/site-packages/salt/utils/rsax931.py", line 85, in <module>
    libcrypto = _init_libcrypto()
  File "/usr/lib/python2.7/site-packages/salt/utils/rsax931.py", line 76, in _init_libcrypto
    raise OSError("Failed to initialize OpenSSL library (OPENSSL_init_crypto failed)")
OSError: Failed to initialize OpenSSL library (OPENSSL_init_crypto failed)
```

I am not a suse expert, so I may be missing a step somewhere. I can look at this more tomorrow, but I wanted to get this posted in case anyone has seen this before.

@noelmcloughlin and @vutny FYI