### PR TITLE
Reference `master` instead of `develop` branch of Salt

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -80,7 +80,7 @@ Using ``curl`` to install latest development version from GitHub:
 .. code:: console
 
   curl -o bootstrap-salt.sh -L https://bootstrap.saltstack.com
-  sudo sh bootstrap-salt.sh git develop
+  sudo sh bootstrap-salt.sh git master
 
 If you want to install a specific release version (based on the Git tags):
 
@@ -101,7 +101,7 @@ If all you want is to install a ``salt-master`` using latest Git:
 .. code:: console
 
   curl -o bootstrap-salt.sh -L https://bootstrap.saltstack.com
-  sudo sh bootstrap-salt.sh -M -N git develop
+  sudo sh bootstrap-salt.sh -M -N git master
 
 If your host has Internet access only via HTTP proxy:
 
@@ -143,14 +143,14 @@ If you already have Python installed, ``python 2.7``, then it's as easy as:
 .. code:: console
 
   python -m urllib "https://bootstrap.saltstack.com" > bootstrap-salt.sh
-  sudo sh bootstrap-salt.sh git develop
+  sudo sh bootstrap-salt.sh git master
 
 All Python versions should support the following in-line code:
 
 .. code:: console
 
   python -c 'import urllib; print urllib.urlopen("https://bootstrap.saltstack.com").read()' > bootstrap-salt.sh
-  sudo sh bootstrap-salt.sh git develop
+  sudo sh bootstrap-salt.sh git master
 
 
 Install using fetch
@@ -208,11 +208,11 @@ Using ``wget`` to install your distribution's stable packages:
 
   wget -O - https://bootstrap.saltstack.com | sudo sh
 
-Installing the latest develop branch of Salt:
+Installing the latest master branch of Salt:
 
 .. code:: console
 
-  curl -L https://bootstrap.saltstack.com | sudo sh -s -- git develop
+  curl -L https://bootstrap.saltstack.com | sudo sh -s -- git master
 
 
 Supported Operating Systems
@@ -236,7 +236,7 @@ You also may need to disable repository configuration and allow ``pip`` installa
 
 .. code:: console
 
-  sudo sh bootstrap-salt.sh -r -P git develop
+  sudo sh bootstrap-salt.sh -r -P git master
 
 **NOTE**
 


### PR DESCRIPTION
### What does this PR do?
Since the default branch of saltstack/salt was changed from `develop` to
`master`, the documentation of saltstack/salt-bootstrap should follow
this change as well, otherwise users might end up dealing with outdated
installations while expecting to have bleeding-edge code running.

### What issues does this PR fix or reference?
None