### PR TITLE
Typo in WARN message

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1872,7 +1872,7 @@ if [ "$ITYPE" = "git" ]; then
     if [ "$_POST_NEON_INSTALL" -eq $BS_TRUE ]; then
         echo
         echowarn "Post Neon git based installations will always install salt"
-        echowarn "and it's dependencies using pip which will be upgraded to"
+        echowarn "and its dependencies using pip which will be upgraded to"
         echowarn "at least v${_MINIMUM_PIP_VERSION}, and, in case the setuptools version is also"
         echowarn "too old, it will be upgraded to at least v${_MINIMUM_SETUPTOOLS_VERSION}"
         echo


### PR DESCRIPTION
### What does this PR do?

Fixes a tiny typo in the WARN section of output bootstrap shell script. Incorrect use of the word "it's".

### What issues does this PR fix or reference?

N/A