### PR TITLE
Handle salt 3000

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -603,10 +603,10 @@ elif [ "$ITYPE" = "stable" ]; then
     if [ "$#" -eq 0 ];then
         STABLE_REV="latest"
     else
-        if [ "$(echo "$1" | grep -E '^(latest|1\.6|1\.7|2014\.1|2014\.7|2015\.5|2015\.8|2016\.3|2016\.11|2017\.7|2018\.3|2019\.2)$')" != "" ]; then
+        if [ "$(echo "$1" | grep -E '^(latest|1\.6|1\.7|2014\.1|2014\.7|2015\.5|2015\.8|2016\.3|2016\.11|2017\.7|2018\.3|2019\.2|3000)$')" != "" ]; then
             STABLE_REV="$1"
             shift
-        elif [ "$(echo "$1" | grep -E '^([0-9]*\.[0-9]*\.[0-9]*)$')" != "" ]; then
+        elif [ "$(echo "$1" | grep -E '^(2[0-9]*\.[0-9]*\.[0-9]*|[3-9][0-9]*(\.[0-9]*)?)$')" != "" ]; then
             if [ "$(uname)" = "Darwin" ]; then
               STABLE_REV="$1"
             else
@@ -614,7 +614,7 @@ elif [ "$ITYPE" = "stable" ]; then
             fi
             shift
         else
-            echo "Unknown stable version: $1 (valid: 1.6, 1.7, 2014.1, 2014.7, 2015.5, 2015.8, 2016.3, 2016.11, 2017.7, 2018.3, 2019.2, latest, \$MAJOR.\$MINOR.\$PATCH)"
+            echo "Unknown stable version: $1 (valid: 1.6, 1.7, 2014.1, 2014.7, 2015.5, 2015.8, 2016.3, 2016.11, 2017.7, 2018.3, 2019.2, 3000, latest, \$MAJOR.\$MINOR.\$PATCH until 2019.2, \$MAJOR or \$MAJOR.\$PATCH starting from 3000)"
             exit 1
         fi
     fi


### PR DESCRIPTION
### What does this PR do?

Fix installing salt 3000 specifically (not "latest")
Now that [pin-to-major repo appears to have come back](https://github.com/saltstack/salt/issues/56167) for salt 3000+ it is trivial to fix #1429

### What issues does this PR fix or reference?

 #1429 

### Previous Behavior

`saltbootstrap.sh -XUdfP -x python3 stable 3000` fails to install salt 3000

### New Behavior

now it works