### PR TITLE
added support for FreeBSD 12

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -5163,7 +5163,7 @@ __configure_freebsd_pkg_details() {
     FROM_FREEBSD="-r FreeBSD"
 
     ##### Workaround : Waiting for SaltStack Repository to be available for FreeBSD 12 ####
-    if [ ${DISTRO_MAJOR_VERSION} -ne 12 ]; then
+    if [ "${DISTRO_MAJOR_VERSION}" -ne 12 ]; then
         ## add saltstack freebsd repo
         salt_conf_file=/usr/local/etc/pkg/repos/saltstack.conf
         {

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -5163,7 +5163,7 @@ __configure_freebsd_pkg_details() {
     FROM_FREEBSD="-r FreeBSD"
 
     ##### Workaround : Waiting for SaltStack Repository to be available for FreeBSD 12 ####
-    if [ 12 -ne $( freebsd-version -k | cut -d. -f1 ) ]; then
+    if [ ${DISTRO_MAJOR_VERSION} -ne 12 ]; then
         ## add saltstack freebsd repo
         salt_conf_file=/usr/local/etc/pkg/repos/saltstack.conf
         {

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -5162,17 +5162,21 @@ __configure_freebsd_pkg_details() {
     fi
     FROM_FREEBSD="-r FreeBSD"
 
-    ## add saltstack freebsd repo
-    salt_conf_file=/usr/local/etc/pkg/repos/saltstack.conf
-    {
-        echo "SaltStack:{"
-        echo "    url: \"${SALTPKGCONFURL}\","
-        echo "    mirror_type: \"http\","
-        echo "    enabled: true"
-        echo "    priority: 10"
-        echo "}"
-    } > $salt_conf_file
-    FROM_SALTSTACK="-r SaltStack"
+    ##### Workaround : Waiting for SaltStack Repository to be available for FreeBSD 12 ####
+    if [ 12 -ne $( freebsd-version -k | cut -d. -f1 ) ]; then
+        ## add saltstack freebsd repo
+        salt_conf_file=/usr/local/etc/pkg/repos/saltstack.conf
+        {
+            echo "SaltStack:{"
+            echo "    url: \"${SALTPKGCONFURL}\","
+            echo "    mirror_type: \"http\","
+            echo "    enabled: true"
+            echo "    priority: 10"
+            echo "}"
+        } > $salt_conf_file
+        FROM_SALTSTACK="-r SaltStack"
+    fi
+    ##### End Workaround : Waiting for SaltStack Repository to be available for FreeBSD 12 ####
 
     ## ensure future ports builds use pkgng
     echo "WITH_PKGNG=   yes" >> /etc/make.conf
@@ -5227,6 +5231,10 @@ install_freebsd_10_stable_deps() {
 }
 
 install_freebsd_11_stable_deps() {
+    install_freebsd_9_stable_deps
+}
+
+install_freebsd_12_stable_deps() {
     install_freebsd_9_stable_deps
 }
 
@@ -5316,6 +5324,16 @@ install_freebsd_11_stable() {
     return 0
 }
 
+install_freebsd_12_stable() {
+#
+# installing latest version of salt from FreeBSD CURRENT ports repo
+#
+    # shellcheck disable=SC2086
+    /usr/local/sbin/pkg install ${FROM_FREEBSD} -y sysutils/py-salt || return 1
+
+    return 0
+}
+
 install_freebsd_git() {
 
     # /usr/local/bin/python2 in FreeBSD is a symlink to /usr/local/bin/python2.7
@@ -5379,6 +5397,10 @@ install_freebsd_10_stable_post() {
 }
 
 install_freebsd_11_stable_post() {
+    install_freebsd_9_stable_post
+}
+
+install_freebsd_12_stable_post() {
     install_freebsd_9_stable_post
 }
 


### PR DESCRIPTION
### What does this PR do?
Add support For SaltStack installation on FreeBSD 12

### What issues does this PR fix or reference?
SaltStack/salt #50914 -> https://github.com/saltstack/salt/issues/50914

### Previous Behavior
Installation impossible on FreeBSD 12
### New Behavior
Installation now possible on FreeBSD 12 via Bootstrap.sh

L.5166: https://github.com/saltstack/salt-bootstrap/pull/1329/files#diff-a8778033f6225c137abf05cf8d0bb113R5165  : 
A special case has been introduced to not install SaltStack FreeBSD repo on FreeBSD 12 as it is not yet available.
sysutils/py-salt is available on official FreeBSD package repository.

Clean needed and has to be discussed !
