### PR TITLE
Add TLS support up to TLS 1.2

### DIFF
--- a/bootstrap-salt.ps1
+++ b/bootstrap-salt.ps1
@@ -99,6 +99,9 @@ Param(
     [string]$repourl= "https://repo.saltstack.com/windows"
 )
 
+# Powershell supports only TLS 1.0 by default. Add support up to TLS 1.2
+[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]'Tls,Tls11,Tls12'
+
 #===============================================================================
 # Script Functions
 #===============================================================================


### PR DESCRIPTION
### What does this PR do?
Adds support for TLS up to version 1.2. By default Powershell only supports TLS 1.0... lame

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-bootstrap/issues/1338