### PR TITLE
more accurate deps parsing for FreeBSD git installs

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -5698,8 +5698,11 @@ install_freebsd_git_deps() {
 
     if [ "${_POST_NEON_INSTALL}" -eq $BS_FALSE ]; then
 
-        SALT_DEPENDENCIES=$(/usr/local/sbin/pkg search -R -d py37-salt | grep 'origin:' \
-            | tail -n +2 | awk -F\" '{print $2}')
+        if ! __check_command_exists jq; then
+            /usr/local/sbin/pkg install -y jq || return 1
+        fi
+
+        SALT_DEPENDENCIES=$(/usr/local/sbin/pkg search -R -d --raw-format json py37-salt | jq -r '.deps|keys[]')
         # shellcheck disable=SC2086
         /usr/local/sbin/pkg install -y ${SALT_DEPENDENCIES} python || return 1
 

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -5698,11 +5698,7 @@ install_freebsd_git_deps() {
 
     if [ "${_POST_NEON_INSTALL}" -eq $BS_FALSE ]; then
 
-        if ! __check_command_exists jq; then
-            /usr/local/sbin/pkg install -y jq || return 1
-        fi
-
-        SALT_DEPENDENCIES=$(/usr/local/sbin/pkg search -R -d --raw-format json py37-salt | jq -r '.deps|keys[]')
+        SALT_DEPENDENCIES=$(/usr/local/sbin/pkg rquery %dn py37-salt)
         # shellcheck disable=SC2086
         /usr/local/sbin/pkg install -y ${SALT_DEPENDENCIES} python || return 1
 


### PR DESCRIPTION
### What does this PR do?
This patch updates the dependency list for git-based installs on FreeBSD.

### What issues does this PR fix or reference?
No reported issue, but current functionality using port origins ends up installing unnecessary packages, like multiple versions of Python.

### Previous Behavior
unnecessary packages get installed
https://gist.github.com/cedwards/a81d7a73b678c04f0eefeb3acc962b17

### New Behavior
exact package dependencies get installed
https://gist.github.com/cedwards/6fb2380b21b5a07fd64c0997992b49c1
