### PR TITLE
Allow pinning minor 3xxx versions (3000.0, 3001.0, etc)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -412,6 +412,52 @@ jobs:
           bundle exec kitchen destroy py3-git-3001-amazon-2
 
 
+  py3-stable-3001-0-amazon-2:
+    name: Amazon 2 v3001.0 Py3 Stable
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    needs: lint
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Setup Ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 2.6.x
+
+      - name: Install Bundler
+        run: |
+          gem install bundler
+
+      - name: Setup Bundle
+        run: |
+          bundle install --with docker --without opennebula ec2 windows vagrant
+
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+
+      - name: Install Python Dependencies
+        run: |
+          pip install -U pip
+          pip install -r tests/requirements.txt
+
+      - name: Create Test Container
+        run: |
+          bundle exec kitchen create py3-stable-3001-0-amazon-2 || bundle exec kitchen create py3-stable-3001-0-amazon-2
+
+      - name: Test Bootstrap In Test Container
+        run: |
+          bundle exec kitchen verify py3-stable-3001-0-amazon-2
+
+      - name: Destroy Test Container
+        if: always()
+        run: |
+          bundle exec kitchen destroy py3-stable-3001-0-amazon-2
+
+
   py3-git-master-amazon-2:
     name: Amazon 2 Master Py3 Git
     runs-on: ubuntu-latest
@@ -1148,6 +1194,52 @@ jobs:
           bundle exec kitchen destroy py3-git-3001-centos-7
 
 
+  py3-stable-3001-0-centos-7:
+    name: CentOS 7 v3001.0 Py3 Stable
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    needs: lint
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Setup Ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 2.6.x
+
+      - name: Install Bundler
+        run: |
+          gem install bundler
+
+      - name: Setup Bundle
+        run: |
+          bundle install --with docker --without opennebula ec2 windows vagrant
+
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+
+      - name: Install Python Dependencies
+        run: |
+          pip install -U pip
+          pip install -r tests/requirements.txt
+
+      - name: Create Test Container
+        run: |
+          bundle exec kitchen create py3-stable-3001-0-centos-7 || bundle exec kitchen create py3-stable-3001-0-centos-7
+
+      - name: Test Bootstrap In Test Container
+        run: |
+          bundle exec kitchen verify py3-stable-3001-0-centos-7
+
+      - name: Destroy Test Container
+        if: always()
+        run: |
+          bundle exec kitchen destroy py3-stable-3001-0-centos-7
+
+
   py3-git-master-centos-7:
     name: CentOS 7 Master Py3 Git
     runs-on: ubuntu-latest
@@ -1516,6 +1608,52 @@ jobs:
           bundle exec kitchen destroy py3-git-3001-centos-8
 
 
+  py3-stable-3001-0-centos-8:
+    name: CentOS 8 v3001.0 Py3 Stable
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    needs: lint
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Setup Ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 2.6.x
+
+      - name: Install Bundler
+        run: |
+          gem install bundler
+
+      - name: Setup Bundle
+        run: |
+          bundle install --with docker --without opennebula ec2 windows vagrant
+
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+
+      - name: Install Python Dependencies
+        run: |
+          pip install -U pip
+          pip install -r tests/requirements.txt
+
+      - name: Create Test Container
+        run: |
+          bundle exec kitchen create py3-stable-3001-0-centos-8 || bundle exec kitchen create py3-stable-3001-0-centos-8
+
+      - name: Test Bootstrap In Test Container
+        run: |
+          bundle exec kitchen verify py3-stable-3001-0-centos-8
+
+      - name: Destroy Test Container
+        if: always()
+        run: |
+          bundle exec kitchen destroy py3-stable-3001-0-centos-8
+
+
   py3-git-master-centos-8:
     name: CentOS 8 Master Py3 Git
     runs-on: ubuntu-latest
@@ -1882,6 +2020,52 @@ jobs:
         if: always()
         run: |
           bundle exec kitchen destroy py3-git-3001-debian-10
+
+
+  py3-stable-3001-0-debian-10:
+    name: Debian 10 v3001.0 Py3 Stable
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    needs: lint
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Setup Ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 2.6.x
+
+      - name: Install Bundler
+        run: |
+          gem install bundler
+
+      - name: Setup Bundle
+        run: |
+          bundle install --with docker --without opennebula ec2 windows vagrant
+
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+
+      - name: Install Python Dependencies
+        run: |
+          pip install -U pip
+          pip install -r tests/requirements.txt
+
+      - name: Create Test Container
+        run: |
+          bundle exec kitchen create py3-stable-3001-0-debian-10 || bundle exec kitchen create py3-stable-3001-0-debian-10
+
+      - name: Test Bootstrap In Test Container
+        run: |
+          bundle exec kitchen verify py3-stable-3001-0-debian-10
+
+      - name: Destroy Test Container
+        if: always()
+        run: |
+          bundle exec kitchen destroy py3-stable-3001-0-debian-10
 
 
   py3-git-master-debian-10:
@@ -2480,6 +2664,52 @@ jobs:
         if: always()
         run: |
           bundle exec kitchen destroy py3-git-3001-debian-9
+
+
+  py3-stable-3001-0-debian-9:
+    name: Debian 9 v3001.0 Py3 Stable
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    needs: lint
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Setup Ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 2.6.x
+
+      - name: Install Bundler
+        run: |
+          gem install bundler
+
+      - name: Setup Bundle
+        run: |
+          bundle install --with docker --without opennebula ec2 windows vagrant
+
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+
+      - name: Install Python Dependencies
+        run: |
+          pip install -U pip
+          pip install -r tests/requirements.txt
+
+      - name: Create Test Container
+        run: |
+          bundle exec kitchen create py3-stable-3001-0-debian-9 || bundle exec kitchen create py3-stable-3001-0-debian-9
+
+      - name: Test Bootstrap In Test Container
+        run: |
+          bundle exec kitchen verify py3-stable-3001-0-debian-9
+
+      - name: Destroy Test Container
+        if: always()
+        run: |
+          bundle exec kitchen destroy py3-stable-3001-0-debian-9
 
 
   py3-git-master-debian-9:
@@ -3632,6 +3862,52 @@ jobs:
           bundle exec kitchen destroy py3-git-3001-ubuntu-1604
 
 
+  py3-stable-3001-0-ubuntu-1604:
+    name: Ubuntu 16.04 v3001.0 Py3 Stable
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    needs: lint
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Setup Ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 2.6.x
+
+      - name: Install Bundler
+        run: |
+          gem install bundler
+
+      - name: Setup Bundle
+        run: |
+          bundle install --with docker --without opennebula ec2 windows vagrant
+
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+
+      - name: Install Python Dependencies
+        run: |
+          pip install -U pip
+          pip install -r tests/requirements.txt
+
+      - name: Create Test Container
+        run: |
+          bundle exec kitchen create py3-stable-3001-0-ubuntu-1604 || bundle exec kitchen create py3-stable-3001-0-ubuntu-1604
+
+      - name: Test Bootstrap In Test Container
+        run: |
+          bundle exec kitchen verify py3-stable-3001-0-ubuntu-1604
+
+      - name: Destroy Test Container
+        if: always()
+        run: |
+          bundle exec kitchen destroy py3-stable-3001-0-ubuntu-1604
+
+
   py3-git-master-ubuntu-1604:
     name: Ubuntu 16.04 Master Py3 Git
     runs-on: ubuntu-latest
@@ -4092,6 +4368,52 @@ jobs:
           bundle exec kitchen destroy py3-git-3001-ubuntu-1804
 
 
+  py3-stable-3001-0-ubuntu-1804:
+    name: Ubuntu 18.04 v3001.0 Py3 Stable
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    needs: lint
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Setup Ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 2.6.x
+
+      - name: Install Bundler
+        run: |
+          gem install bundler
+
+      - name: Setup Bundle
+        run: |
+          bundle install --with docker --without opennebula ec2 windows vagrant
+
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+
+      - name: Install Python Dependencies
+        run: |
+          pip install -U pip
+          pip install -r tests/requirements.txt
+
+      - name: Create Test Container
+        run: |
+          bundle exec kitchen create py3-stable-3001-0-ubuntu-1804 || bundle exec kitchen create py3-stable-3001-0-ubuntu-1804
+
+      - name: Test Bootstrap In Test Container
+        run: |
+          bundle exec kitchen verify py3-stable-3001-0-ubuntu-1804
+
+      - name: Destroy Test Container
+        if: always()
+        run: |
+          bundle exec kitchen destroy py3-stable-3001-0-ubuntu-1804
+
+
   py3-git-master-ubuntu-1804:
     name: Ubuntu 18.04 Master Py3 Git
     runs-on: ubuntu-latest
@@ -4274,6 +4596,52 @@ jobs:
         if: always()
         run: |
           bundle exec kitchen destroy py3-git-3001-ubuntu-2004
+
+
+  py3-stable-3001-0-ubuntu-2004:
+    name: Ubuntu 20.04 v3001.0 Py3 Stable
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    needs: lint
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Setup Ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 2.6.x
+
+      - name: Install Bundler
+        run: |
+          gem install bundler
+
+      - name: Setup Bundle
+        run: |
+          bundle install --with docker --without opennebula ec2 windows vagrant
+
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+
+      - name: Install Python Dependencies
+        run: |
+          pip install -U pip
+          pip install -r tests/requirements.txt
+
+      - name: Create Test Container
+        run: |
+          bundle exec kitchen create py3-stable-3001-0-ubuntu-2004 || bundle exec kitchen create py3-stable-3001-0-ubuntu-2004
+
+      - name: Test Bootstrap In Test Container
+        run: |
+          bundle exec kitchen verify py3-stable-3001-0-ubuntu-2004
+
+      - name: Destroy Test Container
+        if: always()
+        run: |
+          bundle exec kitchen destroy py3-stable-3001-0-ubuntu-2004
 
 
   py3-git-master-ubuntu-2004:

--- a/.github/workflows/templates/generate.py
+++ b/.github/workflows/templates/generate.py
@@ -70,6 +70,7 @@ SALT_BRANCHES = [
     '2019-2',
     '3000',
     '3001',
+    '3001-0',
     'master',
     'latest'
 ]
@@ -84,6 +85,7 @@ BRANCH_DISPLAY_NAMES = {
     '2019-2': 'v2019.2',
     '3000': 'v3000',
     '3001': 'v3001',
+    '3001-0': 'v3001.0',
     'master': 'Master',
     'latest': 'Latest'
 }
@@ -163,7 +165,7 @@ def generate_test_jobs():
                     continue
 
                 try:
-                    if int(branch) >= 3000 and python_version == 'py2':
+                    if int(branch.split('-')[0]) >= 3000 and python_version == 'py2':
                         # Salt's 300X versions no longer supports Python 2
                         continue
                 except ValueError:
@@ -185,6 +187,10 @@ def generate_test_jobs():
                             continue
 
                     if bootstrap_type == "git":
+                        # .0 versions are a virtual version for pinning to the first point release of a major release, such as 3001, there is no git version.
+                        if branch.endswith('-0'):
+                            continue
+
                         if python_version == "py3":
                             if distro in ("arch", "fedora-32"):
                                 allowed_branches = ["master"]

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -194,17 +194,19 @@ suites:
       - opensuse-15
       - arch
       - ubuntu-2004
-  - name: py3-stable-3000-pin
+  - name: py3-stable-3001-0
     provisioner:
-      salt_version: 3000
-      salt_bootstrap_options: -x python3 -MP stable 3000.0
+      salt_version: 3001
+      salt_bootstrap_options: -x python3 -MP stable 3001.0
     excludes:
       - amazon-1
       - centos-6
       - debian-8
       - opensuse-15
+      - fedora-30
+      - fedora-31
+      - fedora-32
       - arch
-      - ubuntu-2004
   - name: py3-stable-3001
     provisioner:
       salt_version: 3001

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -194,6 +194,17 @@ suites:
       - opensuse-15
       - arch
       - ubuntu-2004
+  - name: py3-stable-3000-pin
+    provisioner:
+      salt_version: 3000
+      salt_bootstrap_options: -x python3 -MP stable 3000.0
+    excludes:
+      - amazon-1
+      - centos-6
+      - debian-8
+      - opensuse-15
+      - arch
+      - ubuntu-2004
   - name: py3-stable-3001
     provisioner:
       salt_version: 3001

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -606,11 +606,15 @@ elif [ "$ITYPE" = "stable" ]; then
         if [ "$(echo "$1" | grep -E '^(latest|1\.6|1\.7|2014\.1|2014\.7|2015\.5|2015\.8|2016\.3|2016\.11|2017\.7|2018\.3|2019\.2|3000|3001)$')" != "" ]; then
             STABLE_REV="$1"
             shift
-        elif [ "$(echo "$1" | grep -E '^(2[0-9]*\.[0-9]*\.[0-9]*|[3-9][0-9]{3}*(\.[0-9]*)?)$')" != "" ]; then
-            if [ "$(uname)" = "Darwin" ]; then
-              STABLE_REV="$1"
+        elif [ "$(echo "$1" | grep -E '^(2[0-9]*\.[0-9]*\.[0-9]*|[3-9][0-9]{3}(\.[0-9]*)?)$')" != "" ]; then
+            # Handle the 3xxx.0 version as 3xxx archive (pin to minor) and strip the fake ".0" suffix
+            if [ "$(echo "$1" | grep -E '[3-9][0-9]{3}\.0$')" != "" ]; then
+                STABLE_REV=$(echo "$1" | sed -e 's/\.0$//')
             else
-              STABLE_REV="archive/$1"
+                STABLE_REV="$1"
+            fi
+            if [ "$(uname)" != "Darwin" ]; then
+                STABLE_REV="archive/$STABLE_REV"
             fi
             shift
         else

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -609,11 +609,7 @@ elif [ "$ITYPE" = "stable" ]; then
             shift
         elif [ "$(echo "$1" | grep -E '^(2[0-9]*\.[0-9]*\.[0-9]*|[3-9][0-9]{3}(\.[0-9]*)?)$')" != "" ]; then
             # Handle the 3xxx.0 version as 3xxx archive (pin to minor) and strip the fake ".0" suffix
-            if [ "$(echo "$1" | grep -E '[3-9][0-9]{3}\.0$')" != "" ]; then
-                STABLE_REV=$(echo "$1" | sed -e 's/\.0$//')
-            else
-                STABLE_REV="$1"
-            fi
+            STABLE_REV=$(echo "$1" | sed -E 's/^([3-9][0-9]{3})\.0$/\1/')
             if [ "$(uname)" != "Darwin" ]; then
                 STABLE_REV="archive/$STABLE_REV"
             fi

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -296,6 +296,7 @@ __usage() {
                           for packages available at repo.saltstack.com
     - stable [version]    Install a specific version. Only supported for
                           packages available at repo.saltstack.com
+                          To pin a 3xxx minor version, specify it as 3xxx.0
     - testing             RHEL-family specific: configure EPEL testing repo
     - git                 Install from the head of the master branch
     - git [ref]           Install from any git ref (such as a branch, tag, or

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,6 +31,8 @@ def target_python_version():
 @pytest.fixture(scope='session')
 def target_salt_version():
     target_salt = os.environ["KITCHEN_SUITE"].split("-", 2)[-1].replace("-", ".")
+    if target_salt.endswith(".0") and float(target_salt) >= 3000:
+        target_salt = ".".join(target_salt.split(".")[:-1])
     if target_salt in ("latest", "master"):
         pytest.skip("Don't have a specific salt version to test against")
     return target_salt


### PR DESCRIPTION
### What does this PR do?

Allow pinning minor 3xxx versions. This is enabled by specifying a fake `.0` version suffix:

`salt-bootstrap.sh -x python3 stable 3001.0`
  
### What issues does this PR fix or reference?

https://github.com/saltstack/salt-bootstrap/issues/1436

Previously, it was impossible to have reproducible bootstrap process - a major 3xxx version install could mean 3xxx, 3xxx.1, 3xxx.2, etc. depending on the time of the install.

Also addressed the following comment: https://github.com/saltstack/salt-bootstrap/commit/a321d51c385db225ddc08e42852fc59cba7b1992#r37765195

Note to reviewers: not sure if I added the test properly. Is `.kitchen.yml` the right place?