### PR TITLE
fix bootstrap-salt.sh for FreeBSD

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -5369,9 +5369,6 @@ install_freebsd_stable_post() {
 }
 
 install_freebsd_git_post() {
-    if [ -f $salt_conf_file ]; then
-        rm -f $salt_conf_file
-    fi
     install_freebsd_stable_post || return 1
     return 0
 }

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -5272,7 +5272,7 @@ __configure_freebsd_pkg_details() {
 }
 
 install_freebsd_deps() {
-    __configure_freebsd_pkg_details()
+    __configure_freebsd_pkg_details
     pkg install -y pkg
 }
 

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -5288,7 +5288,7 @@ install_freebsd_git_deps() {
         /usr/local/sbin/pkg install -y git || return 1
     fi
 
-    /usr/local/sbin/pkg install -y www/py36-requests || return 1
+    /usr/local/sbin/pkg install -y py36-requests || return 1
 
     __git_clone_and_checkout || return 1
 

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -5280,7 +5280,7 @@ install_freebsd_deps() {
 }
 
 install_freebsd_git_deps() {
-    install_freebsd_9_stable_deps || return 1
+    install_freebsd_stable_deps || return 1
 
     # shellcheck disable=SC2086
     SALT_DEPENDENCIES=$(/usr/local/sbin/pkg search -R -d sysutils/py-salt | grep -i origin | sed -e 's/^[[:space:]]*//' | tail -n +2 | awk -F\" '{print $2}' | tr '\n' ' ')

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -239,7 +239,7 @@ _CONFIG_ONLY=$BS_FALSE
 _PIP_ALLOWED=${BS_PIP_ALLOWED:-$BS_FALSE}
 _PIP_ALL=${BS_PIP_ALL:-$BS_FALSE}
 if uname -a | grep FreeBSD > /dev/null; then
-  SALT_ETC_DIR=${BS_SALT_ETC_DIR:-/usr/local/etc/salt}
+  _SALT_ETC_DIR=${BS_SALT_ETC_DIR:-/usr/local/etc/salt}
 else
   _SALT_ETC_DIR=${BS_SALT_ETC_DIR:-/etc/salt}
 fi

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -5240,32 +5240,6 @@ install_arch_check_services() {
 #   FreeBSD Install Functions
 #
 
-__freebsd_get_packagesite() {
-    if [ "$CPU_ARCH_L" = "amd64" ]; then
-        BSD_ARCH="x86:64"
-    elif [ "$CPU_ARCH_L" = "x86_64" ]; then
-        BSD_ARCH="x86:64"
-    elif [ "$CPU_ARCH_L" = "i386" ]; then
-        BSD_ARCH="x86:32"
-    elif [ "$CPU_ARCH_L" = "i686" ]; then
-        BSD_ARCH="x86:32"
-    fi
-
-    # Since the variable might not be set, don't, momentarily treat it as a
-    # failure
-    set +o nounset
-
-    # ABI is a std format for identifying release / architecture combos
-    ABI="freebsd:${DISTRO_MAJOR_VERSION}:${BSD_ARCH}"
-    _PACKAGESITE="http://pkg.freebsd.org/${ABI}/latest"
-    # Awkwardly, we want the `${ABI}` to be in conf file without escaping
-    PKGCONFURL="pkg+http://pkg.freebsd.org/\${ABI}/latest"
-    SALTPKGCONFURL="http://repo.saltstack.com/freebsd/\${ABI}/"
-
-    # Treat unset variables as errors once more
-    set -o nounset
-}
-
 # Using a separate conf step to head for idempotent install...
 __configure_freebsd_pkg_details() {
     _SALT_ETC_DIR="/usr/local/etc/salt"

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -238,11 +238,7 @@ _ECHO_DEBUG=${BS_ECHO_DEBUG:-$BS_FALSE}
 _CONFIG_ONLY=$BS_FALSE
 _PIP_ALLOWED=${BS_PIP_ALLOWED:-$BS_FALSE}
 _PIP_ALL=${BS_PIP_ALL:-$BS_FALSE}
-if uname -a | grep FreeBSD > /dev/null; then
-    _SALT_ETC_DIR=${BS_SALT_ETC_DIR:-/usr/local/etc/salt}
-else
-    _SALT_ETC_DIR=${BS_SALT_ETC_DIR:-/etc/salt}
-fi
+_SALT_ETC_DIR=${BS_SALT_ETC_DIR:-/etc/salt}
 _SALT_CACHE_DIR=${BS_SALT_CACHE_DIR:-/var/cache/salt}
 _PKI_DIR=${_SALT_ETC_DIR}/pki
 _FORCE_OVERWRITE=${BS_FORCE_OVERWRITE:-$BS_FALSE}
@@ -5272,18 +5268,17 @@ __freebsd_get_packagesite() {
 
 # Using a separate conf step to head for idempotent install...
 __configure_freebsd_pkg_details() {
-    echo 'not hijacking pkg repo configurations'
+    _SALT_ETC_DIR=${BS_SALT_ETC_DIR:-/usr/local/etc/salt}
 }
 
 install_freebsd_deps() {
+    __configure_freebsd_pkg_details()
     pkg install -y pkg
 }
 
 install_freebsd_git_deps() {
     install_freebsd_stable_deps || return 1
 
-    # shellcheck disable=SC2086
-    SALT_DEPENDENCIES=$(/usr/local/sbin/pkg search -R -d sysutils/py-salt | grep -i origin | sed -e 's/^[[:space:]]*//' | tail -n +2 | awk -F\" '{print $2}' | tr '\n' ' ')
     SALT_DEPENDENCIES=$(/usr/local/sbin/pkg search -R -d py36-salt | grep 'origin:' \
         | tail -n +2 | awk -F\" '{print $2}' | sed 's#.*/py-#py36-#g')
     # shellcheck disable=SC2086

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -5293,7 +5293,7 @@ install_freebsd_git_deps() {
         /usr/local/sbin/pkg install -y git || return 1
     fi
 
-    /usr/local/sbin/pkg install -y www/py-requests || return 1
+    /usr/local/sbin/pkg install -y www/py36-requests || return 1
 
     __git_clone_and_checkout || return 1
 

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -5268,7 +5268,7 @@ __freebsd_get_packagesite() {
 
 # Using a separate conf step to head for idempotent install...
 __configure_freebsd_pkg_details() {
-    _SALT_ETC_DIR=${BS_SALT_ETC_DIR:-/usr/local/etc/salt}
+    _SALT_ETC_DIR="/usr/local/etc/salt"
 }
 
 install_freebsd_deps() {


### PR DESCRIPTION
FreeBSD has py36-salt packages which handle all dependencies, etc - simple as pkg install -y py36-salt and then enabling it.  Don't need dependencies or git hacks.

### What does this PR do?
able to bootstrap salt on FreeBSD

### What issues does this PR fix or reference?
able to bootstrap salt on FreeBSD

### Previous Behavior
bootstrap FreeBSD did not work, failed with logic and dependency hell

### New Behavior
installs FreeBSD built py36-salt package with correct paths, etc.

