### PR TITLE
Updated Opensuse from 15.0 to 15.1 to get past Opensuse curl induced SIGSEGV

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -30,7 +30,7 @@ local distros = [
   { name: 'Debian 9', slug: 'debian-9', multiplier: 5, depends: [] },
   { name: 'Debian 10', slug: 'debian-10', multiplier: 4, depends: [] },
   { name: 'Fedora 30', slug: 'fedora-30', multiplier: 3, depends: [] },
-  { name: 'Opensuse 15.0', slug: 'opensuse-15', multiplier: 2, depends: [] },
+  { name: 'Opensuse 15.1', slug: 'opensuse-15', multiplier: 2, depends: [] },
   { name: 'Ubuntu 16.04', slug: 'ubuntu-1604', multiplier: 1, depends: [] },
   { name: 'Ubuntu 18.04', slug: 'ubuntu-1804', multiplier: 0, depends: [] },
 ];

--- a/.drone.yml
+++ b/.drone.yml
@@ -972,7 +972,7 @@ depends_on:
 
 ---
 kind: pipeline
-name: Opensuse 15.0
+name: Opensuse 15.1
 
 platform:
   os: linux
@@ -1326,6 +1326,6 @@ depends_on:
 
 ---
 kind: signature
-hmac: 59c8f7c861aea35dba9890b536519e10b6e41452bb6c15f88b6a7dbc6e158506
+hmac: 9c01a5f3f8d8fe0b09aad2cc73976678a432edf3c81aafdff0d17e52ce4cc7f8
 
 ...

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -83,7 +83,7 @@ platforms:
       run_command: /usr/lib/systemd/systemd
   - name: opensuse-15
     driver_config:
-      image: opensuse/leap:15.0
+      image: opensuse/leap:15.1
       run_command: /usr/lib/systemd/systemd
       provision_command:
         - zypper --non-interactive install --auto-agree-with-licenses dbus-1


### PR DESCRIPTION
### What does this PR do?
Upgrade the version of Opensuse tested against from 15.0 to 15.1

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-bootstrap/issues/1407

### Previous Behavior
Container creation would fail with error code 139 (SIGSEGV)

### New Behavior
Container creation succeeds

