### PR TITLE
Fixed Amazon Linux 2 detection when lsb_release is installed

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1001,7 +1001,7 @@ __gather_linux_system_info() {
         elif [ "${DISTRO_NAME}" = "OracleServer" ]; then
             # This the Oracle Linux Server 6.5
             DISTRO_NAME="Oracle Linux"
-        elif [ "${DISTRO_NAME}" = "AmazonAMI" ]; then
+        elif [ "${DISTRO_NAME}" = "AmazonAMI" ] || [ "${DISTRO_NAME}" = "Amazon" ]; then
             DISTRO_NAME="Amazon Linux AMI"
         elif [ "${DISTRO_NAME}" = "ManjaroLinux" ]; then
             DISTRO_NAME="Arch Linux"


### PR DESCRIPTION
### What does this PR do?
Fixed Amazon Linux 2 detection when lsb_release is installed

### What issues does this PR fix or reference?
None created

### Previous Behavior
Distribution detected as "Amazon 2", which Errors, and states "No dependencies installation function found. Exiting..."

### New Behavior
Distribution detected as "Amazon Linux AMI 2", and install succeeds.  

