### PR TITLE
use official amazon linux 2 repo for amazon linux 2

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -46,6 +46,11 @@ platforms:
       run_command: /sbin/init
       provision_command:
         - yum install -y upstart
+  - name: amazon-2
+    driver_config:
+      image: amazonlinux:2
+      platform: rhel
+      run_command: /usr/lib/systemd/systemd
   - name: ubuntu-18.04
     driver_config:
       run_command: /lib/systemd/systemd
@@ -83,6 +88,8 @@ suites:
   - name: py2-git-2017.7
     provisioner:
       salt_version: 2017.7
+    excludes:
+      - arch
   - name: py2-git-2018.3
     provisioner:
       salt_version: 2018.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ env:
   - PLATFORM=centos-7
   - PLATFORM=centos-6
   - PLATFORM=amazon-1
+  - PLATFORM=amazon-2
   - PLATFORM=ubuntu-1804
   - PLATFORM=ubuntu-1604
   - PLATFORM=ubuntu-1404

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -4687,12 +4687,9 @@ install_amazon_linux_ami_2_git_deps() {
     PIP_EXE='pip'
     if __check_command_exists python2.7; then
         if ! __check_command_exists pip2.7; then
-            if ! __check_command_exists easy_install-2.7; then
-                __yum_install_noinput python27-setuptools
-            fi
-            /usr/bin/easy_install-2.7 pip || return 1
+            __yum_install_noinput python2-pip
         fi
-        PIP_EXE='/usr/local/bin/pip2.7'
+        PIP_EXE='/bin/pip'
         _PY_EXE='python2.7'
     fi
 

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -4715,7 +4715,7 @@ install_amazon_linux_ami_2_deps() {
         __REPO_FILENAME="saltstack-repo.repo"
 
         base_url="$HTTP_VAL://${_REPO_URL}/yum/redhat/7/\$basearch/$repo_rev/"
-        base_url="$HTTP_VAL://${_REPO_URL}/yum/amazon/2/\$basearch/latest"
+        base_url="$HTTP_VAL://${_REPO_URL}/yum/amazon/2/\$basearch/latest/"
         gpg_key="${base_url}SALTSTACK-GPG-KEY.pub
         ${base_url}base/RPM-GPG-KEY-CentOS-7"
         repo_name="SaltStack repo for Amazon Linux 2.0"

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -4746,12 +4746,6 @@ _eof
 
     # Package python-ordereddict-1.1-2.el6.noarch is obsoleted by python26-2.6.9-2.88.amzn1.x86_64
     # which is already installed
-    '''
-    __PACKAGES="m2crypto ${pkg_append}-crypto ${pkg_append}-jinja2 PyYAML"
-    __PACKAGES="${__PACKAGES} ${pkg_append}-msgpack ${pkg_append}-requests ${pkg_append}-zmq"
-    __PACKAGES="${__PACKAGES} ${pkg_append}-futures"
-    __PACKAGES="${__PACKAGES} ${pkg_append}-markupsafe python2-pip ${pkg_append}-tornado pciutils-libs"
-    '''
     __PACKAGES="m2crypto ${pkg_append}-crypto ${pkg_append}-jinja2 PyYAML"
     __PACKAGES="${__PACKAGES} ${pkg_append}-msgpack ${pkg_append}-requests ${pkg_append}-zmq"
     __PACKAGES="${__PACKAGES} ${pkg_append}-futures"

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1632,7 +1632,8 @@ __check_end_of_life_versions() {
 
         amazon*linux*ami)
             # Amazon Linux versions lower than 2012.0X no longer supported
-            if [ "$DISTRO_MAJOR_VERSION" -lt 2012 -a "$DISTRO_MAJOR_VERSION" -gt 10 ]; then
+            # Except for Amazon Linux 2, which reset the major version counter
+            if [ "$DISTRO_MAJOR_VERSION" -lt 2012 ] && [ "$DISTRO_MAJOR_VERSION" -gt 10 ]; then
                 echoerror "End of life distributions are not supported."
                 echoerror "Please consider upgrading to the next stable. See:"
                 echoerror "    https://aws.amazon.com/amazon-linux-ami/"
@@ -4715,17 +4716,11 @@ install_amazon_linux_ami_2_deps() {
     if [ $_DISABLE_REPOS -eq $BS_FALSE ] || [ "$_CUSTOM_REPO_URL" != "null" ]; then
         __REPO_FILENAME="saltstack-repo.repo"
 
-        # Set a few vars to make life easier.
-        if [ $_USEAWS -eq $BS_TRUE ]; then
-           base_url="$HTTP_VAL://${_REPO_URL}/yum/redhat/7/\$basearch/$repo_rev/"
-           gpg_key="${base_url}SALTSTACK-GPG-KEY.pub
-           ${base_url}base/RPM-GPG-KEY-CentOS-7"
-           repo_name="SaltStack repo for Amazon Linux 2.0"
-        else
-           base_url="$HTTP_VAL://${_REPO_URL}/yum/redhat/6/\$basearch/$repo_rev/"
-           gpg_key="${base_url}SALTSTACK-GPG-KEY.pub"
-           repo_name="SaltStack repo for RHEL/CentOS 6"
-        fi
+        base_url="$HTTP_VAL://${_REPO_URL}/yum/redhat/7/\$basearch/$repo_rev/"
+        base_url="$HTTP_VAL://${_REPO_URL}/yum/amazon/2/\$basearch/latest"
+        gpg_key="${base_url}SALTSTACK-GPG-KEY.pub
+        ${base_url}base/RPM-GPG-KEY-CentOS-7"
+        repo_name="SaltStack repo for Amazon Linux 2.0"
 
         # This should prob be refactored to use __install_saltstack_rhel_repository()
         # With args passed in to do the right thing.  Reformatted to be more like the


### PR DESCRIPTION
### What does this PR do?
~"Supports" Amazon Linux 2 by using the saltstack centos7 yum repo
Don't know if this is an upstream-able change, but it works for us.~
Update to use new amazon linux 2 yum repo

### What issues does this PR fix or reference?
#1194

### Previous Behavior
bootstrap-salt.sh fails on amazon linux 2

### New Behavior
bootstrap-salt.sh successfully installs and runs salt-minion

