### PR TITLE
Feature/add procps debian slim container

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -3019,6 +3019,11 @@ __install_saltstack_debian_repository() {
 
     __PACKAGES=''
 
+    # Install procps i.e. debian:stretch-slim container images
+    if ! [ -x "$(command -v ps)" ]; then
+        __PACKAGES="${__PACKAGES} procps"
+    fi
+
     # Install downloader backend for GPG keys fetching
     if [ "$DISTRO_MAJOR_VERSION" -ge 9 ]; then
         __PACKAGES="${__PACKAGES} gnupg2 dirmngr"

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -3019,7 +3019,7 @@ __install_saltstack_debian_repository() {
 
     __PACKAGES=''
 
-    # Install procps i.e. debian:stretch-slim container images
+    # Install procps packages on systems missing it, e.g. debian:stretch-slim container images
     if ! [ -x "$(command -v ps)" ]; then
         __PACKAGES="${__PACKAGES} procps"
     fi


### PR DESCRIPTION
### What does this PR do?
installs procps package if command _ps_ is missing

### What issues does this PR fix or reference?
procps package is missing in debian:stretch-slim container image