### PR TITLE
Update supported platforms in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -213,9 +213,10 @@ Supported Operating Systems
 ---------------------------
 
 The salt-bootstrap script officially supports the distributions outlined in
-`Salt's Supported Operating Systems`_ document. The operating systems listed below should reflect
-this document but may become out of date. If an operating system is listed below, but is not
-listed on the official supported operating systems document, the level of support is "best-effort".
+`Salt's Supported Operating Systems`_ document, except for Solaris and AIX. The operating systems
+listed below should reflect this document but may become out of date. If an operating system is
+listed below, but is not listed on the official supported operating systems document, the level of
+support is "best-effort".
 
 Since Salt is written in Python, the packages available from `SaltStack's corporate repository`_
 are CPU architecture independent and could be installed on any hardware supported by Linux kernel.
@@ -242,7 +243,7 @@ Debian and derivatives
 ~~~~~~~~~~~~~~~~~~~~~~
 
 - Cumulus Linux 2/3
-- Debian GNU/Linux 7/8/9
+- Debian GNU/Linux 7/8/9/10
 - Devuan GNU/Linux 1/2
 - Kali Linux 1.0 (based on Debian 7)
 - Linux Mint Debian Edition 1 (based on Debian 8)
@@ -265,11 +266,12 @@ Red Hat family
 ~~~~~~~~~~~~~~
 
 - Amazon Linux 2012.3 and later
-- CentOS 6/7
+- Amazon Linux 2
+- CentOS 6/7/8
 - Cloud Linux 6/7
-- Fedora 27/28 (install latest stable from standard repositories)
+- Fedora 30/31 (install latest stable from standard repositories)
 - Oracle Linux 6/7
-- Red Hat Enterprise Linux 6/7
+- Red Hat Enterprise Linux 6/7/8
 - Scientific Linux 6/7
 
 

--- a/README.rst
+++ b/README.rst
@@ -436,7 +436,7 @@ Salt components, custom configurations, and even `pre-accepted Minion keys`_ alr
 .. _`pre-accepted Minion keys`: https://docs.saltstack.com/en/latest/topics/tutorials/preseed_key.html
 .. _`read the source`: https://github.com/saltstack/salt-bootstrap/blob/develop/bootstrap-salt.sh
 .. _`Salt`: https://saltstack.com/community/
-.. _`Salt's Supported Operating Systems`: http://saltstack.com/wp-content/uploads/2016/08/SaltStack-Supported-Operating-Systems.pdf
+.. _`Salt's Supported Operating Systems`: http://get.saltstack.com/rs/304-PHQ-615/images/SaltStack-Supported-Operating-Systems.pdf
 .. _`SaltStack's corporate repository`: https://repo.saltstack.com/
 .. _`SaltStack's Debian repository`: http://repo.saltstack.com/#debian
 .. _`SaltStack's Ubuntu repository`: http://repo.saltstack.com/#ubuntu


### PR DESCRIPTION
Update supported platforms in README.
- clarify solaris and aix are not supported on bootstrap
- add debian10,amazon linux 2, centos8, fedora 30/31