### PR TITLE
Fix busybox mktemp compatibility

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -499,7 +499,7 @@ exec 2>"$LOGPIPE"
 #              14               SIGALRM
 #              15               SIGTERM
 #----------------------------------------------------------------------------------------------------------------------
-APT_ERR=$(mktemp /tmp/apt_error.XXXX)
+APT_ERR=$(mktemp /tmp/apt_error.XXXXXX)
 __exit_cleanup() {
     EXIT_CODE=$?
 


### PR DESCRIPTION
Command `mktemp` accepts templates like /tmp/name.XXXXXX to create
a temporary file. Standard GNU mktemp requires at least 3 'X's
while busybox's version requires at least 6 'X's.

For compatibility we should use at least 6 'X's in mktemp templates.
