### PR TITLE
Adding changes for kitchen pytest params and the drone build.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -166,7 +166,6 @@ steps:
 - name: build
   image: saltstack/drone-plugin-kitchen
   privileged: true
-  failure: ignore
   settings:
     target: ubuntu-1604
     requirements: tests/requirements.txt
@@ -185,7 +184,6 @@ steps:
 - name: build
   image: saltstack/drone-plugin-kitchen
   privileged: true
-  failure: ignore
   settings:
     target: ubuntu-1804
     requirements: tests/requirements.txt

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -118,4 +118,4 @@ suites:
 verifier:
   name: shell
   remote_exec: false
-  command: pytest -v tests/integration/
+  command: pytest --cache-clear -v tests/integration/


### PR DESCRIPTION
### What does this PR do?
Updates pytest not to cache locally. This should not matter unless testing locally.

Also making ubuntu builds run and not ignore failure.
