### PR TITLE
give more useful error message on download failure, make curl fail on failure

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -792,11 +792,12 @@ fi
 #----------------------------------------------------------------------------------------------------------------------
 __fetch_url() {
     # shellcheck disable=SC2086
-    curl $_CURL_ARGS -L -s -o "$1" "$2" >/dev/null 2>&1        ||
+    curl $_CURL_ARGS -L -s -f -o "$1" "$2" >/dev/null 2>&1     ||
         wget $_WGET_ARGS -q -O "$1" "$2" >/dev/null 2>&1       ||
             fetch $_FETCH_ARGS -q -o "$1" "$2" >/dev/null 2>&1 ||  # FreeBSD
                 fetch -q -o "$1" "$2" >/dev/null 2>&1          ||  # Pre FreeBSD 10
-                    ftp -o "$1" "$2" >/dev/null 2>&1               # OpenBSD
+                    ftp -o "$1" "$2" >/dev/null 2>&1           ||  # OpenBSD
+                        (echoerror "$2 failed to download to $1"; exit 1)
 }
 
 #---  FUNCTION  -------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
### What does this PR do?
Since we've moved a lot of repos to archive.repo.saltstack.com, the error message is that there was an invalid GPG key by apt-key.  It was skipping right past the curl error instead of stopping at the error.  I also added an error message that is helpful for debugging.

### Previous Behavior
Curl errors were not caught.

### New Behavior
Curl errors are caught and a useful message is displayed on error.
