### PR TITLE
Fix possible typo with `gnupg-curl` vs `gnupg curl`

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2654,7 +2654,7 @@ __install_saltstack_ubuntu_repository() {
     if [ "$DISTRO_MAJOR_VERSION" -gt 16 ]; then
         __PACKAGES="${__PACKAGES} gnupg dirmngr"
     else
-        __PACKAGES="${__PACKAGES} gnupg-curl"
+        __PACKAGES="${__PACKAGES} gnupg curl"
     fi
 
     # Make sure https transport is available
@@ -3055,7 +3055,7 @@ __install_saltstack_debian_repository() {
     if [ "$DISTRO_MAJOR_VERSION" -ge 9 ]; then
         __PACKAGES="${__PACKAGES} gnupg2 dirmngr"
     else
-        __PACKAGES="${__PACKAGES} gnupg-curl"
+        __PACKAGES="${__PACKAGES} gnupg2 curl"
     fi
 
     # Make sure https transport is available

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2651,6 +2651,11 @@ __install_saltstack_ubuntu_repository() {
     # Install downloader backend for GPG keys fetching
     __PACKAGES='wget'
 
+    # Required as it is not installed by default on Ubuntu 18+
+    if [ "$DISTRO_MAJOR_VERSION" -ge 18 ]; then
+        __PACKAGES="${__PACKAGES} gnupg"
+    fi
+
     # Make sure https transport is available
     if [ "$HTTP_VAL" = "https" ] ; then
         __PACKAGES="${__PACKAGES} apt-transport-https ca-certificates"
@@ -3045,6 +3050,11 @@ __install_saltstack_debian_repository() {
 
     # Install downloader backend for GPG keys fetching
     __PACKAGES='wget'
+
+    # Required as it is not installed by default on Debian 9+
+    if [ "$DISTRO_MAJOR_VERSION" -ge 9 ]; then
+        __PACKAGES="${__PACKAGES} gnupg2"
+    fi
 
     # Make sure https transport is available
     if [ "$HTTP_VAL" = "https" ] ; then

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2648,14 +2648,8 @@ __install_saltstack_ubuntu_repository() {
         UBUNTU_CODENAME=${DISTRO_CODENAME}
     fi
 
-    __PACKAGES=''
-
     # Install downloader backend for GPG keys fetching
-    if [ "$DISTRO_MAJOR_VERSION" -gt 16 ]; then
-        __PACKAGES="${__PACKAGES} gnupg dirmngr"
-    else
-        __PACKAGES="${__PACKAGES} gnupg curl"
-    fi
+    __PACKAGES='wget'
 
     # Make sure https transport is available
     if [ "$HTTP_VAL" = "https" ] ; then
@@ -3049,14 +3043,8 @@ __install_saltstack_debian_repository() {
         __PY_VERSION_REPO="py3"
     fi
 
-    __PACKAGES=''
-
     # Install downloader backend for GPG keys fetching
-    if [ "$DISTRO_MAJOR_VERSION" -ge 9 ]; then
-        __PACKAGES="${__PACKAGES} gnupg2 dirmngr"
-    else
-        __PACKAGES="${__PACKAGES} gnupg2 curl"
-    fi
+    __PACKAGES='wget'
 
     # Make sure https transport is available
     if [ "$HTTP_VAL" = "https" ] ; then


### PR DESCRIPTION
### What does this PR do?
Fixes an issue with salt not installing on Ubuntu 16, failing on `install_ubuntu_stable_deps`.  The issue lay with a possible suspect typo, where it was installing just `gnupg-curl`, but looking at the lines above, that was installing two packages `gnupg dirmngr`.

So installing `curl` fixed the issue, as it looks to be reliant upon a sub-dependency of it.

### What issues does this PR fix or reference?

### Previous Behavior
`install_ubuntu_stable_deps` exits unsuccessfully..

```
Setting up ca-certificates (20170717~16.04.2) ...
Setting up krb5-locales (1.13.2+dfsg-5ubuntu2.1) ...
Setting up libsasl2-modules:amd64 (2.1.26.dfsg1-14ubuntu0.1) ...
Setting up gnupg-curl (1.4.20-1ubuntu3.3) ...
Processing triggers for libc-bin (2.23-0ubuntu11) ...
Processing triggers for ca-certificates (20170717~16.04.2) ...
Updating certificates in /etc/ssl/certs...
148 added, 0 removed; done.
Running hooks in /etc/ca-certificates/update.d...
done.
 * ERROR: Failed to run install_ubuntu_stable_deps()!!!
 * DEBUG: Removing the logging pipe /tmp/bootstrap-salt.logpipe
 * DEBUG: Removing the temporary apt error file /tmp/apt_error.n3jI
ERROR: Service 'ubuntu-16-tester' failed to build: The command '/bin/sh -c /tmp/bootstrap-salt.sh -X -d -D' returned a non-zero code: 1
```

### New Behavior
`install_ubuntu_stable_deps` now runs successfully.

```
Setting up ca-certificates (20170717~16.04.2) ...
Setting up krb5-locales (1.13.2+dfsg-5ubuntu2.1) ...
Setting up libsasl2-modules:amd64 (2.1.26.dfsg1-14ubuntu0.1) ...
Setting up curl (7.47.0-1ubuntu2.13) ...
Processing triggers for libc-bin (2.23-0ubuntu11) ...
Processing triggers for ca-certificates (20170717~16.04.2) ...
Updating certificates in /etc/ssl/certs...
148 added, 0 removed; done.
Running hooks in /etc/ca-certificates/update.d...
done.
OK
```