### PR TITLE
FIX #1237 SmartOS should use pkgin show-deps

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -322,7 +322,7 @@ UNIX systems
 
 **SunOS**:
 
-- SmartOS
+- SmartOS (2015Q4 and later)
 
 Unsupported Distributions
 -------------------------

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -5336,7 +5336,8 @@ install_openbsd_restart_daemons() {
 #   SmartOS Install Functions
 #
 install_smartos_deps() {
-    pkgin -y install zeromq py27-crypto py27-m2crypto py27-msgpack py27-yaml py27-jinja2 py27-zmq py27-requests || return 1
+    smartos_deps="$(pkgin show-deps salt | grep '^\s' | grep -v '\snot' | xargs) py27-m2crypto"
+    pkgin -y install "${smartos_deps}" || return 1
 
     # Set _SALT_ETC_DIR to SmartOS default if they didn't specify
     _SALT_ETC_DIR=${BS_SALT_ETC_DIR:-/opt/local/etc/salt}


### PR DESCRIPTION
### What does this PR do?
The install_smartos_deps function is used for both stable and git.
Only the m2crypt package is not included in the automatic dependacies
for the salt package.

We simply query the salt package to figure out the dependancies. That we
we have the right set for both git and stable. Even if pacakge names
change in the future.

### What issues does this PR fix or reference?
#1237 

### Previous Behavior
Hardcoded list of dependacies

### New Behavior
We query the OS provided package so we always grab the right set of dependacies.

### Testing notes
This was minimally tested on in a zone only using both stable and git and it seems to work.
I did hit a error a few times because the error handling makes no difference between package install failure and config file download in the function. Which made me wast a bit of time as the zone was originally in a super restricted environment.

