### PR TITLE
Pin previous release of ShellCheck in CI tests

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -76,7 +76,7 @@ local Shellcheck() = {
   steps: [
     {
       name: 'shellcheck',
-      image: 'koalaman/shellcheck-alpine',
+      image: 'koalaman/shellcheck-alpine:v0.6.0',
       commands: [
         'shellcheck -s sh -f checkstyle bootstrap-salt.sh',
       ],

--- a/.drone.yml
+++ b/.drone.yml
@@ -8,7 +8,7 @@ platform:
 
 steps:
 - name: shellcheck
-  image: koalaman/shellcheck-alpine
+  image: koalaman/shellcheck-alpine:v0.6.0
   commands:
   - shellcheck -s sh -f checkstyle bootstrap-salt.sh
 


### PR DESCRIPTION
### What does this PR do?
It would be better to freeze the SC version and update it explicitly
with fixing all new founded issues.

### What issues does this PR fix or reference?
The latest and greatest version of ShellCheck seems to have more
hardened rules. This currently breaks CI tests in lint phase and
shows error messages for untouched lines in a PR.

I see the fixes for the latest version are here: https://github.com/saltstack/salt-bootstrap/pull/1381/commits/7d0b06ccf8677d81f6cb2ed5a96b023847855a6f
But it would not be added until the whole PR #1381 gonna to be merged.
In the meanwhile, the lint check for any other PRs will be broken.

@s0undt3ch, @Ch3LL, please take a look.