### PR TITLE
Split up some tests to avoid travis timeout

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -68,9 +68,12 @@ platforms:
         run_command: /lib/systemd/systemd
         provision_command:
         - apt-get install -y dbus
-  - name: debian-9
+  - name: debian-9-git
     driver_config:
       run_command: /lib/systemd/systemd
+  - name: debian-9-stable
+      driver_config:
+        run_command: /lib/systemd/systemd
   - name: arch
     driver_config:
       image: base/archlinux
@@ -90,21 +93,25 @@ suites:
       salt_version: 2017.7
     excludes:
       - debian-8-stable
+      - debian-9-stable
   - name: py2-git-2018.3
     provisioner:
       salt_version: 2018.3
     excludes:
       - debian-8-stable
+      - debian-9-stable
   - name: py2-git-fluorine
     provisioner:
       salt_version: fluorine
     excludes:
       - debian-8-stable
+      - debian-9-stable
   - name: py2-git-develop
     provisioner:
       salt_version: develop
     excludes:
       - debian-8-stable
+      - debian-9-stable
   - name: py2-stable-2017.7
     provisioner:
       salt_version: 2017.7
@@ -113,6 +120,7 @@ suites:
       - arch
       - centos-6
       - debian-8-git
+      - debian-9-git
       - fedora
       - opensuse
   - name: py2-stable-2018.3
@@ -122,6 +130,7 @@ suites:
     excludes:
       - centos-6
       - debian-8-git
+      - debian-9-git
 
 verifier:
   name: shell

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -58,10 +58,15 @@ platforms:
       provision_command:
         - rm -f /sbin/initctl
         - dpkg-divert --local --rename --remove /sbin/initctl
-  - name: debian-8
+  - name: debian-8-git
     driver_config:
       run_command: /lib/systemd/systemd
       provision_command:
+        - apt-get install -y dbus
+  - name: debian-8-stable
+      driver_config:
+        run_command: /lib/systemd/systemd
+        provision_command:
         - apt-get install -y dbus
   - name: debian-9
     driver_config:
@@ -83,15 +88,23 @@ suites:
   - name: py2-git-2017.7
     provisioner:
       salt_version: 2017.7
+    excludes:
+      - debian-8-stable
   - name: py2-git-2018.3
     provisioner:
       salt_version: 2018.3
+    excludes:
+      - debian-8-stable
   - name: py2-git-fluorine
     provisioner:
       salt_version: fluorine
+    excludes:
+      - debian-8-stable
   - name: py2-git-develop
     provisioner:
       salt_version: develop
+    excludes:
+      - debian-8-stable
   - name: py2-stable-2017.7
     provisioner:
       salt_version: 2017.7
@@ -99,6 +112,7 @@ suites:
     excludes:
       - arch
       - centos-6
+      - debian-8-git
       - fedora
       - opensuse
   - name: py2-stable-2018.3
@@ -107,6 +121,7 @@ suites:
       salt_bootstrap_options: -MP stable
     excludes:
       - centos-6
+      - debian-8-git
 
 verifier:
   name: shell

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,8 @@ env:
   - PLATFORM=ubuntu-1404
   - PLATFORM=debian-8-git
   - PLATFORM=debian-8-stable
-  - PLATFORM=debian-9
+  - PLATFORM=debian-9-git
+  - PLATFORM=debian-9-stable
   - PLATFORM=arch
   - PLATFORM=opensuse
 
@@ -33,7 +34,6 @@ matrix:
   allow_failures:
   - env: PLATFORM=ubuntu-1804
   - env: PLATFORM=ubuntu-1604
-  - env: PLATFORM=debian-9
   - env: PLATFORM=centos-6
 
 sudo: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,8 @@ env:
   - PLATFORM=ubuntu-1804
   - PLATFORM=ubuntu-1604
   - PLATFORM=ubuntu-1404
-  - PLATFORM=debian-8
+  - PLATFORM=debian-8-git
+  - PLATFORM=debian-8-stable
   - PLATFORM=debian-9
   - PLATFORM=arch
   - PLATFORM=opensuse
@@ -32,7 +33,6 @@ matrix:
   allow_failures:
   - env: PLATFORM=ubuntu-1804
   - env: PLATFORM=ubuntu-1604
-  - env: PLATFORM=debian-8
   - env: PLATFORM=debian-9
   - env: PLATFORM=centos-6
 


### PR DESCRIPTION
This PR splits up some of the test platforms into multiple instances so we can avoid hitting the timeout errors.

Some distros were in the "allowed failures" category because sometimes they would hit timeouts.

By splitting the distros up into `git` and `stable` tests, we use more executors, but we allow the tests to complete all of the time.