### PR TITLE
apt_key_fetch: use curl

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1875,7 +1875,7 @@ __apt_key_fetch() {
     url=$1
 
     # shellcheck disable=SC2086
-    __wait_for_apt apt-key adv ${_GPG_ARGS} --fetch-keys "$url"; return $?
+    __wait_for_apt curl ${_CURL_ARGS} -sSL "$url" | apt-key add -; return $?
 }   # ----------  end of function __apt_key_fetch  ----------
 
 

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1894,7 +1894,7 @@ __temp_gpg_pub() {
 __apt_key_fetch() {
     url=$1
 
-    tempfile=__temp_gpg_pub || return 1
+    tempfile="$(__temp_gpg_pub)" || return 1
 
     __fetch_url "$tempfile" "$url" || return 1
     apt-key add "$tempfile" || return 1
@@ -1912,7 +1912,7 @@ __apt_key_fetch() {
 __rpm_import_gpg() {
     url=$1
 
-    tempfile=__temp_gpg_pub || return 1
+    tempfile="$(__temp_gpg_pub)" || return 1
 
     __fetch_url "$tempfile" "$url" || return 1
     rpm --import "$tempfile" || return 1

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1894,7 +1894,7 @@ __temp_gpg_pub() {
 __apt_key_fetch() {
     url=$1
 
-    tempfile = __temp_gpg_pub || return 1
+    tempfile=__temp_gpg_pub || return 1
 
     __fetch_url "$tempfile" "$url" || return 1
     apt-key add "$tempfile" || return 1
@@ -1912,7 +1912,7 @@ __apt_key_fetch() {
 __rpm_import_gpg() {
     url=$1
 
-    tempfile = __temp_gpg_pub || return 1
+    tempfile=__temp_gpg_pub || return 1
 
     __fetch_url "$tempfile" "$url" || return 1
     rpm --import "$tempfile" || return 1

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1875,7 +1875,7 @@ __apt_key_fetch() {
     url=$1
 
     # shellcheck disable=SC2086
-    __wait_for_apt curl ${_CURL_ARGS} -sSL "$url" | apt-key add -; return $?
+    __fetch_url - "$url" | apt-key add -; return $?
 }   # ----------  end of function __apt_key_fetch  ----------
 
 

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1894,7 +1894,7 @@ __temp_gpg_pub() {
 __apt_key_fetch() {
     url=$1
 
-    tempfile="$(__temp_gpg_pub)" || return 1
+    tempfile="$(__temp_gpg_pub)"
 
     __fetch_url "$tempfile" "$url" || return 1
     apt-key add "$tempfile" || return 1
@@ -1912,7 +1912,7 @@ __apt_key_fetch() {
 __rpm_import_gpg() {
     url=$1
 
-    tempfile="$(__temp_gpg_pub)" || return 1
+    tempfile="$(__temp_gpg_pub)"
 
     __fetch_url "$tempfile" "$url" || return 1
     rpm --import "$tempfile" || return 1


### PR DESCRIPTION
### What does this PR do?

using curl + apt-key rather than keyserver-options no-check-cert which is not always supported

### What issues does this PR fix or reference?

unknown

### Previous Behavior

the saltstack GPG key is downloaded by apt-key

### New Behavior

the saltstack GPG key is downloaded by curl
