### PR TITLE
Use current ius-release links

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -91,6 +91,7 @@ Justin Anderson             justinta               justin.ta@outlook.com
 Justin Findlay              jfindlay               jfindlay@gmail.com
                             kgbsd
 Karl Grzeszczak             karlgrz
+Ken Crowell                 oeuftete               kcrowell@saltstack.com
 Kenneth Wilke               KennethWilke
 Kevin Quinn                 kevinquinnyo           kevin.quinn@totalserversolutions.com
 kiemlicz                    kiemlicz

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1153,7 +1153,7 @@ __install_python() {
         echoinfo "$DISTRO_NAME_L"
         case "$DISTRO_NAME_L" in
             "red_hat"|"centos")
-                __PYTHON_REPO_URL="https://centos${DISTRO_MAJOR_VERSION}.iuscommunity.org/ius-release.rpm"
+                __PYTHON_REPO_URL="https://repo.ius.io/ius-release-el${DISTRO_MAJOR_VERSION}.rpm"
                 ;;
             *)
                 echoerror "Installing a repo to provide a python package is only supported on Redhat/CentOS.


### PR DESCRIPTION
See https://github.com/iusrepo/announce/issues/18.  The old redirects no longer redirect.

### What does this PR do?

Fixes use of a now-removed redirect link for ius-release.

https://centos7.iuscommunity.org/ius-release.rpm:

![image](https://user-images.githubusercontent.com/170730/82842071-ad775b00-9eae-11ea-897f-2617090d5cf7.png)
