### PR TITLE
Add debian 10 git install support

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -3339,10 +3339,10 @@ install_debian_10_git_deps() {
     fi
 
     __install_tornado_pip ${_py}|| return 1
-    # shellcheck disable=SC2086
     __PACKAGES="${__PACKAGES} python${PY_PKG_VER}-msgpack python${PY_PKG_VER}-jinja2"
     __PACKAGES="${__PACKAGES} python${PY_PKG_VER}-tornado python${PY_PKG_VER}-yaml python${PY_PKG_VER}-zmq"
 
+    # shellcheck disable=SC2086
     __apt_get_install_noinput ${__PACKAGES} || return 1
 
     return 0

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -3333,8 +3333,9 @@ install_debian_10_git_deps() {
         PY_PKG_VER=3
         __PACKAGES="python${PY_PKG_VER}-distutils"
     else
-        PY_PKG_VER=""
         _py="python"
+        PY_PKG_VER=""
+        __PACKAGES=""
     fi
 
     __install_tornado_pip ${_py}|| return 1

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2516,14 +2516,33 @@ __install_pip_pkgs() {
 
     # Install pip and pip dependencies
     if ! __check_command_exists "${_pip_cmd} --version"; then
-        __PACKAGES="${_py_pkg}-setuptools ${_py_pkg}-pip gcc ${_py_pkg}-devel"
+        __PACKAGES="${_py_pkg}-setuptools ${_py_pkg}-pip gcc"
         # shellcheck disable=SC2086
-        __yum_install_noinput ${__PACKAGES} || return 1
+        if [ "$DISTRO_NAME_L" = "debian" ];then
+            __PACKAGES="${__PACKAGES} ${_py_pkg}-dev"
+            __apt_get_install_noinput ${__PACKAGES} || return 1
+        else
+            __PACKAGES="${__PACKAGES} ${_py_pkg}-devel"
+            __yum_install_noinput ${__PACKAGES} || return 1
+        fi
+
     fi
 
     echoinfo "Installing pip packages: ${_pip_pkgs} using ${_py_exe}"
     # shellcheck disable=SC2086
     ${_pip_cmd} install ${_pip_pkgs} || return 1
+}
+
+#---  FUNCTION  -------------------------------------------------------------------------------------------------------
+#          NAME:  __install_tornado_pip
+#    PARAMETERS:  python executable
+#   DESCRIPTION:  Return 0 or 1 if successfully able to install tornado<5.0
+#----------------------------------------------------------------------------------------------------------------------
+__install_tornado_pip() {
+    # OS needs tornado <5.0 from pip
+    __check_pip_allowed "You need to allow pip based installations (-P) for Tornado <5.0 in order to install Salt on Python 3"
+    ## install pip if its not installed and install tornado
+    __install_pip_pkgs "tornado<5.0" "${1}" || return 1
 }
 
 #---  FUNCTION  -------------------------------------------------------------------------------------------------------
@@ -3140,6 +3159,24 @@ install_debian_deps() {
     return 0
 }
 
+install_debian_git_pre() {
+    if ! __check_command_exists git; then
+        __apt_get_install_noinput git || return 1
+    fi
+
+    if [ "$_INSECURE_DL" -eq $BS_FALSE ] && [ "${_SALT_REPO_URL%%://*}" = "https" ]; then
+        __apt_get_install_noinput ca-certificates
+    fi
+
+    __git_clone_and_checkout || return 1
+
+    # Let's trigger config_salt()
+    if [ "$_TEMP_CONFIG_DIR" = "null" ]; then
+        _TEMP_CONFIG_DIR="${_SALT_GIT_CHECKOUT_DIR}/conf/"
+        CONFIG_SALT_FUNC="config_salt"
+    fi
+}
+
 install_debian_git_deps() {
     if ! __check_command_exists git; then
         __apt_get_install_noinput git || return 1
@@ -3289,7 +3326,24 @@ install_debian_9_git_deps() {
 }
 
 install_debian_10_git_deps() {
-    install_debian_9_git_deps || return 1
+    install_debian_git_pre || return 1
+
+    if [ -n "$_PY_EXE" ] && [ "$_PY_MAJOR_VERSION" -eq 3 ]; then
+        _py=${_PY_EXE}
+        PY_PKG_VER=3
+        __PACKAGES="python${PY_PKG_VER}-distutils"
+    else
+        PY_PKG_VER=""
+        _py="python"
+    fi
+
+    __install_tornado_pip ${_py}|| return 1
+    # shellcheck disable=SC2086
+    __PACKAGES="${__PACKAGES} python${PY_PKG_VER}-msgpack python${PY_PKG_VER}-jinja2"
+    __PACKAGES="${__PACKAGES} python${PY_PKG_VER}-tornado python${PY_PKG_VER}-yaml python${PY_PKG_VER}-zmq"
+
+    __apt_get_install_noinput ${__PACKAGES} || return 1
+
     return 0
 }
 


### PR DESCRIPTION
### What does this PR do?
Adds the ability to run a git install on debian 10. Requires a pip install of tornado <5

There is a python3-tornado4 package on debian 10 (and even centos8) but you have to run `python3 -c "import tornado4"` in order to use it so it is not working with the salt install, hence the requirement to do a pip install:

```
[root@centos8 salt-bootstrap]# python3 -c "import tornado"                                                                                                                           
Traceback (most recent call last):                                                                                                                                                   
  File "<string>", line 1, in <module>                                                                                                                                               
ModuleNotFoundError: No module named 'tornado'                                                                                                                                       
[root@centos8 salt-bootstrap]# yum install python3-tornado4                                                                                                                          
Last metadata expiration check: 0:01:54 ago on Wed 30 Oct 2019 04:42:45 PM UTC.                                                                                                      
Dependencies resolved.                                                                                                                                                               
=====================================================================================================================================================================================
 Package                                         Arch                                  Version                                        Repository                                Size 
=====================================================================================================================================================================================
Installing:                                                                                                                                                                          
 python3-tornado4                                x86_64                                4.5.2-3.el8                                    saltstack                                729 k 
Installing dependencies:                                                                                                                                                             
 python3-pycurl                                  x86_64                                7.43.0.2-3.el8                                 AppStream                                227 k 
                                                                                                                                                                                     
Transaction Summary                                                                                                                                                                  
=====================================================================================================================================================================================
Install  2 Packages                                                                                                                                                                  
                                                                                                                                                                                     
Total download size: 957 k                                                                                                                                                           
Installed size: 4.4 M
Is this ok [y/N]: y
Downloading Packages:
(1/2): python3-pycurl-7.43.0.2-3.el8.x86_64.rpm                                                                                                      589 kB/s | 227 kB     00:00    
(2/2): python3-tornado4-4.5.2-3.el8.x86_64.rpm                                                                                                       1.4 MB/s | 729 kB     00:00    
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Total                                                                                                                                                590 kB/s | 957 kB     00:01     
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                                                                                                                             1/1 
  Installing       : python3-pycurl-7.43.0.2-3.el8.x86_64                                                                                                                        1/2 
  Installing       : python3-tornado4-4.5.2-3.el8.x86_64                                                                                                                         2/2 
  Running scriptlet: python3-tornado4-4.5.2-3.el8.x86_64                                                                                                                         2/2 
  Verifying        : python3-pycurl-7.43.0.2-3.el8.x86_64                                                                                                                        1/2 
  Verifying        : python3-tornado4-4.5.2-3.el8.x86_64                                                                                                                         2/2 

Installed:
  python3-tornado4-4.5.2-3.el8.x86_64                                                      python3-pycurl-7.43.0.2-3.el8.x86_64                                                     

Complete!
[root@centos8 salt-bootstrap]# python3 -c "import tornado"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ModuleNotFoundError: No module named 'tornado'
[root@centos8 salt-bootstrap]# python3 -c "import tornado4"
[root@centos8 salt-bootstrap]# salt --versions
Traceback (most recent call last):
  File "/usr/bin/salt", line 10, in <module>
    salt_main()
  File "/usr/lib/python3.6/site-packages/salt/scripts.py", line 511, in salt_main
    import salt.cli.salt
  File "/usr/lib/python3.6/site-packages/salt/cli/salt.py", line 11, in <module>
    import salt.utils.job
  File "/usr/lib/python3.6/site-packages/salt/utils/job.py", line 11, in <module>
    import salt.minion
  File "/usr/lib/python3.6/site-packages/salt/minion.py", line 28, in <module>
    from salt.utils.network import parse_host_port
  File "/usr/lib/python3.6/site-packages/salt/utils/network.py", line 35, in <module>
    import salt.utils.zeromq
  File "/usr/lib/python3.6/site-packages/salt/utils/zeromq.py", line 9, in <module>
    import tornado.ioloop
ModuleNotFoundError: No module named 'tornado'

```


### What issues does this PR fix or reference?
Part of fix for https://github.com/saltstack/salt-bootstrap/issues/1360

### Previous Behavior
Could not use git install on debian 10 . 

### New Behavior
Can now install a git install on debian 10 (`./bootstrap_salt.sh -x python3 -P git v2019.2.2`)The tornado version 4 package is not available on debian 10's repo's so we are requiring a pip install to install tornado 4. This will only be required until we add Tornado 5/6 support in the salt project.
