### PR TITLE
readme.rst, adds minimum Salt version for python3

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -372,6 +372,8 @@ Installing the Python 3 packages for Salt is done via the ``-x`` option:
 
 See the ``-x`` option for more information.
 
+The earliest release of Salt that supports Python3 is `2018.3.4`.
+
 Tornado 5/6 Workaround
 ----------------------
 Salt does not support tornado>=5.0 currently. This support will not be added until the neon


### PR DESCRIPTION
### What does this PR do?

Updates the README with a note regarding the minimum version of Salt that can be installed when using the `-x python3` parameter.

### What issues does this PR fix or reference?

* https://github.com/saltstack/salt-bootstrap/issues/1398
