### PR TITLE
Fedora Py3 fixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -342,10 +342,15 @@ Python 3 Support
 Some distributions support installing Salt to use Python 3 instead of Python 2. The availability of
 this offering, while limited, is as follows:
 
+- CentOS 6
 - CentOS 7
 - Debian 9
+- Fedora
 - Ubuntu 16.04
 - Ubuntu 18.04
+
+The Fedora and CentOS 6 options only support git installations.
+On Fedora 28, PIP installation must be allowed (-P) due to incompatibility with the shipped Tornado library.
 
 Installing the Python 3 packages for Salt is done via the ``-x`` option:
 

--- a/README.rst
+++ b/README.rst
@@ -342,14 +342,12 @@ Python 3 Support
 Some distributions support installing Salt to use Python 3 instead of Python 2. The availability of
 this offering, while limited, is as follows:
 
-- CentOS 6
 - CentOS 7
 - Debian 9
-- Fedora
+- Fedora (only git installations)
 - Ubuntu 16.04
 - Ubuntu 18.04
 
-The Fedora and CentOS 6 options only support git installations.
 On Fedora 28, PIP installation must be allowed (-P) due to incompatibility with the shipped Tornado library.
 
 Installing the Python 3 packages for Salt is done via the ``-x`` option:

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -3429,8 +3429,8 @@ install_fedora_deps() {
        fi
     fi
 
-    __PACKAGES="dnf-utils ${__PACKAGES} python${PY_PKG_VER}-crypto python${PY_PKG_VER}-requests python${PY_PKG_VER}-zmq"
-    __PACKAGES="${__PACKAGES} libyaml python${PY_PKG_VER}-jinja2 python${PY_PKG_VER}-msgpack"
+    __PACKAGES="${__PACKAGES} dnf-utils libyaml python${PY_PKG_VER}-crypto python${PY_PKG_VER}-jinja2"
+    __PACKAGES="${__PACKAGES} python${PY_PKG_VER}-msgpack python${PY_PKG_VER}-requests python${PY_PKG_VER}-zmq"
 
     # shellcheck disable=SC2086
     dnf install -y ${__PACKAGES} || return 1

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -381,8 +381,8 @@ __usage() {
         a complete overwrite of the file.
     -q  Quiet salt installation from git (setup.py install -q)
     -x  Changes the Python version used to install Salt. Currently, this is only
-        supported on CentOS 7, Debian 9, Ubuntu 16 and CentOS 6. The CentOS 6
-        option only works with git installations.
+        supported on CentOS 6+, Debian 9+, Ubuntu 16+, and Fedora.
+        The Fedora and CentOS 6 options only work with git installations.
     -y  Installs a different python version on host. Currently this has only been
         tested with CentOS 6 and is considered experimental. This will install the
         ius repo on the box if disable repo is false. This must be used in conjunction

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -3509,9 +3509,9 @@ install_fedora_git_deps() {
     __PACKAGES="python${PY_PKG_VER}-systemd"
     if [ "${PY_PKG_VER}" -eq 3 ] && [ "$DISTRO_MAJOR_VERSION" -ge 28 ]; then
         __check_pip_allowed "You need to allow pip based installations (-P) for Tornado <5.0 in order to install Salt on Python 3"
-        # shellcheck disable=SC2039
-        grep tornado "${_SALT_GIT_CHECKOUT_DIR}/requirements/base.txt" | while IFS=$'\n' read -r dep; do
-          "${_PY_EXE}" -m pip install "${dep}" || return 1
+        grep tornado "${_SALT_GIT_CHECKOUT_DIR}/requirements/base.txt" | while IFS='
+'         read -r dep; do
+            "${_PY_EXE}" -m pip install "${dep}" || return 1
         done
     else
         __PACKAGES="${__PACKAGES} python${PY_PKG_VER}-tornado"

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -3506,7 +3506,15 @@ install_fedora_git_deps() {
 
     __git_clone_and_checkout || return 1
 
-    __PACKAGES="python${PY_PKG_VER}-tornado python${PY_PKG_VER}-systemd"
+    __PACKAGES="python${PY_PKG_VER}-systemd"
+    if [ "${PY_PKG_VER}" -eq 3 -a "$DISTRO_MAJOR_VERSION" -ge 28 ]; then
+        __check_pip_allowed "You need to allow pip based installations (-P) for Tornado <5.0 in order to install Salt on Python 3"
+        grep tornado "${_SALT_GIT_CHECKOUT_DIR}/requirements/base.txt" | while IFS=$'\n' read -r dep; do
+          "${_PY_EXE}" -m pip install "${dep}" || return 1
+        done
+    else
+        __PACKAGES="${__PACKAGES} python${PY_PKG_VER}-tornado"
+    fi
 
     if [ "$_INSTALL_CLOUD" -eq $BS_TRUE ]; then
         __PACKAGES="${__PACKAGES} python${PY_PKG_VER}-libcloud python${PY_PKG_VER}-netaddr"

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -3415,9 +3415,22 @@ install_debian_check_services() {
 #
 
 install_fedora_deps() {
+    if [ -n "$_PY_EXE" ] && [ "$_PY_MAJOR_VERSION" -eq 3 ]; then
+        # Packages are named python3-<whatever>
+        PY_PKG_VER=3
+        __PACKAGES="python3-m2crypto python3-PyYAML"
+    else
+        PY_PKG_VER=2
+        __PACKAGES="m2crypto"
+        if [ "$DISTRO_MAJOR_VERSION" -ge 28 ]; then
+          __PACKAGES="${__PACKAGES} python2-pyyaml"
+        else
+          __PACKAGES="${__PACKAGES} PyYAML"
+       fi
+    fi
 
-    __PACKAGES="dnf-utils libyaml m2crypto PyYAML python-crypto python-jinja2"
-    __PACKAGES="${__PACKAGES} python2-msgpack python2-requests python-zmq"
+    __PACKAGES="dnf-utils ${__PACKAGES} python${PY_PKG_VER}-crypto python${PY_PKG_VER}-requests python${PY_PKG_VER}-zmq"
+    __PACKAGES="${__PACKAGES} libyaml python${PY_PKG_VER}-jinja2 python${PY_PKG_VER}-msgpack"
 
     # shellcheck disable=SC2086
     dnf install -y ${__PACKAGES} || return 1
@@ -3474,6 +3487,12 @@ install_fedora_stable_post() {
 }
 
 install_fedora_git_deps() {
+    if [ -n "$_PY_EXE" ] && [ "$_PY_MAJOR_VERSION" -eq 3 ]; then
+        # Packages are named python3-<whatever>
+        PY_PKG_VER=3
+    else
+        PY_PKG_VER=2
+    fi
 
     if [ "$_INSECURE_DL" -eq $BS_FALSE ] && [ "${_SALT_REPO_URL%%://*}" = "https" ]; then
         dnf install -y ca-certificates || return 1
@@ -3487,10 +3506,10 @@ install_fedora_git_deps() {
 
     __git_clone_and_checkout || return 1
 
-    __PACKAGES="python2-tornado systemd-python"
+    __PACKAGES="python${PY_PKG_VER}-tornado python${PY_PKG_VER}-systemd"
 
     if [ "$_INSTALL_CLOUD" -eq $BS_TRUE ]; then
-        __PACKAGES="${__PACKAGES} python-libcloud python-netaddr"
+        __PACKAGES="${__PACKAGES} python${PY_PKG_VER}-libcloud python${PY_PKG_VER}-netaddr"
     fi
 
     # shellcheck disable=SC2086
@@ -3506,10 +3525,17 @@ install_fedora_git_deps() {
 }
 
 install_fedora_git() {
-    if [ -f "${_SALT_GIT_CHECKOUT_DIR}/salt/syspaths.py" ]; then
-        python setup.py --salt-config-dir="$_SALT_ETC_DIR" --salt-cache-dir="${_SALT_CACHE_DIR}" ${SETUP_PY_INSTALL_ARGS} install || return 1
+    if [ "${_PY_EXE}" != "" ]; then
+        _PYEXE=${_PY_EXE}
+        echoinfo "Using the following python version: ${_PY_EXE} to install salt"
     else
-        python setup.py ${SETUP_PY_INSTALL_ARGS} install || return 1
+        _PYEXE='python2'
+    fi
+
+    if [ -f "${_SALT_GIT_CHECKOUT_DIR}/salt/syspaths.py" ]; then
+        ${_PYEXE} setup.py --salt-config-dir="$_SALT_ETC_DIR" --salt-cache-dir="${_SALT_CACHE_DIR}" ${SETUP_PY_INSTALL_ARGS} install --prefix=/usr || return 1
+    else
+        ${_PYEXE} setup.py ${SETUP_PY_INSTALL_ARGS} install --prefix=/usr || return 1
     fi
     return 0
 }

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -380,9 +380,9 @@ __usage() {
         no ".bak" file will be created as either of those options will force
         a complete overwrite of the file.
     -q  Quiet salt installation from git (setup.py install -q)
-    -x  Changes the Python version used to install Salt. Currently, this is only
-        supported on CentOS 6+, Debian 9+, Ubuntu 16+, and Fedora.
-        The Fedora and CentOS 6 options only work with git installations.
+    -x  Changes the Python version used to install Salt.
+        For CentOS 6 git installations python2.7 is supported.
+        Fedora git installation, CentOS 7, Debian 9, Ubuntu 16.04 and 18.04 support python3.
     -y  Installs a different python version on host. Currently this has only been
         tested with CentOS 6 and is considered experimental. This will install the
         ius repo on the box if disable repo is false. This must be used in conjunction

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -3507,8 +3507,9 @@ install_fedora_git_deps() {
     __git_clone_and_checkout || return 1
 
     __PACKAGES="python${PY_PKG_VER}-systemd"
-    if [ "${PY_PKG_VER}" -eq 3 -a "$DISTRO_MAJOR_VERSION" -ge 28 ]; then
+    if [ "${PY_PKG_VER}" -eq 3 ] && [ "$DISTRO_MAJOR_VERSION" -ge 28 ]; then
         __check_pip_allowed "You need to allow pip based installations (-P) for Tornado <5.0 in order to install Salt on Python 3"
+        # shellcheck disable=SC2039
         grep tornado "${_SALT_GIT_CHECKOUT_DIR}/requirements/base.txt" | while IFS=$'\n' read -r dep; do
           "${_PY_EXE}" -m pip install "${dep}" || return 1
         done


### PR DESCRIPTION
### What does this PR do?
Add support for Python 3 on Fedora.

### New Behavior
* Due to the rpm's still being for Python 2, this only works for Git installations. Once the rpms are fixxed it should work automatically
* The `tornado<5.0` for Python 3 must be satisfied through PIP on Fedora 28
* I haven't tested F27, but I did fix the deps for it
