### PR TITLE
Fix Amazon Linux 2 Python 3 support and other clean up

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -67,6 +67,7 @@ local py2_blacklist = [
 local blacklist_2018 = [
   'centos-8',
   'debian-10',
+  'amazon-2',
 ];
 
 local Shellcheck() = {

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -50,7 +50,6 @@ local stable_distros = [
 
 local py3_distros = [
   'amazon-2',
-  'arch',
   'centos-7',
   'centos-8',
   'debian-9',

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -67,6 +67,7 @@ local py2_blacklist = [
 local blacklist_2018 = [
   'centos-8',
   'debian-10',
+  'amazon-2',
 ];
 
 local Shellcheck() = {
@@ -104,7 +105,11 @@ local Build(distro) = {
     else
       [],
 
-  local temp_git_py3_suites = if std.count(py3_distros, distro.slug) > 0 then
+  local temp_git_py3_suites = if std.count(py3_distros, distro.slug) < 1 then
+      []
+    else if std.count(blacklist_2018, distro.slug) > 0 then
+      git_py3_suites[1:]
+    else if std.count(py3_distros, distro.slug) > 0 then
       git_py3_suites
     else
       [],

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -50,6 +50,7 @@ local stable_distros = [
 
 local py3_distros = [
   'amazon-2',
+  'arch',
   'centos-7',
   'centos-8',
   'debian-9',

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -93,17 +93,33 @@ local Build(distro) = {
     project: 'open',
   },
 
-  local suite =
-      if std.count(py2_blacklist, distro.slug) > 0 then
-          []
-      else if std.count(stable_distros, distro.slug) > 0 then
-          git_suites + stable_suites
-      else git_suites,
-  local suites = suite + if std.count(blacklist_2018, distro.slug) > 0 then
-                             git_py3_suites + stable_py3_suites[1:]
-                         else if std.count(py3_distros, distro.slug) > 0 then
-                             git_py3_suites + stable_py3_suites
-                         else [],
+  local temp_git_suites = if std.count(py2_blacklist, distro.slug) > 0 then
+      []
+    else
+      git_suites,
+
+  local temp_stable_suites = if std.count(py2_blacklist, distro.slug) > 0 then
+      []
+    else if std.count(stable_distros, distro.slug) > 0 then
+      stable_suites
+    else
+      [],
+
+  local temp_git_py3_suites = if std.count(py3_distros, distro.slug) > 0 then
+      git_py3_suites
+    else
+      [],
+
+  local temp_stable_py3_suites = if std.count(stable_distros, distro.slug) < 1 then
+      []
+    else if std.count(blacklist_2018, distro.slug) > 0 then
+      stable_py3_suites[1:]
+    else if std.count(py3_distros, distro.slug) > 0 then
+      stable_py3_suites
+    else
+      [],
+
+  local suites = temp_git_suites + temp_stable_suites + temp_git_py3_suites + temp_stable_py3_suites,
 
   steps: [
     {

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -149,7 +149,7 @@ local Build(distro) = {
       commands: [
         'bundle install --with docker --without opennebula ec2 windows vagrant',
         "echo 'Waiting for docker to start'",
-        'sleep 15',  // give docker enough time to start
+        'sleep 30',  // give docker enough time to start
         'docker ps -a',
         std.format('bundle exec kitchen create %s', [distro.slug]),
       ],

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -20,7 +20,7 @@ local stable_py3_suites = [
 ];
 
 local distros = [
-  { name: 'Arch', slug: 'arch', multiplier: 0, depends: [] },
+//  { name: 'Arch', slug: 'arch', multiplier: 0, depends: [] },
 //  { name: 'Amazon 1', slug: 'amazon-1', multiplier: 1, depends: [] },
   { name: 'Amazon 2', slug: 'amazon-2', multiplier: 2, depends: [] },
   { name: 'CentOS 6', slug: 'centos-6', multiplier: 3, depends: [] },

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -67,7 +67,6 @@ local py2_blacklist = [
 local blacklist_2018 = [
   'centos-8',
   'debian-10',
-  'amazon-2',
 ];
 
 local Shellcheck() = {

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -20,7 +20,7 @@ local stable_py3_suites = [
 ];
 
 local distros = [
-//  { name: 'Arch', slug: 'arch', multiplier: 0, depends: [] },
+  { name: 'Arch', slug: 'arch', multiplier: 0, depends: [] },
 //  { name: 'Amazon 1', slug: 'amazon-1', multiplier: 1, depends: [] },
   { name: 'Amazon 2', slug: 'amazon-2', multiplier: 2, depends: [] },
   { name: 'CentOS 6', slug: 'centos-6', multiplier: 3, depends: [] },
@@ -50,6 +50,7 @@ local stable_distros = [
 
 local py3_distros = [
   'amazon-2',
+  'arch',
   'centos-7',
   'centos-8',
   'debian-9',
@@ -148,7 +149,7 @@ local Build(distro) = {
       commands: [
         'bundle install --with docker --without opennebula ec2 windows vagrant',
         "echo 'Waiting for docker to start'",
-        'sleep 30',  // give docker enough time to start
+        'sleep 20',  // give docker enough time to start
         'docker ps -a',
         std.format('bundle exec kitchen create %s', [distro.slug]),
       ],

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -44,6 +44,7 @@ local stable_distros = [
   'debian-8',
   'debian-9',
   'debian-10',
+  'fedora-30',
   'ubuntu-1604',
   'ubuntu-1804',
 ];

--- a/.drone.yml
+++ b/.drone.yml
@@ -90,7 +90,7 @@ steps:
 - name: throttle-build
   image: alpine
   commands:
-  - sh -c 't=96; echo Sleeping 96 seconds; sleep 96'
+  - sh -c 't=84; echo Sleeping 84 seconds; sleep 84'
 
 - name: create
   image: saltstack/drone-salt-bootstrap-testing
@@ -177,19 +177,6 @@ steps:
   - pip install -r tests/requirements.txt
   - bundle install --with docker --without opennebula ec2 windows vagrant
   - bundle exec kitchen test py3-git-2019-2-amazon-2
-  environment:
-    DOCKER_HOST: tcp://docker:2375
-  depends_on:
-  - throttle-build
-  - create
-
-- name: Py3 2018.3(Stable)
-  image: saltstack/drone-salt-bootstrap-testing
-  commands:
-  - pip install -U pip
-  - pip install -r tests/requirements.txt
-  - bundle install --with docker --without opennebula ec2 windows vagrant
-  - bundle exec kitchen test py3-stable-2018-3-amazon-2
   environment:
     DOCKER_HOST: tcp://docker:2375
   depends_on:
@@ -1326,6 +1313,6 @@ depends_on:
 
 ---
 kind: signature
-hmac: 2965bebb9df629cca7184c1b3e63b55a4b5a364927a04d66f7e9abab840323de
+hmac: 01bfd9713517348f9861dd811b44531bb17d6cf1e6635083aa27415824f36bed
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -851,7 +851,7 @@ steps:
 - name: throttle-build
   image: alpine
   commands:
-  - sh -c 't=108; echo Sleeping 108 seconds; sleep 108'
+  - sh -c 't=72; echo Sleeping 72 seconds; sleep 72'
 
 - name: create
   image: saltstack/drone-salt-bootstrap-testing
@@ -912,32 +912,6 @@ steps:
   - pip install -r tests/requirements.txt
   - bundle install --with docker --without opennebula ec2 windows vagrant
   - bundle exec kitchen test py3-git-2019-2-fedora-30
-  environment:
-    DOCKER_HOST: tcp://docker:2375
-  depends_on:
-  - throttle-build
-  - create
-
-- name: Py3 2018.3(Stable)
-  image: saltstack/drone-salt-bootstrap-testing
-  commands:
-  - pip install -U pip
-  - pip install -r tests/requirements.txt
-  - bundle install --with docker --without opennebula ec2 windows vagrant
-  - bundle exec kitchen test py3-stable-2018-3-fedora-30
-  environment:
-    DOCKER_HOST: tcp://docker:2375
-  depends_on:
-  - throttle-build
-  - create
-
-- name: Py3 2019.2(Stable)
-  image: saltstack/drone-salt-bootstrap-testing
-  commands:
-  - pip install -U pip
-  - pip install -r tests/requirements.txt
-  - bundle install --with docker --without opennebula ec2 windows vagrant
-  - bundle exec kitchen test py3-stable-2019-2-fedora-30
   environment:
     DOCKER_HOST: tcp://docker:2375
   depends_on:
@@ -1313,6 +1287,6 @@ depends_on:
 
 ---
 kind: signature
-hmac: 01bfd9713517348f9861dd811b44531bb17d6cf1e6635083aa27415824f36bed
+hmac: da059b4d6fe84b6de7a7406e52a05e1c8c3666782b0e7191cecc5803014c4d60
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -65,32 +65,6 @@ steps:
   - throttle-build
   - create
 
-- name: Py3 2018.3(Git)
-  image: saltstack/drone-salt-bootstrap-testing
-  commands:
-  - pip install -U pip
-  - pip install -r tests/requirements.txt
-  - bundle install --with docker --without opennebula ec2 windows vagrant
-  - bundle exec kitchen test py3-git-2018-3-arch
-  environment:
-    DOCKER_HOST: tcp://docker:2375
-  depends_on:
-  - throttle-build
-  - create
-
-- name: Py3 2019.2(Git)
-  image: saltstack/drone-salt-bootstrap-testing
-  commands:
-  - pip install -U pip
-  - pip install -r tests/requirements.txt
-  - bundle install --with docker --without opennebula ec2 windows vagrant
-  - bundle exec kitchen test py3-git-2019-2-arch
-  environment:
-    DOCKER_HOST: tcp://docker:2375
-  depends_on:
-  - throttle-build
-  - create
-
 services:
 - name: docker
   image: saltstack/drone-salt-bootstrap-testing
@@ -1274,6 +1248,6 @@ depends_on:
 
 ---
 kind: signature
-hmac: 5b2b9370523a7c47e068ffd8e99fda323bfa69f4d2a489b8e96241028ebd1967
+hmac: 1501ae2ebbd8a40fdb84727c1144aaf4b58e3aa4a4d354e49f820acb213d4a4e
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -838,7 +838,7 @@ steps:
 - name: throttle-build
   image: alpine
   commands:
-  - sh -c 't=72; echo Sleeping 72 seconds; sleep 72'
+  - sh -c 't=144; echo Sleeping 144 seconds; sleep 144'
 
 - name: create
   image: saltstack/drone-salt-bootstrap-testing
@@ -879,6 +879,32 @@ steps:
   - throttle-build
   - create
 
+- name: Py2 2018.3(Stable)
+  image: saltstack/drone-salt-bootstrap-testing
+  commands:
+  - pip install -U pip
+  - pip install -r tests/requirements.txt
+  - bundle install --with docker --without opennebula ec2 windows vagrant
+  - bundle exec kitchen test py2-stable-2018-3-fedora-30
+  environment:
+    DOCKER_HOST: tcp://docker:2375
+  depends_on:
+  - throttle-build
+  - create
+
+- name: Py2 2019.2(Stable)
+  image: saltstack/drone-salt-bootstrap-testing
+  commands:
+  - pip install -U pip
+  - pip install -r tests/requirements.txt
+  - bundle install --with docker --without opennebula ec2 windows vagrant
+  - bundle exec kitchen test py2-stable-2019-2-fedora-30
+  environment:
+    DOCKER_HOST: tcp://docker:2375
+  depends_on:
+  - throttle-build
+  - create
+
 - name: Py3 2018.3(Git)
   image: saltstack/drone-salt-bootstrap-testing
   commands:
@@ -899,6 +925,32 @@ steps:
   - pip install -r tests/requirements.txt
   - bundle install --with docker --without opennebula ec2 windows vagrant
   - bundle exec kitchen test py3-git-2019-2-fedora-30
+  environment:
+    DOCKER_HOST: tcp://docker:2375
+  depends_on:
+  - throttle-build
+  - create
+
+- name: Py3 2018.3(Stable)
+  image: saltstack/drone-salt-bootstrap-testing
+  commands:
+  - pip install -U pip
+  - pip install -r tests/requirements.txt
+  - bundle install --with docker --without opennebula ec2 windows vagrant
+  - bundle exec kitchen test py3-stable-2018-3-fedora-30
+  environment:
+    DOCKER_HOST: tcp://docker:2375
+  depends_on:
+  - throttle-build
+  - create
+
+- name: Py3 2019.2(Stable)
+  image: saltstack/drone-salt-bootstrap-testing
+  commands:
+  - pip install -U pip
+  - pip install -r tests/requirements.txt
+  - bundle install --with docker --without opennebula ec2 windows vagrant
+  - bundle exec kitchen test py3-stable-2019-2-fedora-30
   environment:
     DOCKER_HOST: tcp://docker:2375
   depends_on:
@@ -1274,6 +1326,6 @@ depends_on:
 
 ---
 kind: signature
-hmac: 93a6ec723c8cd2d30cb3926f1faaffc1876b68438b8be2abaece471941026d78
+hmac: 59c8f7c861aea35dba9890b536519e10b6e41452bb6c15f88b6a7dbc6e158506
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -90,7 +90,7 @@ steps:
 - name: throttle-build
   image: alpine
   commands:
-  - sh -c 't=84; echo Sleeping 84 seconds; sleep 84'
+  - sh -c 't=96; echo Sleeping 96 seconds; sleep 96'
 
 - name: create
   image: saltstack/drone-salt-bootstrap-testing
@@ -177,6 +177,19 @@ steps:
   - pip install -r tests/requirements.txt
   - bundle install --with docker --without opennebula ec2 windows vagrant
   - bundle exec kitchen test py3-git-2019-2-amazon-2
+  environment:
+    DOCKER_HOST: tcp://docker:2375
+  depends_on:
+  - throttle-build
+  - create
+
+- name: Py3 2018.3(Stable)
+  image: saltstack/drone-salt-bootstrap-testing
+  commands:
+  - pip install -U pip
+  - pip install -r tests/requirements.txt
+  - bundle install --with docker --without opennebula ec2 windows vagrant
+  - bundle exec kitchen test py3-stable-2018-3-amazon-2
   environment:
     DOCKER_HOST: tcp://docker:2375
   depends_on:
@@ -1287,6 +1300,6 @@ depends_on:
 
 ---
 kind: signature
-hmac: da059b4d6fe84b6de7a7406e52a05e1c8c3666782b0e7191cecc5803014c4d60
+hmac: 7149a0a774f38abdd26d312c9df3febaaa4ca7b3e502da0847d42c3973e373ae
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -14,6 +14,98 @@ steps:
 
 ---
 kind: pipeline
+name: Arch
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+- name: throttle-build
+  image: alpine
+  commands:
+  - sh -c 't=0; echo Sleeping 0 seconds; sleep 0'
+
+- name: create
+  image: saltstack/drone-salt-bootstrap-testing
+  commands:
+  - bundle install --with docker --without opennebula ec2 windows vagrant
+  - echo 'Waiting for docker to start'
+  - sleep 20
+  - docker ps -a
+  - bundle exec kitchen create arch
+  environment:
+    DOCKER_HOST: tcp://docker:2375
+  depends_on:
+  - throttle-build
+
+- name: Py2 2018.3(Git)
+  image: saltstack/drone-salt-bootstrap-testing
+  commands:
+  - pip install -U pip
+  - pip install -r tests/requirements.txt
+  - bundle install --with docker --without opennebula ec2 windows vagrant
+  - bundle exec kitchen test py2-git-2018-3-arch
+  environment:
+    DOCKER_HOST: tcp://docker:2375
+  depends_on:
+  - throttle-build
+  - create
+
+- name: Py2 2019.2(Git)
+  image: saltstack/drone-salt-bootstrap-testing
+  commands:
+  - pip install -U pip
+  - pip install -r tests/requirements.txt
+  - bundle install --with docker --without opennebula ec2 windows vagrant
+  - bundle exec kitchen test py2-git-2019-2-arch
+  environment:
+    DOCKER_HOST: tcp://docker:2375
+  depends_on:
+  - throttle-build
+  - create
+
+- name: Py3 2018.3(Git)
+  image: saltstack/drone-salt-bootstrap-testing
+  commands:
+  - pip install -U pip
+  - pip install -r tests/requirements.txt
+  - bundle install --with docker --without opennebula ec2 windows vagrant
+  - bundle exec kitchen test py3-git-2018-3-arch
+  environment:
+    DOCKER_HOST: tcp://docker:2375
+  depends_on:
+  - throttle-build
+  - create
+
+- name: Py3 2019.2(Git)
+  image: saltstack/drone-salt-bootstrap-testing
+  commands:
+  - pip install -U pip
+  - pip install -r tests/requirements.txt
+  - bundle install --with docker --without opennebula ec2 windows vagrant
+  - bundle exec kitchen test py3-git-2019-2-arch
+  environment:
+    DOCKER_HOST: tcp://docker:2375
+  depends_on:
+  - throttle-build
+  - create
+
+services:
+- name: docker
+  image: saltstack/drone-salt-bootstrap-testing
+  command:
+  - --storage-driver=overlay2
+  privileged: true
+
+node:
+  project: open
+
+depends_on:
+- Lint
+
+---
+kind: pipeline
 name: Amazon 2
 
 platform:
@@ -31,7 +123,7 @@ steps:
   commands:
   - bundle install --with docker --without opennebula ec2 windows vagrant
   - echo 'Waiting for docker to start'
-  - sleep 30
+  - sleep 20
   - docker ps -a
   - bundle exec kitchen create amazon-2
   environment:
@@ -149,7 +241,7 @@ steps:
   commands:
   - bundle install --with docker --without opennebula ec2 windows vagrant
   - echo 'Waiting for docker to start'
-  - sleep 30
+  - sleep 20
   - docker ps -a
   - bundle exec kitchen create centos-6
   environment:
@@ -241,7 +333,7 @@ steps:
   commands:
   - bundle install --with docker --without opennebula ec2 windows vagrant
   - echo 'Waiting for docker to start'
-  - sleep 30
+  - sleep 20
   - docker ps -a
   - bundle exec kitchen create centos-7
   environment:
@@ -385,7 +477,7 @@ steps:
   commands:
   - bundle install --with docker --without opennebula ec2 windows vagrant
   - echo 'Waiting for docker to start'
-  - sleep 30
+  - sleep 20
   - docker ps -a
   - bundle exec kitchen create centos-8
   environment:
@@ -451,7 +543,7 @@ steps:
   commands:
   - bundle install --with docker --without opennebula ec2 windows vagrant
   - echo 'Waiting for docker to start'
-  - sleep 30
+  - sleep 20
   - docker ps -a
   - bundle exec kitchen create debian-8
   environment:
@@ -543,7 +635,7 @@ steps:
   commands:
   - bundle install --with docker --without opennebula ec2 windows vagrant
   - echo 'Waiting for docker to start'
-  - sleep 30
+  - sleep 20
   - docker ps -a
   - bundle exec kitchen create debian-9
   environment:
@@ -687,7 +779,7 @@ steps:
   commands:
   - bundle install --with docker --without opennebula ec2 windows vagrant
   - echo 'Waiting for docker to start'
-  - sleep 30
+  - sleep 20
   - docker ps -a
   - bundle exec kitchen create debian-10
   environment:
@@ -753,7 +845,7 @@ steps:
   commands:
   - bundle install --with docker --without opennebula ec2 windows vagrant
   - echo 'Waiting for docker to start'
-  - sleep 30
+  - sleep 20
   - docker ps -a
   - bundle exec kitchen create fedora-30
   environment:
@@ -845,7 +937,7 @@ steps:
   commands:
   - bundle install --with docker --without opennebula ec2 windows vagrant
   - echo 'Waiting for docker to start'
-  - sleep 30
+  - sleep 20
   - docker ps -a
   - bundle exec kitchen create opensuse-15
   environment:
@@ -911,7 +1003,7 @@ steps:
   commands:
   - bundle install --with docker --without opennebula ec2 windows vagrant
   - echo 'Waiting for docker to start'
-  - sleep 30
+  - sleep 20
   - docker ps -a
   - bundle exec kitchen create ubuntu-1604
   environment:
@@ -1055,7 +1147,7 @@ steps:
   commands:
   - bundle install --with docker --without opennebula ec2 windows vagrant
   - echo 'Waiting for docker to start'
-  - sleep 30
+  - sleep 20
   - docker ps -a
   - bundle exec kitchen create ubuntu-1804
   environment:
@@ -1182,6 +1274,6 @@ depends_on:
 
 ---
 kind: signature
-hmac: b6b552aff7d2d8de9fc31b11c86faae9d5da0f58499fd529210c94854e70b45b
+hmac: 93a6ec723c8cd2d30cb3926f1faaffc1876b68438b8be2abaece471941026d78
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -31,7 +31,7 @@ steps:
   commands:
   - bundle install --with docker --without opennebula ec2 windows vagrant
   - echo 'Waiting for docker to start'
-  - sleep 15
+  - sleep 30
   - docker ps -a
   - bundle exec kitchen create arch
   environment:
@@ -123,7 +123,7 @@ steps:
   commands:
   - bundle install --with docker --without opennebula ec2 windows vagrant
   - echo 'Waiting for docker to start'
-  - sleep 15
+  - sleep 30
   - docker ps -a
   - bundle exec kitchen create amazon-2
   environment:
@@ -241,7 +241,7 @@ steps:
   commands:
   - bundle install --with docker --without opennebula ec2 windows vagrant
   - echo 'Waiting for docker to start'
-  - sleep 15
+  - sleep 30
   - docker ps -a
   - bundle exec kitchen create centos-6
   environment:
@@ -333,7 +333,7 @@ steps:
   commands:
   - bundle install --with docker --without opennebula ec2 windows vagrant
   - echo 'Waiting for docker to start'
-  - sleep 15
+  - sleep 30
   - docker ps -a
   - bundle exec kitchen create centos-7
   environment:
@@ -477,7 +477,7 @@ steps:
   commands:
   - bundle install --with docker --without opennebula ec2 windows vagrant
   - echo 'Waiting for docker to start'
-  - sleep 15
+  - sleep 30
   - docker ps -a
   - bundle exec kitchen create centos-8
   environment:
@@ -543,7 +543,7 @@ steps:
   commands:
   - bundle install --with docker --without opennebula ec2 windows vagrant
   - echo 'Waiting for docker to start'
-  - sleep 15
+  - sleep 30
   - docker ps -a
   - bundle exec kitchen create debian-8
   environment:
@@ -635,7 +635,7 @@ steps:
   commands:
   - bundle install --with docker --without opennebula ec2 windows vagrant
   - echo 'Waiting for docker to start'
-  - sleep 15
+  - sleep 30
   - docker ps -a
   - bundle exec kitchen create debian-9
   environment:
@@ -779,7 +779,7 @@ steps:
   commands:
   - bundle install --with docker --without opennebula ec2 windows vagrant
   - echo 'Waiting for docker to start'
-  - sleep 15
+  - sleep 30
   - docker ps -a
   - bundle exec kitchen create debian-10
   environment:
@@ -845,7 +845,7 @@ steps:
   commands:
   - bundle install --with docker --without opennebula ec2 windows vagrant
   - echo 'Waiting for docker to start'
-  - sleep 15
+  - sleep 30
   - docker ps -a
   - bundle exec kitchen create fedora-30
   environment:
@@ -937,7 +937,7 @@ steps:
   commands:
   - bundle install --with docker --without opennebula ec2 windows vagrant
   - echo 'Waiting for docker to start'
-  - sleep 15
+  - sleep 30
   - docker ps -a
   - bundle exec kitchen create opensuse-15
   environment:
@@ -1003,7 +1003,7 @@ steps:
   commands:
   - bundle install --with docker --without opennebula ec2 windows vagrant
   - echo 'Waiting for docker to start'
-  - sleep 15
+  - sleep 30
   - docker ps -a
   - bundle exec kitchen create ubuntu-1604
   environment:
@@ -1147,7 +1147,7 @@ steps:
   commands:
   - bundle install --with docker --without opennebula ec2 windows vagrant
   - echo 'Waiting for docker to start'
-  - sleep 15
+  - sleep 30
   - docker ps -a
   - bundle exec kitchen create ubuntu-1804
   environment:
@@ -1274,6 +1274,6 @@ depends_on:
 
 ---
 kind: signature
-hmac: d34adb5aae5ec297aaf275c1fc17ae87369b57b0d043be2a6c15b294456a57a3
+hmac: 5b2b9370523a7c47e068ffd8e99fda323bfa69f4d2a489b8e96241028ebd1967
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -90,7 +90,7 @@ steps:
 - name: throttle-build
   image: alpine
   commands:
-  - sh -c 't=96; echo Sleeping 96 seconds; sleep 96'
+  - sh -c 't=72; echo Sleeping 72 seconds; sleep 72'
 
 - name: create
   image: saltstack/drone-salt-bootstrap-testing
@@ -157,19 +157,6 @@ steps:
   - throttle-build
   - create
 
-- name: Py3 2018.3(Git)
-  image: saltstack/drone-salt-bootstrap-testing
-  commands:
-  - pip install -U pip
-  - pip install -r tests/requirements.txt
-  - bundle install --with docker --without opennebula ec2 windows vagrant
-  - bundle exec kitchen test py3-git-2018-3-amazon-2
-  environment:
-    DOCKER_HOST: tcp://docker:2375
-  depends_on:
-  - throttle-build
-  - create
-
 - name: Py3 2019.2(Git)
   image: saltstack/drone-salt-bootstrap-testing
   commands:
@@ -177,19 +164,6 @@ steps:
   - pip install -r tests/requirements.txt
   - bundle install --with docker --without opennebula ec2 windows vagrant
   - bundle exec kitchen test py3-git-2019-2-amazon-2
-  environment:
-    DOCKER_HOST: tcp://docker:2375
-  depends_on:
-  - throttle-build
-  - create
-
-- name: Py3 2018.3(Stable)
-  image: saltstack/drone-salt-bootstrap-testing
-  commands:
-  - pip install -U pip
-  - pip install -r tests/requirements.txt
-  - bundle install --with docker --without opennebula ec2 windows vagrant
-  - bundle exec kitchen test py3-stable-2018-3-amazon-2
   environment:
     DOCKER_HOST: tcp://docker:2375
   depends_on:
@@ -470,7 +444,7 @@ steps:
 - name: throttle-build
   image: alpine
   commands:
-  - sh -c 't=90; echo Sleeping 90 seconds; sleep 90'
+  - sh -c 't=60; echo Sleeping 60 seconds; sleep 60'
 
 - name: create
   image: saltstack/drone-salt-bootstrap-testing
@@ -484,19 +458,6 @@ steps:
     DOCKER_HOST: tcp://docker:2375
   depends_on:
   - throttle-build
-
-- name: Py3 2018.3(Git)
-  image: saltstack/drone-salt-bootstrap-testing
-  commands:
-  - pip install -U pip
-  - pip install -r tests/requirements.txt
-  - bundle install --with docker --without opennebula ec2 windows vagrant
-  - bundle exec kitchen test py3-git-2018-3-centos-8
-  environment:
-    DOCKER_HOST: tcp://docker:2375
-  depends_on:
-  - throttle-build
-  - create
 
 - name: Py3 2019.2(Git)
   image: saltstack/drone-salt-bootstrap-testing
@@ -785,7 +746,7 @@ steps:
 - name: throttle-build
   image: alpine
   commands:
-  - sh -c 't=72; echo Sleeping 72 seconds; sleep 72'
+  - sh -c 't=48; echo Sleeping 48 seconds; sleep 48'
 
 - name: create
   image: saltstack/drone-salt-bootstrap-testing
@@ -799,19 +760,6 @@ steps:
     DOCKER_HOST: tcp://docker:2375
   depends_on:
   - throttle-build
-
-- name: Py3 2018.3(Git)
-  image: saltstack/drone-salt-bootstrap-testing
-  commands:
-  - pip install -U pip
-  - pip install -r tests/requirements.txt
-  - bundle install --with docker --without opennebula ec2 windows vagrant
-  - bundle exec kitchen test py3-git-2018-3-debian-10
-  environment:
-    DOCKER_HOST: tcp://docker:2375
-  depends_on:
-  - throttle-build
-  - create
 
 - name: Py3 2019.2(Git)
   image: saltstack/drone-salt-bootstrap-testing
@@ -1300,6 +1248,6 @@ depends_on:
 
 ---
 kind: signature
-hmac: 7149a0a774f38abdd26d312c9df3febaaa4ca7b3e502da0847d42c3973e373ae
+hmac: a1e3b561c227bc7ec6fa8c0319d4c55d98f42c7311015123d63cf78292e9d318
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -14,72 +14,6 @@ steps:
 
 ---
 kind: pipeline
-name: Arch
-
-platform:
-  os: linux
-  arch: amd64
-
-steps:
-- name: throttle-build
-  image: alpine
-  commands:
-  - sh -c 't=0; echo Sleeping 0 seconds; sleep 0'
-
-- name: create
-  image: saltstack/drone-salt-bootstrap-testing
-  commands:
-  - bundle install --with docker --without opennebula ec2 windows vagrant
-  - echo 'Waiting for docker to start'
-  - sleep 30
-  - docker ps -a
-  - bundle exec kitchen create arch
-  environment:
-    DOCKER_HOST: tcp://docker:2375
-  depends_on:
-  - throttle-build
-
-- name: Py2 2018.3(Git)
-  image: saltstack/drone-salt-bootstrap-testing
-  commands:
-  - pip install -U pip
-  - pip install -r tests/requirements.txt
-  - bundle install --with docker --without opennebula ec2 windows vagrant
-  - bundle exec kitchen test py2-git-2018-3-arch
-  environment:
-    DOCKER_HOST: tcp://docker:2375
-  depends_on:
-  - throttle-build
-  - create
-
-- name: Py2 2019.2(Git)
-  image: saltstack/drone-salt-bootstrap-testing
-  commands:
-  - pip install -U pip
-  - pip install -r tests/requirements.txt
-  - bundle install --with docker --without opennebula ec2 windows vagrant
-  - bundle exec kitchen test py2-git-2019-2-arch
-  environment:
-    DOCKER_HOST: tcp://docker:2375
-  depends_on:
-  - throttle-build
-  - create
-
-services:
-- name: docker
-  image: saltstack/drone-salt-bootstrap-testing
-  command:
-  - --storage-driver=overlay2
-  privileged: true
-
-node:
-  project: open
-
-depends_on:
-- Lint
-
----
-kind: pipeline
 name: Amazon 2
 
 platform:
@@ -1248,6 +1182,6 @@ depends_on:
 
 ---
 kind: signature
-hmac: 1501ae2ebbd8a40fdb84727c1144aaf4b58e3aa4a4d354e49f820acb213d4a4e
+hmac: b6b552aff7d2d8de9fc31b11c86faae9d5da0f58499fd529210c94854e70b45b
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -65,6 +65,32 @@ steps:
   - throttle-build
   - create
 
+- name: Py3 2018.3(Git)
+  image: saltstack/drone-salt-bootstrap-testing
+  commands:
+  - pip install -U pip
+  - pip install -r tests/requirements.txt
+  - bundle install --with docker --without opennebula ec2 windows vagrant
+  - bundle exec kitchen test py3-git-2018-3-arch
+  environment:
+    DOCKER_HOST: tcp://docker:2375
+  depends_on:
+  - throttle-build
+  - create
+
+- name: Py3 2019.2(Git)
+  image: saltstack/drone-salt-bootstrap-testing
+  commands:
+  - pip install -U pip
+  - pip install -r tests/requirements.txt
+  - bundle install --with docker --without opennebula ec2 windows vagrant
+  - bundle exec kitchen test py3-git-2019-2-arch
+  environment:
+    DOCKER_HOST: tcp://docker:2375
+  depends_on:
+  - throttle-build
+  - create
+
 services:
 - name: docker
   image: saltstack/drone-salt-bootstrap-testing
@@ -1248,6 +1274,6 @@ depends_on:
 
 ---
 kind: signature
-hmac: a1e3b561c227bc7ec6fa8c0319d4c55d98f42c7311015123d63cf78292e9d318
+hmac: d34adb5aae5ec297aaf275c1fc17ae87369b57b0d043be2a6c15b294456a57a3
 
 ...

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -47,6 +47,7 @@ platforms:
       image: archlinux/base
       run_command: /usr/lib/systemd/systemd
       provision_command:
+        - pacman-key --refresh-keys
         - pacman -Syu --noconfirm --needed systemd grep awk procps which
         - systemctl enable sshd
   - name: centos-8

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -47,7 +47,9 @@ platforms:
       image: archlinux/base
       run_command: /usr/lib/systemd/systemd
       provision_command:
-        - pacman-key --refresh-keys
+        - rm -fR /etc/pacman.d/gnupg
+        - pacman-key --init
+        - pacman-key --populate archlinux
         - pacman -Syu --noconfirm --needed systemd grep awk procps which
         - systemctl enable sshd
   - name: centos-8

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -47,9 +47,6 @@ platforms:
       image: archlinux/base
       run_command: /usr/lib/systemd/systemd
       provision_command:
-        - rm -fR /etc/pacman.d/gnupg
-        - pacman-key --init
-        - pacman-key --populate archlinux
         - pacman -Syu --noconfirm --needed systemd grep awk procps which
         - systemctl enable sshd
   - name: centos-8

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -131,6 +131,7 @@ suites:
       - centos-6
       - debian-8
       - opensuse-15
+      - amazon-2
   - name: py3-git-2019-2
     provisioner:
       salt_version: 2019.2
@@ -149,6 +150,7 @@ suites:
       - centos-6
       - debian-8
       - opensuse-15
+      - amazon-2
   - name: py3-stable-2019-2
     provisioner:
       salt_version: 2019.2

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -135,7 +135,7 @@ suites:
   - name: py3-git-2019-2
     provisioner:
       salt_version: 2019.2
-      salt_bootstrap_options: -y -x python3 -MPfq git %s
+      salt_bootstrap_options: -x python3 -MPfq git %s
     excludes:
       - amazon-1
       - centos-6

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -40,6 +40,8 @@ platforms:
       image: amazonlinux:2
       platform: rhel
       run_command: /usr/lib/systemd/systemd
+      provision_command:
+        - yum install -y procps-ng
   - name: arch
     driver_config:
       image: archlinux/base
@@ -129,10 +131,11 @@ suites:
       - centos-6
       - debian-8
       - opensuse-15
+      - amazon-2
   - name: py3-git-2019-2
     provisioner:
       salt_version: 2019.2
-      salt_bootstrap_options: -x python3 -MPfq git %s
+      salt_bootstrap_options: -y -x python3 -MPfq git %s
     excludes:
       - amazon-1
       - centos-6
@@ -150,7 +153,7 @@ suites:
   - name: py3-stable-2019-2
     provisioner:
       salt_version: 2019.2
-      salt_bootstrap_options: -x python3 -MP stable %s
+      salt_bootstrap_options: -y -x python3 -MP stable %s
     excludes:
       - amazon-1
       - centos-6

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -131,7 +131,6 @@ suites:
       - centos-6
       - debian-8
       - opensuse-15
-      - amazon-2
   - name: py3-git-2019-2
     provisioner:
       salt_version: 2019.2

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -41,7 +41,7 @@ platforms:
       platform: rhel
       run_command: /usr/lib/systemd/systemd
       provision_command:
-        - yum install -y procps-ng
+        - yum -y install procps-ng
   - name: arch
     driver_config:
       image: archlinux/base

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -153,7 +153,7 @@ suites:
   - name: py3-stable-2019-2
     provisioner:
       salt_version: 2019.2
-      salt_bootstrap_options: -y -x python3 -MP stable %s
+      salt_bootstrap_options: -x python3 -MP stable %s
     excludes:
       - amazon-1
       - centos-6

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1,7 +1,5 @@
 #!/bin/sh -
 
-set -o functrace
-
 # WARNING: Changes to this file in the salt repo will be overwritten!
 # Please submit pull requests against the salt-bootstrap repo:
 # https://github.com/saltstack/salt-bootstrap

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -4859,7 +4859,7 @@ install_amazon_linux_ami_2_git_deps() {
 
     if [ "$_INSTALL_CLOUD" -eq $BS_TRUE ]; then
         __check_pip_allowed "You need to allow pip based installations \(-P\) in order to install apache-libcloud"
-        if [ $PARSED_VERSION -eq 2 ]; then
+        if [ "$PARSED_VERSION" -eq 2 ]; then
             if [ -n "$_PY_EXE" ] && [ "$_PY_MAJOR_VERSION" -eq 3 ]; then
                 __PACKAGES="${__PACKAGES} python3-pip"
             else

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -23,7 +23,7 @@
 #======================================================================================================================
 set -o nounset                              # Treat unset variables as an error
 
-__ScriptVersion="2019.12.18"
+__ScriptVersion="2019.12.19"
 __ScriptName="bootstrap-salt.sh"
 
 __ScriptFullName="$0"

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2542,7 +2542,7 @@ __install_pip_pkgs() {
 #----------------------------------------------------------------------------------------------------------------------
 __install_tornado_pip() {
     # OS needs tornado <5.0 from pip
-    __check_pip_allowed "You need to allow pip based installations (-P) for Tornado <5.0 in order to install Salt on Python 3"
+    __check_pip_allowed "You need to allow pip based installations \(-P\) for Tornado <5.0 in order to install Salt on Python 3"
     ## install pip if its not installed and install tornado
     __install_pip_pkgs "tornado<5.0" "${1}" || return 1
 }
@@ -3620,7 +3620,7 @@ install_fedora_git_deps() {
     # Fedora 28+ needs tornado <5.0 from pip
     # https://github.com/saltstack/salt-bootstrap/issues/1220
     if [ "${PY_PKG_VER}" -eq 3 ] && [ "$DISTRO_MAJOR_VERSION" -ge 28 ]; then
-        __check_pip_allowed "You need to allow pip based installations (-P) for Tornado <5.0 in order to install Salt on Python 3"
+        __check_pip_allowed "You need to allow pip based installations \(-P\) for Tornado <5.0 in order to install Salt on Python 3"
         grep tornado "${_SALT_GIT_CHECKOUT_DIR}/requirements/base.txt" | while IFS='
 '         read -r dep; do
             "${_PY_EXE}" -m pip install "${dep}" || return 1
@@ -4793,7 +4793,7 @@ install_amazon_linux_ami_git_deps() {
     __PIP_PACKAGES=""
 
     if [ "$_INSTALL_CLOUD" -eq $BS_TRUE ]; then
-        __check_pip_allowed "You need to allow pip based installations (-P) in order to install apache-libcloud"
+        __check_pip_allowed "You need to allow pip based installations \(-P\) in order to install apache-libcloud"
         __PACKAGES="${__PACKAGES} python27-pip"
         __PIP_PACKAGES="${__PIP_PACKAGES} apache-libcloud>=$_LIBCLOUD_MIN_VERSION"
     fi
@@ -4858,7 +4858,7 @@ install_amazon_linux_ami_2_git_deps() {
     __PIP_PACKAGES=""
 
     if [ "$_INSTALL_CLOUD" -eq $BS_TRUE ]; then
-        __check_pip_allowed "You need to allow pip based installations (-P) in order to install apache-libcloud"
+        __check_pip_allowed "You need to allow pip based installations \(-P\) in order to install apache-libcloud"
         if [ $PARSED_VERSION -eq 2 ]; then
             if [ -n "$_PY_EXE" ] && [ "$_PY_MAJOR_VERSION" -eq 3 ]; then
                 __PACKAGES="${__PACKAGES} python3-pip"

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2110,7 +2110,7 @@ __copyfile() {
         dfile=$2
         overwrite=$3
     else
-        echoerror "Wrong number of arguments for __copyfile()"
+        echoerror "Wrong number of arguments for __copyfile\(\)"
         echoinfo "USAGE: __copyfile <source> <dest>  OR  __copyfile <source> <dest> <overwrite>"
         exit 1
     fi
@@ -2158,7 +2158,7 @@ __movefile() {
         dfile=$2
         overwrite=$3
     else
-        echoerror "Wrong number of arguments for __movefile()"
+        echoerror "Wrong number of arguments for __movefile\(\)"
         echoinfo "USAGE: __movefile <source> <dest>  OR  __movefile <source> <dest> <overwrite>"
         exit 1
     fi
@@ -2215,7 +2215,7 @@ __linkfile() {
         linkname=$2
         overwrite=$3
     else
-        echoerror "Wrong number of arguments for __linkfile()"
+        echoerror "Wrong number of arguments for __linkfile\(\)"
         echoinfo "USAGE: __linkfile <target> <link>  OR  __linkfile <tagret> <link> <overwrite>"
         exit 1
     fi
@@ -2260,7 +2260,7 @@ __overwriteconfig() {
         target=$1
         json=$2
     else
-        echoerror "Wrong number of arguments for __convert_json_to_yaml_str()"
+        echoerror "Wrong number of arguments for __convert_json_to_yaml_str\(\)"
         echoinfo "USAGE: __convert_json_to_yaml_str <configfile> <jsonstring>"
         exit 1
     fi
@@ -4832,13 +4832,12 @@ install_amazon_linux_ami_2_git_deps() {
         yum -y install ca-certificates || return 1
     fi
 
-        if __check_command_exists python3; then
+    if __check_command_exists python3; then
             if ! __check_command_exists pip3; then
                 __yum_install_noinput python3-pip
             fi
             PIP_EXE='/bin/pip3'
             _PY_EXE='python3'
-        fi
     else
         PIP_EXE='pip'
         if __check_command_exists python2.7; then
@@ -4942,13 +4941,13 @@ install_amazon_linux_ami_2_deps() {
         if [ -n "$_PY_EXE" ] && [ "$_PY_MAJOR_VERSION" -eq 3 ]; then
             __PY_VERSION_REPO="py3"
             PY_PKG_VER=3
-            repo_name="SaltStack Python 3 repo for Amazon Linux 2.0"
+            repo_name="SaltStack Python 3 repo for Amazon Linux 2"
         fi
 
         base_url="$HTTP_VAL://${_REPO_URL}/${__PY_VERSION_REPO}/amazon/2/\$basearch/$repo_rev/"
-        gpg_key="${base_url}SALTSTACK-GPG-KEY.pub
+        gpg_key="${base_url}SALTSTACK-GPG-KEY.pub"
         if [ -n "$_PY_EXE" ] && [ "$_PY_MAJOR_VERSION" -ne 3 ]; then
-            ${base_url}base/RPM-GPG-KEY-CentOS-7"
+            "${base_url}base/RPM-GPG-KEY-CentOS-7"
         fi
 
         # This should prob be refactored to use __install_saltstack_rhel_repository()
@@ -5593,11 +5592,11 @@ install_smartos_git_deps() {
     if [ -f "${_SALT_GIT_CHECKOUT_DIR}/requirements/base.txt" ]; then
         # Install whichever tornado is in the requirements file
         __REQUIRED_TORNADO="$(grep tornado "${_SALT_GIT_CHECKOUT_DIR}/requirements/base.txt")"
-        __check_pip_allowed "You need to allow pip based installations (-P) in order to install the python package '${__REQUIRED_TORNADO}'"
+        __check_pip_allowed "You need to allow pip based installations \(-P\) in order to install the python package '${__REQUIRED_TORNADO}'"
 
         # Install whichever futures is in the requirements file
         __REQUIRED_FUTURES="$(grep futures "${_SALT_GIT_CHECKOUT_DIR}/requirements/base.txt")"
-        __check_pip_allowed "You need to allow pip based installations (-P) in order to install the python package '${__REQUIRED_FUTURES}'"
+        __check_pip_allowed "You need to allow pip based installations \(-P\) in order to install the python package '${__REQUIRED_FUTURES}'"
 
         if [ "${__REQUIRED_TORNADO}" != "" ]; then
             if ! __check_command_exists pip; then
@@ -6722,7 +6721,7 @@ config_salt() {
     [ "$_TEMP_CONFIG_DIR" = "null" ] && return
 
     if [ "$_CONFIG_ONLY" -eq $BS_TRUE ]; then
-        echowarn "Passing -C (config only) option implies -F (forced overwrite)."
+        echowarn "Passing -C \(config only\) option implies -F \(forced overwrite\)."
 
         if [ "$_FORCE_OVERWRITE" -ne $BS_TRUE ]; then
             echowarn "Overwriting configs in 11 seconds!"
@@ -7102,9 +7101,9 @@ fi
 # Install dependencies
 if [ ${_NO_DEPS} -eq $BS_FALSE ] && [ $_CONFIG_ONLY -eq $BS_FALSE ]; then
     # Only execute function is not in config mode only
-    echoinfo "Running ${DEPS_INSTALL_FUNC}()"
+    echoinfo "Running ${DEPS_INSTALL_FUNC}\(\)"
     if ! ${DEPS_INSTALL_FUNC}; then
-        echoerror "Failed to run ${DEPS_INSTALL_FUNC}()!!!"
+        echoerror "Failed to run ${DEPS_INSTALL_FUNC}\(\)!!!"
         exit 1
     fi
 fi
@@ -7126,9 +7125,9 @@ if [ "$_CUSTOM_MASTER_CONFIG" != "null" ] || [ "$_CUSTOM_MINION_CONFIG" != "null
 
     if [ ${_NO_DEPS} -eq $BS_FALSE ] && [ $_CONFIG_ONLY -eq $BS_TRUE ]; then
         # Execute function to satisfy dependencies for configuration step
-        echoinfo "Running ${DEPS_INSTALL_FUNC}()"
+        echoinfo "Running ${DEPS_INSTALL_FUNC}\(\)"
         if ! ${DEPS_INSTALL_FUNC}; then
-            echoerror "Failed to run ${DEPS_INSTALL_FUNC}()!!!"
+            echoerror "Failed to run ${DEPS_INSTALL_FUNC}\(\)!!!"
             exit 1
         fi
     fi
@@ -7136,9 +7135,9 @@ fi
 
 # Configure Salt
 if [ "$CONFIG_SALT_FUNC" != "null" ] && [ "$_TEMP_CONFIG_DIR" != "null" ]; then
-    echoinfo "Running ${CONFIG_SALT_FUNC}()"
+    echoinfo "Running ${CONFIG_SALT_FUNC}\(\)"
     if ! ${CONFIG_SALT_FUNC}; then
-        echoerror "Failed to run ${CONFIG_SALT_FUNC}()!!!"
+        echoerror "Failed to run ${CONFIG_SALT_FUNC}\(\)!!!"
         exit 1
     fi
 fi
@@ -7159,9 +7158,9 @@ fi
 
 # Pre-seed master keys
 if [ "$PRESEED_MASTER_FUNC" != "null" ] && [ "$_TEMP_KEYS_DIR" != "null" ]; then
-    echoinfo "Running ${PRESEED_MASTER_FUNC}()"
+    echoinfo "Running ${PRESEED_MASTER_FUNC}\(\)"
     if ! ${PRESEED_MASTER_FUNC}; then
-        echoerror "Failed to run ${PRESEED_MASTER_FUNC}()!!!"
+        echoerror "Failed to run ${PRESEED_MASTER_FUNC}\(\)!!!"
         exit 1
     fi
 fi
@@ -7169,49 +7168,49 @@ fi
 # Install Salt
 if [ "$_CONFIG_ONLY" -eq $BS_FALSE ]; then
     # Only execute function is not in config mode only
-    echoinfo "Running ${INSTALL_FUNC}()"
+    echoinfo "Running ${INSTALL_FUNC}\(\)"
     if ! ${INSTALL_FUNC}; then
-        echoerror "Failed to run ${INSTALL_FUNC}()!!!"
+        echoerror "Failed to run ${INSTALL_FUNC}\(\)!!!"
         exit 1
     fi
 fi
 
 # Run any post install function. Only execute function if not in config mode only
 if [ "$POST_INSTALL_FUNC" != "null" ] && [ "$_CONFIG_ONLY" -eq $BS_FALSE ]; then
-    echoinfo "Running ${POST_INSTALL_FUNC}()"
+    echoinfo "Running ${POST_INSTALL_FUNC}\(\)"
     if ! ${POST_INSTALL_FUNC}; then
-        echoerror "Failed to run ${POST_INSTALL_FUNC}()!!!"
+        echoerror "Failed to run ${POST_INSTALL_FUNC}\(\)!!!"
         exit 1
     fi
 fi
 
 # Run any check services function, Only execute function if not in config mode only
 if [ "$CHECK_SERVICES_FUNC" != "null" ] && [ "$_CONFIG_ONLY" -eq $BS_FALSE ]; then
-    echoinfo "Running ${CHECK_SERVICES_FUNC}()"
+    echoinfo "Running ${CHECK_SERVICES_FUNC}\(\)"
     if ! ${CHECK_SERVICES_FUNC}; then
-        echoerror "Failed to run ${CHECK_SERVICES_FUNC}()!!!"
+        echoerror "Failed to run ${CHECK_SERVICES_FUNC}\(\)!!!"
         exit 1
     fi
 fi
 
 # Run any start daemons function
 if [ "$STARTDAEMONS_INSTALL_FUNC" != "null" ] && [ ${_START_DAEMONS} -eq $BS_TRUE ]; then
-    echoinfo "Running ${STARTDAEMONS_INSTALL_FUNC}()"
+    echoinfo "Running ${STARTDAEMONS_INSTALL_FUNC}\(\)"
     echodebug "Waiting ${_SLEEP} seconds for processes to settle before checking for them"
     sleep ${_SLEEP}
     if ! ${STARTDAEMONS_INSTALL_FUNC}; then
-        echoerror "Failed to run ${STARTDAEMONS_INSTALL_FUNC}()!!!"
+        echoerror "Failed to run ${STARTDAEMONS_INSTALL_FUNC}\(\)!!!"
         exit 1
     fi
 fi
 
 # Check if the installed daemons are running or not
 if [ "$DAEMONS_RUNNING_FUNC" != "null" ] && [ ${_START_DAEMONS} -eq $BS_TRUE ]; then
-    echoinfo "Running ${DAEMONS_RUNNING_FUNC}()"
+    echoinfo "Running ${DAEMONS_RUNNING_FUNC}\(\)"
     echodebug "Waiting ${_SLEEP} seconds for processes to settle before checking for them"
     sleep ${_SLEEP}  # Sleep a little bit to let daemons start
     if ! ${DAEMONS_RUNNING_FUNC}; then
-        echoerror "Failed to run ${DAEMONS_RUNNING_FUNC}()!!!"
+        echoerror "Failed to run ${DAEMONS_RUNNING_FUNC}\(\)!!!"
 
         for fname in api master minion syndic; do
             # Skip salt-api since the service should be opt-in and not necessarily started on boot

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -4977,7 +4977,7 @@ _eof
     # Package python-ordereddict-1.1-2.el6.noarch is obsoleted by python26-2.6.9-2.88.amzn1.x86_64
     # which is already installed
     if [ "${PY_PKG_VER}" -eq 3 ]; then
-        __PACKAGES="python3 ${pkg_append}${PY_PKG_VER}-m2crypto ${pkg_append}${PY_PKG_VER}-pyyaml"
+        __PACKAGES="${pkg_append}${PY_PKG_VER}-m2crypto ${pkg_append}${PY_PKG_VER}-pyyaml"
     else
         __PACKAGES="m2crypto PyYAML ${pkg_append}-futures"
     fi

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1,4 +1,4 @@
-!/bin/sh -
+#!/bin/sh -
 
 # WARNING: Changes to this file in the salt repo will be overwritten!
 # Please submit pull requests against the salt-bootstrap repo:

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -4834,6 +4834,7 @@ install_amazon_linux_ami_2_git_deps() {
         yum -y install ca-certificates || return 1
     fi
 
+    install_amazon_linux_ami_2_deps || return 1
     if __check_command_exists python3; then
             if ! __check_command_exists pip3; then
                 __yum_install_noinput python3-pip
@@ -4850,7 +4851,6 @@ install_amazon_linux_ami_2_git_deps() {
             _PY_EXE='python2.7'
         fi
     fi
-    install_amazon_linux_ami_2_deps || return 1
 
     if ! __check_command_exists git; then
         __yum_install_noinput git || return 1
@@ -4936,14 +4936,16 @@ install_amazon_linux_ami_2_deps() {
 
     if [ $_DISABLE_REPOS -eq $BS_FALSE ] || [ "$_CUSTOM_REPO_URL" != "null" ]; then
         __REPO_FILENAME="saltstack-repo.repo"
-
         __PY_VERSION_REPO="yum"
         PY_PKG_VER=""
         _PY_MAJOR_VERSION=$(echo "$_PY_PKG_VER" | cut -c 7)
+        repo_label="saltstack-repo"
         repo_name="SaltStack repo for Amazon Linux 2"
         if [ -n "$_PY_EXE" ] && [ "$_PY_MAJOR_VERSION" -eq 3 ]; then
+            __REPO_FILENAME="saltstack-py3-repo.repo"
             __PY_VERSION_REPO="py3"
             PY_PKG_VER=3
+            repo_label="saltstack-py3-repo"
             repo_name="SaltStack Python 3 repo for Amazon Linux 2"
         fi
 
@@ -4958,7 +4960,7 @@ install_amazon_linux_ami_2_deps() {
         # amazon linux yum file.
         if [ ! -s "/etc/yum.repos.d/${__REPO_FILENAME}" ]; then
           cat <<_eof > "/etc/yum.repos.d/${__REPO_FILENAME}"
-[saltstack-repo]
+[$repo_label]
 name=$repo_name
 failovermethod=priority
 priority=10
@@ -4973,10 +4975,9 @@ _eof
     # Package python-ordereddict-1.1-2.el6.noarch is obsoleted by python26-2.6.9-2.88.amzn1.x86_64
     # which is already installed
     if [ "${PY_PKG_VER}" -eq 3 ]; then
-    __PACKAGES="${pkg_append}${PY_PKG_VER}-m2crypto ${pkg_append}${PY_PKG_VER}-pyyaml"
-
+        __PACKAGES="python3 ${pkg_append}${PY_PKG_VER}-m2crypto ${pkg_append}${PY_PKG_VER}-pyyaml"
     else
-    __PACKAGES="m2crypto PyYAML ${pkg_append}-futures"
+        __PACKAGES="m2crypto PyYAML ${pkg_append}-futures"
     fi
 
     __PACKAGES="${__PACKAGES} ${pkg_append}${PY_PKG_VER}-crypto ${pkg_append}${PY_PKG_VER}-jinja2 procps-ng"

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -
+!/bin/sh -
 
 # WARNING: Changes to this file in the salt repo will be overwritten!
 # Please submit pull requests against the salt-bootstrap repo:
@@ -23,7 +23,7 @@
 #======================================================================================================================
 set -o nounset                              # Treat unset variables as an error
 
-__ScriptVersion="2019.12.19"
+__ScriptVersion="2019.11.04"
 __ScriptName="bootstrap-salt.sh"
 
 __ScriptFullName="$0"

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -4935,6 +4935,7 @@ install_amazon_linux_ami_2_deps() {
 
         __PY_VERSION_REPO="yum"
         PY_PKG_VER=""
+        _PY_MAJOR_VERSION=$(echo "$_PY_PKG_VER" | cut -c 7)
         repo_name="SaltStack repo for Amazon Linux 2.0"
         if [ -n "$_PY_EXE" ] && [ "$_PY_MAJOR_VERSION" -eq 3 ]; then
             __PY_VERSION_REPO="py3"

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -270,6 +270,7 @@ _QUIET_GIT_INSTALLATION=$BS_FALSE
 _REPO_URL="repo.saltstack.com"
 _PY_EXE=""
 _INSTALL_PY="$BS_FALSE"
+_TORNADO_MAX_PY3_VERSION="5.0"
 
 # Defaults for install arguments
 ITYPE="stable"
@@ -4866,6 +4867,7 @@ install_amazon_linux_ami_2_git_deps() {
         if [ "$PARSED_VERSION" -eq "2" ]; then
             if [ -n "$_PY_EXE" ] && [ "$_PY_MAJOR_VERSION" -eq "3" ]; then
                 __PACKAGES="${__PACKAGES} python3-pip"
+                __PIP_PACKAGES="${__PIP_PACKAGES} tornado<$_TORNADO_MAX_PY3_VERSION"
             else
                 __PACKAGES="${__PACKAGES} python2-pip"
             fi
@@ -4879,7 +4881,7 @@ install_amazon_linux_ami_2_git_deps() {
         # We're on the develop branch, install whichever tornado is on the requirements file
         __REQUIRED_TORNADO="$(grep tornado "${_SALT_GIT_CHECKOUT_DIR}/requirements/base.txt")"
         if [ "${__REQUIRED_TORNADO}" != "" ]; then
-            __PACKAGES="${__PACKAGES} ${pkg_append}-tornado"
+            __PACKAGES="${__PACKAGES} ${pkg_append}${PY_PKG_VER}-tornado"
         fi
     fi
 

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -23,7 +23,7 @@
 #======================================================================================================================
 set -o nounset                              # Treat unset variables as an error
 
-__ScriptVersion="2019.11.04"
+__ScriptVersion="2019.12.18"
 __ScriptName="bootstrap-salt.sh"
 
 __ScriptFullName="$0"

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -4857,10 +4857,10 @@ install_amazon_linux_ami_2_git_deps() {
     __PACKAGES=""
     __PIP_PACKAGES=""
 
-    if [ "$_INSTALL_CLOUD" -eq $BS_TRUE ]; then
+    if [ "$_INSTALL_CLOUD" -eq "$BS_TRUE" ]; then
         __check_pip_allowed "You need to allow pip based installations \(-P\) in order to install apache-libcloud"
-        if [ "$PARSED_VERSION" -eq 2 ]; then
-            if [ -n "$_PY_EXE" ] && [ "$_PY_MAJOR_VERSION" -eq 3 ]; then
+        if [ "$PARSED_VERSION" -eq "2" ]; then
+            if [ -n "$_PY_EXE" ] && [ "$_PY_MAJOR_VERSION" -eq "3" ]; then
                 __PACKAGES="${__PACKAGES} python3-pip"
             else
                 __PACKAGES="${__PACKAGES} python2-pip"

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2911,9 +2911,11 @@ install_ubuntu_git() {
     fi
 
     if [ -f "${_SALT_GIT_CHECKOUT_DIR}/salt/syspaths.py" ]; then
-        ${_PYEXE} setup.py --salt-config-dir="$_SALT_ETC_DIR" --salt-cache-dir="${_SALT_CACHE_DIR}" ${SETUP_PY_INSTALL_ARGS} install --install-layout=deb || return 1
+        # shellcheck disable=SC2086
+        "${_PYEXE}" setup.py --salt-config-dir="$_SALT_ETC_DIR" --salt-cache-dir="${_SALT_CACHE_DIR}" ${SETUP_PY_INSTALL_ARGS} install --install-layout=deb || return 1
     else
-        ${_PYEXE} setup.py ${SETUP_PY_INSTALL_ARGS} install --install-layout=deb || return 1
+        # shellcheck disable=SC2086
+        "${_PYEXE}" setup.py ${SETUP_PY_INSTALL_ARGS} install --install-layout=deb || return 1
     fi
 
     return 0
@@ -3395,9 +3397,11 @@ install_debian_git() {
     fi
 
     if [ -f "${_SALT_GIT_CHECKOUT_DIR}/salt/syspaths.py" ]; then
-        ${_PYEXE} setup.py --salt-config-dir="$_SALT_ETC_DIR" --salt-cache-dir="${_SALT_CACHE_DIR}" ${SETUP_PY_INSTALL_ARGS} install --install-layout=deb || return 1
+        # shellcheck disable=SC2086
+        "${_PYEXE}" setup.py --salt-config-dir="$_SALT_ETC_DIR" --salt-cache-dir="${_SALT_CACHE_DIR}" ${SETUP_PY_INSTALL_ARGS} install --install-layout=deb || return 1
     else
-        ${_PYEXE} setup.py ${SETUP_PY_INSTALL_ARGS} install --install-layout=deb || return 1
+        # shellcheck disable=SC2086
+        "${_PYEXE}" setup.py ${SETUP_PY_INSTALL_ARGS} install --install-layout=deb || return 1
     fi
 }
 

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -4940,7 +4940,7 @@ install_amazon_linux_ami_2_deps() {
         __PY_VERSION_REPO="yum"
         PY_PKG_VER=""
         _PY_MAJOR_VERSION=$(echo "$_PY_PKG_VER" | cut -c 7)
-        repo_name="SaltStack repo for Amazon Linux 2.0"
+        repo_name="SaltStack repo for Amazon Linux 2"
         if [ -n "$_PY_EXE" ] && [ "$_PY_MAJOR_VERSION" -eq 3 ]; then
             __PY_VERSION_REPO="py3"
             PY_PKG_VER=3
@@ -4948,9 +4948,9 @@ install_amazon_linux_ami_2_deps() {
         fi
 
         base_url="$HTTP_VAL://${_REPO_URL}/${__PY_VERSION_REPO}/amazon/2/\$basearch/$repo_rev/"
-        gpg_key="${base_url}SALTSTACK-GPG-KEY.pub"
-        if [ -n "$_PY_EXE" ] && [ "$_PY_MAJOR_VERSION" -ne 3 ]; then
-            "${base_url}base/RPM-GPG-KEY-CentOS-7"
+        gpg_key="${base_url}SALTSTACK-GPG-KEY.pub,${base_url}base/RPM-GPG-KEY-CentOS-7"
+        if [ -n "$_PY_EXE" ] && [ "$_PY_MAJOR_VERSION" -eq 3 ]; then
+            gpg_key="${base_url}SALTSTACK-GPG-KEY.pub"
         fi
 
         # This should prob be refactored to use __install_saltstack_rhel_repository()

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2108,7 +2108,7 @@ __copyfile() {
         dfile=$2
         overwrite=$3
     else
-        echoerror "Wrong number of arguments for __copyfile\(\)"
+        echoerror "Wrong number of arguments for __copyfile()"
         echoinfo "USAGE: __copyfile <source> <dest>  OR  __copyfile <source> <dest> <overwrite>"
         exit 1
     fi
@@ -2156,7 +2156,7 @@ __movefile() {
         dfile=$2
         overwrite=$3
     else
-        echoerror "Wrong number of arguments for __movefile\(\)"
+        echoerror "Wrong number of arguments for __movefile()"
         echoinfo "USAGE: __movefile <source> <dest>  OR  __movefile <source> <dest> <overwrite>"
         exit 1
     fi
@@ -2213,7 +2213,7 @@ __linkfile() {
         linkname=$2
         overwrite=$3
     else
-        echoerror "Wrong number of arguments for __linkfile\(\)"
+        echoerror "Wrong number of arguments for __linkfile()"
         echoinfo "USAGE: __linkfile <target> <link>  OR  __linkfile <tagret> <link> <overwrite>"
         exit 1
     fi
@@ -2258,7 +2258,7 @@ __overwriteconfig() {
         target=$1
         json=$2
     else
-        echoerror "Wrong number of arguments for __convert_json_to_yaml_str\(\)"
+        echoerror "Wrong number of arguments for __convert_json_to_yaml_str()"
         echoinfo "USAGE: __convert_json_to_yaml_str <configfile> <jsonstring>"
         exit 1
     fi
@@ -2542,7 +2542,7 @@ __install_pip_pkgs() {
 #----------------------------------------------------------------------------------------------------------------------
 __install_tornado_pip() {
     # OS needs tornado <5.0 from pip
-    __check_pip_allowed "You need to allow pip based installations \(-P\) for Tornado <5.0 in order to install Salt on Python 3"
+    __check_pip_allowed "You need to allow pip based installations (-P) for Tornado <5.0 in order to install Salt on Python 3"
     ## install pip if its not installed and install tornado
     __install_pip_pkgs "tornado<5.0" "${1}" || return 1
 }
@@ -3620,7 +3620,7 @@ install_fedora_git_deps() {
     # Fedora 28+ needs tornado <5.0 from pip
     # https://github.com/saltstack/salt-bootstrap/issues/1220
     if [ "${PY_PKG_VER}" -eq 3 ] && [ "$DISTRO_MAJOR_VERSION" -ge 28 ]; then
-        __check_pip_allowed "You need to allow pip based installations \(-P\) for Tornado <5.0 in order to install Salt on Python 3"
+        __check_pip_allowed "You need to allow pip based installations (-P) for Tornado <5.0 in order to install Salt on Python 3"
         grep tornado "${_SALT_GIT_CHECKOUT_DIR}/requirements/base.txt" | while IFS='
 '         read -r dep; do
             "${_PY_EXE}" -m pip install "${dep}" || return 1
@@ -4793,7 +4793,7 @@ install_amazon_linux_ami_git_deps() {
     __PIP_PACKAGES=""
 
     if [ "$_INSTALL_CLOUD" -eq $BS_TRUE ]; then
-        __check_pip_allowed "You need to allow pip based installations \(-P\) in order to install apache-libcloud"
+        __check_pip_allowed "You need to allow pip based installations (-P) in order to install apache-libcloud"
         __PACKAGES="${__PACKAGES} python27-pip"
         __PIP_PACKAGES="${__PIP_PACKAGES} apache-libcloud>=$_LIBCLOUD_MIN_VERSION"
     fi
@@ -4858,7 +4858,7 @@ install_amazon_linux_ami_2_git_deps() {
     __PIP_PACKAGES=""
 
     if [ "$_INSTALL_CLOUD" -eq "$BS_TRUE" ]; then
-        __check_pip_allowed "You need to allow pip based installations \(-P\) in order to install apache-libcloud"
+        __check_pip_allowed "You need to allow pip based installations (-P) in order to install apache-libcloud"
         if [ "$PARSED_VERSION" -eq "2" ]; then
             if [ -n "$_PY_EXE" ] && [ "$_PY_MAJOR_VERSION" -eq "3" ]; then
                 __PACKAGES="${__PACKAGES} python3-pip"
@@ -5590,11 +5590,11 @@ install_smartos_git_deps() {
     if [ -f "${_SALT_GIT_CHECKOUT_DIR}/requirements/base.txt" ]; then
         # Install whichever tornado is in the requirements file
         __REQUIRED_TORNADO="$(grep tornado "${_SALT_GIT_CHECKOUT_DIR}/requirements/base.txt")"
-        __check_pip_allowed "You need to allow pip based installations \(-P\) in order to install the python package '${__REQUIRED_TORNADO}'"
+        __check_pip_allowed "You need to allow pip based installations (-P) in order to install the python package '${__REQUIRED_TORNADO}'"
 
         # Install whichever futures is in the requirements file
         __REQUIRED_FUTURES="$(grep futures "${_SALT_GIT_CHECKOUT_DIR}/requirements/base.txt")"
-        __check_pip_allowed "You need to allow pip based installations \(-P\) in order to install the python package '${__REQUIRED_FUTURES}'"
+        __check_pip_allowed "You need to allow pip based installations (-P) in order to install the python package '${__REQUIRED_FUTURES}'"
 
         if [ "${__REQUIRED_TORNADO}" != "" ]; then
             if ! __check_command_exists pip; then
@@ -6719,7 +6719,7 @@ config_salt() {
     [ "$_TEMP_CONFIG_DIR" = "null" ] && return
 
     if [ "$_CONFIG_ONLY" -eq $BS_TRUE ]; then
-        echowarn "Passing -C \(config only\) option implies -F \(forced overwrite\)."
+        echowarn "Passing -C (config only) option implies -F (forced overwrite)."
 
         if [ "$_FORCE_OVERWRITE" -ne $BS_TRUE ]; then
             echowarn "Overwriting configs in 11 seconds!"
@@ -7099,9 +7099,9 @@ fi
 # Install dependencies
 if [ ${_NO_DEPS} -eq $BS_FALSE ] && [ $_CONFIG_ONLY -eq $BS_FALSE ]; then
     # Only execute function is not in config mode only
-    echoinfo "Running ${DEPS_INSTALL_FUNC}\(\)"
+    echoinfo "Running ${DEPS_INSTALL_FUNC}()"
     if ! ${DEPS_INSTALL_FUNC}; then
-        echoerror "Failed to run ${DEPS_INSTALL_FUNC}\(\)!!!"
+        echoerror "Failed to run ${DEPS_INSTALL_FUNC}()!!!"
         exit 1
     fi
 fi
@@ -7123,9 +7123,9 @@ if [ "$_CUSTOM_MASTER_CONFIG" != "null" ] || [ "$_CUSTOM_MINION_CONFIG" != "null
 
     if [ ${_NO_DEPS} -eq $BS_FALSE ] && [ $_CONFIG_ONLY -eq $BS_TRUE ]; then
         # Execute function to satisfy dependencies for configuration step
-        echoinfo "Running ${DEPS_INSTALL_FUNC}\(\)"
+        echoinfo "Running ${DEPS_INSTALL_FUNC}()"
         if ! ${DEPS_INSTALL_FUNC}; then
-            echoerror "Failed to run ${DEPS_INSTALL_FUNC}\(\)!!!"
+            echoerror "Failed to run ${DEPS_INSTALL_FUNC}()!!!"
             exit 1
         fi
     fi
@@ -7133,9 +7133,9 @@ fi
 
 # Configure Salt
 if [ "$CONFIG_SALT_FUNC" != "null" ] && [ "$_TEMP_CONFIG_DIR" != "null" ]; then
-    echoinfo "Running ${CONFIG_SALT_FUNC}\(\)"
+    echoinfo "Running ${CONFIG_SALT_FUNC}()"
     if ! ${CONFIG_SALT_FUNC}; then
-        echoerror "Failed to run ${CONFIG_SALT_FUNC}\(\)!!!"
+        echoerror "Failed to run ${CONFIG_SALT_FUNC}()!!!"
         exit 1
     fi
 fi
@@ -7156,9 +7156,9 @@ fi
 
 # Pre-seed master keys
 if [ "$PRESEED_MASTER_FUNC" != "null" ] && [ "$_TEMP_KEYS_DIR" != "null" ]; then
-    echoinfo "Running ${PRESEED_MASTER_FUNC}\(\)"
+    echoinfo "Running ${PRESEED_MASTER_FUNC}()"
     if ! ${PRESEED_MASTER_FUNC}; then
-        echoerror "Failed to run ${PRESEED_MASTER_FUNC}\(\)!!!"
+        echoerror "Failed to run ${PRESEED_MASTER_FUNC}()!!!"
         exit 1
     fi
 fi
@@ -7166,49 +7166,49 @@ fi
 # Install Salt
 if [ "$_CONFIG_ONLY" -eq $BS_FALSE ]; then
     # Only execute function is not in config mode only
-    echoinfo "Running ${INSTALL_FUNC}\(\)"
+    echoinfo "Running ${INSTALL_FUNC}()"
     if ! ${INSTALL_FUNC}; then
-        echoerror "Failed to run ${INSTALL_FUNC}\(\)!!!"
+        echoerror "Failed to run ${INSTALL_FUNC}()!!!"
         exit 1
     fi
 fi
 
 # Run any post install function. Only execute function if not in config mode only
 if [ "$POST_INSTALL_FUNC" != "null" ] && [ "$_CONFIG_ONLY" -eq $BS_FALSE ]; then
-    echoinfo "Running ${POST_INSTALL_FUNC}\(\)"
+    echoinfo "Running ${POST_INSTALL_FUNC}()"
     if ! ${POST_INSTALL_FUNC}; then
-        echoerror "Failed to run ${POST_INSTALL_FUNC}\(\)!!!"
+        echoerror "Failed to run ${POST_INSTALL_FUNC}()!!!"
         exit 1
     fi
 fi
 
 # Run any check services function, Only execute function if not in config mode only
 if [ "$CHECK_SERVICES_FUNC" != "null" ] && [ "$_CONFIG_ONLY" -eq $BS_FALSE ]; then
-    echoinfo "Running ${CHECK_SERVICES_FUNC}\(\)"
+    echoinfo "Running ${CHECK_SERVICES_FUNC}()"
     if ! ${CHECK_SERVICES_FUNC}; then
-        echoerror "Failed to run ${CHECK_SERVICES_FUNC}\(\)!!!"
+        echoerror "Failed to run ${CHECK_SERVICES_FUNC}()!!!"
         exit 1
     fi
 fi
 
 # Run any start daemons function
 if [ "$STARTDAEMONS_INSTALL_FUNC" != "null" ] && [ ${_START_DAEMONS} -eq $BS_TRUE ]; then
-    echoinfo "Running ${STARTDAEMONS_INSTALL_FUNC}\(\)"
+    echoinfo "Running ${STARTDAEMONS_INSTALL_FUNC}()"
     echodebug "Waiting ${_SLEEP} seconds for processes to settle before checking for them"
     sleep ${_SLEEP}
     if ! ${STARTDAEMONS_INSTALL_FUNC}; then
-        echoerror "Failed to run ${STARTDAEMONS_INSTALL_FUNC}\(\)!!!"
+        echoerror "Failed to run ${STARTDAEMONS_INSTALL_FUNC}()!!!"
         exit 1
     fi
 fi
 
 # Check if the installed daemons are running or not
 if [ "$DAEMONS_RUNNING_FUNC" != "null" ] && [ ${_START_DAEMONS} -eq $BS_TRUE ]; then
-    echoinfo "Running ${DAEMONS_RUNNING_FUNC}\(\)"
+    echoinfo "Running ${DAEMONS_RUNNING_FUNC}()"
     echodebug "Waiting ${_SLEEP} seconds for processes to settle before checking for them"
     sleep ${_SLEEP}  # Sleep a little bit to let daemons start
     if ! ${DAEMONS_RUNNING_FUNC}; then
-        echoerror "Failed to run ${DAEMONS_RUNNING_FUNC}\(\)!!!"
+        echoerror "Failed to run ${DAEMONS_RUNNING_FUNC}()!!!"
 
         for fname in api master minion syndic; do
             # Skip salt-api since the service should be opt-in and not necessarily started on boot


### PR DESCRIPTION
### What does this PR do?
Provides bootstrap support for Amazon Linux 2 Python 3 support, and other minor cleanup
Work-in-progress to utilize testing 

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-bootstrap/issues/1391

### Previous Behavior
Installed Python 2 Amazon Linux 2 salt-minion, when Python 3 Amazon Linux 2 salt-minion was desired

### New Behavior
Installs Python 3 Amazon Linux 2 salt-minion via bootstrap with '-x python3' parameter.