### PR TITLE
Add support for bunsenlabs debian derivative

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1431,7 +1431,7 @@ __debian_derivatives_translation() {
     # If the file does not exist, return
     [ ! -f /etc/os-release ] && return
 
-    DEBIAN_DERIVATIVES="(cumulus_.+|devuan|kali|linuxmint|raspbian)"
+    DEBIAN_DERIVATIVES="(cumulus_.+|devuan|kali|linuxmint|raspbian|bunsenlabs)"
     # Mappings
     cumulus_2_debian_base="7.0"
     cumulus_3_debian_base="8.0"
@@ -1441,6 +1441,7 @@ __debian_derivatives_translation() {
     linuxmint_1_debian_base="8.0"
     raspbian_8_debian_base="8.0"
     raspbian_9_debian_base="9.0"
+    bunsenlabs_9_debian_base="9.0"
 
     # Translate Debian derivatives to their base Debian version
     match=$(echo "$DISTRO_NAME_L" | grep -E ${DEBIAN_DERIVATIVES})
@@ -1466,6 +1467,10 @@ __debian_derivatives_translation() {
             raspbian)
                 _major=$(echo "$DISTRO_VERSION" | sed 's/^\([0-9]*\).*/\1/g')
                 _debian_derivative="raspbian"
+                ;;
+            bunsenlabs)
+                _major=$(echo "$DISTRO_VERSION" | sed 's/^\([0-9]*\).*/\1/g')
+                _debian_derivative="bunsenlabs"
                 ;;
         esac
 


### PR DESCRIPTION
### What does this PR do?
Adds support for bunsenlabs distro (a superficial debian derivative).

I did not bother adding support for bunsenlabs (formerly crunchbang) that are based on older debians, because I'm using 9.

~~I don't think it would be hard to support that with a few changes, but I don't know how many people besides me even use this "distro".~~ I doubt any changes would be needed, because this "distro" is just plain debian with a pre-configured openbox for the UI basically.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-bootstrap/issues/1299

### Previous Behavior
Failed to detect OS info:
```
 * ERROR: No dependencies installation function found. Exiting...

```

### New Behavior
Installs without issues.

