### PR TITLE
Apt wait for lock modification

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1829,7 +1829,7 @@ __wait_for_apt(){
     APT_RETURN=$?
 
     # Make sure we're not waiting on a lock
-    while [ $APT_RETURN -ne 0 ] && grep -q -v '^E: Could not get lock' "$APT_ERR"; do
+    while [ $APT_RETURN -ne 0 ] && grep -q '^E: Could not get lock' "$APT_ERR"; do
       echoinfo "Aware of the lock. Patiently waiting $WAIT_TIMEOUT more seconds..."
       sleep 1
       WAIT_TIMEOUT=$((WAIT_TIMEOUT - 1))
@@ -1839,7 +1839,7 @@ __wait_for_apt(){
           echoerror "Bootstrap script cannot proceed. Aborting."
           return 1
       else
-	  "${@}"
+	  "${@}" 2>$APT_ERR
     	  APT_RETURN=$?
       fi
     done

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -521,6 +521,12 @@ __exit_cleanup() {
         rm -f "$LOGPIPE"
     fi
 
+    # Remove the temporary apt error file when the script exits
+    if [ -f "$APT_ERR" ]; then
+        echodebug "Removing the temporary apt error file $APT_ERR"
+        rm -f "$APT_ERR"
+    fi
+
     # Kill tee when exiting, CentOS, at least requires this
     # shellcheck disable=SC2009
     TEE_PID=$(ps ax | grep tee | grep "$LOGFILE" | awk '{print $1}')
@@ -1813,12 +1819,12 @@ __function_defined() {
 #                 a boot process, such as on AWS AMIs. This func will wait until the boot
 #                 process is finished so the script doesn't exit on a locked proc.
 #----------------------------------------------------------------------------------------------------------------------
+APT_ERR=$(mktemp /tmp/apt_error.XXXX)
 __wait_for_apt(){
     # Timeout set at 15 minutes
     WAIT_TIMEOUT=900
 
     # Run our passed in apt command
-    APT_ERR=$(mktemp /tmp/apt_error.XXXX)
     "${@}" 2>$APT_ERR
     APT_RETURN=$?
 
@@ -1838,7 +1844,6 @@ __wait_for_apt(){
       fi
     done
 
-    rm $APT_ERR
     return $APT_RETURN
 }
 

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1829,7 +1829,7 @@ __wait_for_apt(){
     APT_RETURN=$?
 
     # Make sure we're not waiting on a lock
-    while [ $APT_RETURN -ne 0 ] && [ $(grep -c "^E: Could not get lock" $APT_ERR) -ge 1 ]; do
+    while [ $APT_RETURN -ne 0 ] && grep -q -v '^E: Could not get lock' "$APT_ERR"; do
       echoinfo "Aware of the lock. Patiently waiting $WAIT_TIMEOUT more seconds..."
       sleep 1
       WAIT_TIMEOUT=$((WAIT_TIMEOUT - 1))

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1825,7 +1825,7 @@ __wait_for_apt(){
     WAIT_TIMEOUT=900
 
     # Run our passed in apt command
-    "${@}" 2>$APT_ERR
+    "${@}" 2>"$APT_ERR"
     APT_RETURN=$?
 
     # Make sure we're not waiting on a lock
@@ -1839,7 +1839,7 @@ __wait_for_apt(){
           echoerror "Bootstrap script cannot proceed. Aborting."
           return 1
       else
-	  "${@}" 2>$APT_ERR
+	  "${@}" 2>"$APT_ERR"
     	  APT_RETURN=$?
       fi
     done


### PR DESCRIPTION
### What does this PR do?

Apt command wait based on apt error output rather than exit code.

### What issues does this PR fix or reference?

#1288 

### Previous Behavior
Loop based on apt exit code which may not always be due to a file lock.

### New Behavior
Loop based on apt error output.

