### PR TITLE
Fix bootstrap install for git/develop on FreeBSD

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -5228,9 +5228,11 @@ install_freebsd_git_deps() {
     install_freebsd_9_stable_deps || return 1
 
     # shellcheck disable=SC2086
-    SALT_DEPENDENCIES=$(/usr/local/sbin/pkg search ${FROM_FREEBSD} -R -d sysutils/py-salt | grep -i origin | sed -e 's/^[[:space:]]*//' | tail -n +2 | awk -F\" '{print $2}' | tr '\n' ' ')
+    SALT_DEPENDENCIES=$(/usr/local/sbin/pkg search -d py27-salt | grep -v Depends | sed -e 's/^[[:space:]]*//' | tail -n +3 | tr '\n' ' ')
     # shellcheck disable=SC2086
     /usr/local/sbin/pkg install ${FROM_FREEBSD} -y ${SALT_DEPENDENCIES} || return 1
+    # install python meta package
+    /usr/local/sbin/pkg install ${FROM_FREEBSD} -y python || return 1
 
     if ! __check_command_exists git; then
         /usr/local/sbin/pkg install -y git || return 1

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -5228,7 +5228,7 @@ install_freebsd_git_deps() {
     install_freebsd_9_stable_deps || return 1
 
     # shellcheck disable=SC2086
-    SALT_DEPENDENCIES=$(/usr/local/sbin/pkg search -d py27-salt | grep -v Depends | sed -e 's/^[[:space:]]*//' | tail -n +3 | tr '\n' ' ')
+    SALT_DEPENDENCIES=$(/usr/local/sbin/pkg search ${FROM_FREEBSD} -d py27-salt | grep -v Depends | sed -e 's/^[[:space:]]*//' | tail -n +3 | tr '\n' ' ')
     # shellcheck disable=SC2086
     /usr/local/sbin/pkg install ${FROM_FREEBSD} -y ${SALT_DEPENDENCIES} || return 1
     # install python meta package


### PR DESCRIPTION
### What does this PR do?
1Fix bootstrap install for git/develop on FreeBSD

### What issues does this PR fix or reference?
none

### Previous Behavior
1: dependency detecting on FreeBSD was broken
2: installation failed when python meta package wasn't installed

### New Behavior
fixed that
