### PR TITLE
Support for newer KDE Neon

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -301,7 +301,7 @@ in combination with the ``git`` installation method.
 Ubuntu and derivatives
 ~~~~~~~~~~~~~~~~~~~~~~
 
-- KDE neon (based on Ubuntu 16.04)
+- KDE neon (based on Ubuntu 18.04)
 - Linux Mint 17/18
 - Ubuntu 14.04/16.04/18.04 and subsequent non-LTS releases (see below)
 

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1313,6 +1313,7 @@ __ubuntu_derivatives_translation() {
     elementary_os_02_ubuntu_base="12.04"
     neon_16_ubuntu_base="16.04"
     neon_18_ubuntu_base="18.04"
+    neon_20_ubuntu_base="20.04"
 
     # Translate Ubuntu derivatives to their base Ubuntu version
     match=$(echo "$DISTRO_NAME_L" | grep -E ${UBUNTU_DERIVATIVES})

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1312,6 +1312,7 @@ __ubuntu_derivatives_translation() {
     linaro_12_ubuntu_base="12.04"
     elementary_os_02_ubuntu_base="12.04"
     neon_16_ubuntu_base="16.04"
+    neon_18_ubuntu_base="18.04"
 
     # Translate Ubuntu derivatives to their base Ubuntu version
     match=$(echo "$DISTRO_NAME_L" | grep -E ${UBUNTU_DERIVATIVES})


### PR DESCRIPTION
### What does this PR do?
Causes salt to properly support Ubuntu 18.04 based versions

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-bootstrap/issues/1458

### Previous Behavior
Salt would fail to install on KDE Neon based on Ubuntu 18.04

### New Behavior
Salt properly detects KDE Neon based on Ubuntu 18.04

This PR includes both the fix for neon based on 18.04 as well as what I assume will be the change necessary for neon based on 20.04.  I realize that salt doesn't support Ubuntu 20.04.  KDE Neon based on 20.04 isn't actually out yet but since I was changing things I figured I'd try to future proof things.  