### PR TITLE
Remove Debian 8 from Python 3 supported list

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -362,7 +362,6 @@ this offering, while limited, is as follows:
 
 - CentOS 7
 - Centos 8
-- Debian 8
 - Debian 9
 - Debian 10
 - Fedora (only git installations)


### PR DESCRIPTION
### What does this PR do?
Updates the Readme to remove Debian 8 from Python 3 supported list as confirmed in https://github.com/saltstack/salt-bootstrap/issues/1447 

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-bootstrap/issues/1447
