### PR TITLE
Use package "origin" for all FreeBSD packages

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -328,7 +328,7 @@ UNIX systems
 **BSD**:
 
 - OpenBSD (``pip`` installation)
-- FreeBSD 9/10/11
+- FreeBSD 9/10/11/12
 
 **SunOS**:
 

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -5296,7 +5296,7 @@ install_freebsd_deps() {
 }
 
 install_freebsd_git_deps() {
-    install_freebsd_stable_deps || return 1
+    install_freebsd_deps || return 1
 
     SALT_DEPENDENCIES=$(/usr/local/sbin/pkg search -R -d sysutils/py-salt | grep 'origin:' \
         | tail -n +2 | awk -F\" '{print $2}')
@@ -5361,8 +5361,8 @@ install_freebsd_stable() {
 
 install_freebsd_git() {
 
-    # /usr/local/bin/python2 in FreeBSD is a symlink to /usr/local/bin/python2.7
-    __PYTHON_PATH=$(readlink -f "$(command -v python2)")
+    # /usr/local/bin/python3 in FreeBSD is a symlink to /usr/local/bin/python3.7
+    __PYTHON_PATH=$(readlink -f "$(command -v python3)")
     __ESCAPED_PYTHON_PATH=$(echo "${__PYTHON_PATH}" | sed 's/\//\\\//g')
 
     # Install from git

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -5301,7 +5301,7 @@ install_freebsd_git_deps() {
     SALT_DEPENDENCIES=$(/usr/local/sbin/pkg search -R -d sysutils/py-salt | grep 'origin:' \
         | tail -n +2 | awk -F\" '{print $2}')
     # shellcheck disable=SC2086
-    /usr/local/sbin/pkg install -y ${SALT_DEPENDENCIES} || return 1
+    /usr/local/sbin/pkg install -y ${SALT_DEPENDENCIES} python || return 1
 
     if ! __check_command_exists git; then
         /usr/local/sbin/pkg install -y devel/git || return 1

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -5298,16 +5298,16 @@ install_freebsd_deps() {
 install_freebsd_git_deps() {
     install_freebsd_stable_deps || return 1
 
-    SALT_DEPENDENCIES=$(/usr/local/sbin/pkg search -R -d py36-salt | grep 'origin:' \
-        | tail -n +2 | awk -F\" '{print $2}' | sed 's#.*/py-#py36-#g')
+    SALT_DEPENDENCIES=$(/usr/local/sbin/pkg search -R -d sysutils/py-salt | grep 'origin:' \
+        | tail -n +2 | awk -F\" '{print $2}')
     # shellcheck disable=SC2086
     /usr/local/sbin/pkg install -y ${SALT_DEPENDENCIES} || return 1
 
     if ! __check_command_exists git; then
-        /usr/local/sbin/pkg install -y git || return 1
+        /usr/local/sbin/pkg install -y devel/git-lite || return 1
     fi
 
-    /usr/local/sbin/pkg install -y py36-requests || return 1
+    /usr/local/sbin/pkg install -y www/py-requests || return 1
 
     __git_clone_and_checkout || return 1
 
@@ -5354,7 +5354,7 @@ install_freebsd_stable() {
 # installing latest version of salt from FreeBSD CURRENT ports repo
 #
     # shellcheck disable=SC2086
-    /usr/local/sbin/pkg install -y py36-salt || return 1
+    /usr/local/sbin/pkg install -y sysutils/py-salt || return 1
 
     return 0
 }

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -5304,7 +5304,7 @@ install_freebsd_git_deps() {
     /usr/local/sbin/pkg install -y ${SALT_DEPENDENCIES} || return 1
 
     if ! __check_command_exists git; then
-        /usr/local/sbin/pkg install -y devel/git-lite || return 1
+        /usr/local/sbin/pkg install -y devel/git || return 1
     fi
 
     /usr/local/sbin/pkg install -y www/py-requests || return 1

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -5298,16 +5298,16 @@ install_freebsd_deps() {
 install_freebsd_git_deps() {
     install_freebsd_deps || return 1
 
-    SALT_DEPENDENCIES=$(/usr/local/sbin/pkg search -R -d sysutils/py-salt | grep 'origin:' \
+    SALT_DEPENDENCIES=$(/usr/local/sbin/pkg search -R -d py37-salt | grep 'origin:' \
         | tail -n +2 | awk -F\" '{print $2}')
     # shellcheck disable=SC2086
     /usr/local/sbin/pkg install -y ${SALT_DEPENDENCIES} python || return 1
 
     if ! __check_command_exists git; then
-        /usr/local/sbin/pkg install -y devel/git || return 1
+        /usr/local/sbin/pkg install -y git || return 1
     fi
 
-    /usr/local/sbin/pkg install -y www/py-requests || return 1
+    /usr/local/sbin/pkg install -y py37-requests || return 1
 
     __git_clone_and_checkout || return 1
 
@@ -5354,7 +5354,7 @@ install_freebsd_stable() {
 # installing latest version of salt from FreeBSD CURRENT ports repo
 #
     # shellcheck disable=SC2086
-    /usr/local/sbin/pkg install -y sysutils/py-salt || return 1
+    /usr/local/sbin/pkg install -y py37-salt || return 1
 
     return 0
 }


### PR DESCRIPTION
### What does this PR do?
This reverts an earlier change hard-coding "py36-salt". FreeBSD has moved to py37.

### What issues does this PR fix or reference?
The issue I'm reporting right now with this patch. Referring to packages by specific version will cause issues as the Python versions increase. Referring to packages by their port name (origin) will avoid any future version-specific issues and automatically default to installing the latest.

### Previous Behavior
bootstrap doesn't work on FreeBSD

### New Behavior
bootstrap works on FreeBSD
