### PR TITLE
Fix bootstrap install for git/develop on FreeBSD

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -5231,6 +5231,8 @@ install_freebsd_git_deps() {
     SALT_DEPENDENCIES=$(/usr/local/sbin/pkg search ${FROM_FREEBSD} -R -d sysutils/py-salt | grep -i origin | sed -e 's/^[[:space:]]*//' | tail -n +2 | awk -F\" '{print $2}' | tr '\n' ' ')
     # shellcheck disable=SC2086
     /usr/local/sbin/pkg install ${FROM_FREEBSD} -y ${SALT_DEPENDENCIES} || return 1
+    # install python meta package
+    /usr/local/sbin/pkg install -y lang/python || return 1
 
     if ! __check_command_exists git; then
         /usr/local/sbin/pkg install -y git || return 1


### PR DESCRIPTION
### What does this PR do?
1Fix bootstrap install for git/develop on FreeBSD

### What issues does this PR fix or reference?
none

### Previous Behavior
1: dependency detecting on FreeBSD was broken
2: installation failed when python meta package wasn't installed

### New Behavior
fixed that