### PR TITLE
SLES12SP changed packages git to git-core and libzmq3 to libzmq4

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -5894,14 +5894,14 @@ install_suse_12_git_deps() {
     install_suse_12_stable_deps || return 1
 
     if ! __check_command_exists git; then
-        __zypper_install git  || return 1
+        __zypper_install git-core  || return 1
     fi
 
     __git_clone_and_checkout || return 1
 
     __PACKAGES=""
     # shellcheck disable=SC2089
-    __PACKAGES="${__PACKAGES} libzmq3 python-Jinja2 python-msgpack-python python-pycrypto"
+    __PACKAGES="${__PACKAGES} libzmq4 python-Jinja2 python-msgpack-python python-pycrypto"
     __PACKAGES="${__PACKAGES} python-pyzmq python-xml"
 
     if [ -f "${_SALT_GIT_CHECKOUT_DIR}/requirements/base.txt" ]; then


### PR DESCRIPTION
### What does this PR do?
Fix two packages for SLES12SP2. 

### What issues does this PR fix or reference?
Bootstrap-salt.sh installs the git package. 
On SLES12SP2 the package should be git-core instead of git.
Bootstrap-salt.sh installs the libzmq3 package.
On SLES12SP2 the package should be libzmq4 instead of libzmq3

### Previous Behavior
Failed to bootstrap salt on SLES12SP2 because of failed dependencies. 

### New Behavior
Succeeds to bootstrap salt on SLES12SP2

