### PR TITLE
install into virtualenv is broken

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2443,7 +2443,7 @@ __create_virtualenv() {
 __activate_virtualenv() {
     set +o nounset
     # Is virtualenv empty
-    if [ -z "$_VIRTUALENV_DIR" ]; then
+    if [ -z "$VIRTUAL_ENV" ]; then
         __create_virtualenv || return 1
         # shellcheck source=/dev/null
         . "${_VIRTUALENV_DIR}/bin/activate" || return 1

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2427,9 +2427,9 @@ __create_virtualenv() {
     if [ ! -d "$_VIRTUALENV_DIR" ]; then
         echoinfo "Creating virtualenv ${_VIRTUALENV_DIR}"
         if [ $_PIP_ALL -eq $BS_TRUE ]; then
-            virtualenv --no-site-packages "${_VIRTUALENV_DIR}" || return 1
+            /usr/local/bin/virtualenv --no-site-packages "${_VIRTUALENV_DIR}" || return 1
         else
-            virtualenv --system-site-packages "${_VIRTUALENV_DIR}" || return 1
+            /usr/local/bin/virtualenv --system-site-packages "${_VIRTUALENV_DIR}" || return 1
         fi
     fi
     return 0

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2888,6 +2888,11 @@ install_ubuntu_git_post() {
 
         if [ -f /bin/systemctl ] && [ "$DISTRO_MAJOR_VERSION" -ge 16 ]; then
             __copyfile "${_SALT_GIT_CHECKOUT_DIR}/pkg/salt-${fname}.service" "/lib/systemd/system/salt-${fname}.service"
+            # Set service to know about virtualenv
+            if [ "${_VIRTUALENV_DIR}" != "null" ]; then
+                mkdir -p "/etc/systemd/system/salt-${fname}.service.d" || return 1
+                printf "[Service]\nExecStart=\nExecStart=${_VIRTUALENV_DIR}/bin/python /usr/bin/salt-${fname}\n" > "/etc/systemd/system/salt-${fname}.service.d/override.conf" || return 1
+            fi
 
             # Skip salt-api since the service should be opt-in and not necessarily started on boot
             [ $fname = "api" ] && continue

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2759,7 +2759,7 @@ install_ubuntu_git_deps() {
 
     # See how we are installing packages
     if [ "${_PIP_ALL}" -eq $BS_TRUE ]; then
-        __PACKAGES="${__PACKAGES} python-dev swig libssl-dev libzmq3 libzmq3-dev"
+        __PACKAGES="${__PACKAGES} python-dev swig libssl-dev libzmq5"
 
         if ! __check_command_exists pip; then
             __PACKAGES="${__PACKAGES} python-setuptools python-pip"

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2516,10 +2516,10 @@ __install_pip_deps() {
         __PIP_PACKAGES="${__PIP_PACKAGES} 'apache-libcloud>=$_LIBCLOUD_MIN_VERSION'"
     fi
 
-    # HACK: msgpack added here to prevent v1.x from getting installed later
-    pip install -U msgpack==0.6.1
     # shellcheck disable=SC2086,SC2090
     pip install -U -r ${requirements_file} ${__PIP_PACKAGES}
+    # HACK: msgpack added here to prevent v1.x from getting installed later
+    pip install -U msgpack==0.6.1
 }   # ----------  end of function __install_pip_deps  ----------
 
 

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2892,7 +2892,7 @@ install_ubuntu_git_post() {
             # Set service to know about virtualenv
             if [ "${_VIRTUALENV_DIR}" != "null" ]; then
                 mkdir -p "/etc/systemd/system/salt-${fname}.service.d" || return 1
-                printf "[Service]\nExecStart=\nExecStart=${_VIRTUALENV_DIR}/bin/salt-${fname}\n" > "/etc/systemd/system/salt-${fname}.service.d/override.conf" || return 1
+                printf "[Service]\nExecStart=\nExecStart=%s/bin/salt-%s\n" "$_VIRTUALENV_DIR" "$fname" > "/etc/systemd/system/salt-${fname}.service.d/override.conf" || return 1
             fi
 
             # Skip salt-api since the service should be opt-in and not necessarily started on boot

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2509,7 +2509,8 @@ __install_pip_deps() {
         exit 1
     fi
 
-    __PIP_PACKAGES=''
+    # TODO: shouldn't be hard-coded to xenial, why doesn't pypi have a working version?
+    __PIP_PACKAGES='git+https://salsa.debian.org/apt-team/python-apt@1.1.y-xenial'
     if [ "$_INSTALL_CLOUD" -eq $BS_TRUE ]; then
         # shellcheck disable=SC2089
         __PIP_PACKAGES="${__PIP_PACKAGES} 'apache-libcloud>=$_LIBCLOUD_MIN_VERSION'"

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2891,7 +2891,7 @@ install_ubuntu_git_post() {
             # Set service to know about virtualenv
             if [ "${_VIRTUALENV_DIR}" != "null" ]; then
                 mkdir -p "/etc/systemd/system/salt-${fname}.service.d" || return 1
-                printf "[Service]\nExecStart=\nExecStart=${_VIRTUALENV_DIR}/bin/python /usr/bin/salt-${fname}\n" > "/etc/systemd/system/salt-${fname}.service.d/override.conf" || return 1
+                printf "[Service]\nExecStart=\nExecStart=${_VIRTUALENV_DIR}/bin/salt-${fname}\n" > "/etc/systemd/system/salt-${fname}.service.d/override.conf" || return 1
             fi
 
             # Skip salt-api since the service should be opt-in and not necessarily started on boot

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2760,7 +2760,7 @@ install_ubuntu_git_deps() {
 
     # See how we are installing packages
     if [ "${_PIP_ALL}" -eq $BS_TRUE ]; then
-        __PACKAGES="${__PACKAGES} python-dev swig libssl-dev libzmq5"
+        __PACKAGES="${__PACKAGES} python-dev swig libssl-dev libzmq5 libapt-pkg-dev"
 
         if ! __check_command_exists pip; then
             __PACKAGES="${__PACKAGES} python-setuptools python-pip"

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2497,7 +2497,7 @@ __install_pip_deps() {
             echoerror "Pip not installed: required for -a installs"
             exit 1
         fi
-        pip install -U virtualenv
+        pip install -U virtualenv==16.7.3
         __activate_virtualenv || return 1
     else
         echoerror "Must have virtualenv dir specified for -a installs"

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2516,6 +2516,8 @@ __install_pip_deps() {
         __PIP_PACKAGES="${__PIP_PACKAGES} 'apache-libcloud>=$_LIBCLOUD_MIN_VERSION'"
     fi
 
+    # HACK: msgpack added here to prevent v1.x from getting installed later
+    pip install -U msgpack==0.6.1
     # shellcheck disable=SC2086,SC2090
     pip install -U -r ${requirements_file} ${__PIP_PACKAGES}
 }   # ----------  end of function __install_pip_deps  ----------


### PR DESCRIPTION
### What does this PR do?
fix several issues related to venv installation on ubuntu 16.04 using the following options:
```
sh bootstrap-salt.sh -D -n -V /usr/local/venv/salt -a -X git v2019.2.0
```
### What issues does this PR fix or reference?
issues related to installation in virtualenv:
* actually create virtualenv (revert [bad commit](https://github.com/saltstack/salt-bootstrap/commit/6d595996766841766b4a0e0559bfb49231cf73ad) causing it to silently skip creating the virtualenv)
* there is no libzmq3 apt package for ubuntu 16.04
* libapt-pkg-dev apt package is required by [apt](https://pypi.org/project/apt/) pip package
* an ancient version of the [apt](https://pypi.org/project/apt/) pip package is on pypi so I installed it from source (but needs to be updated to support ubuntu 16.04 and 18.04 version)
* systemd service support

Some work is probably required to get this upstreamed (could really use a unit test), but since the functionality seems completely broken I thought I would share my work and hopefully save someone else from having to work through the parts that are broken.