### PR TITLE
feat: adds support for linuxmint_20_ubuntu_base

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1311,6 +1311,7 @@ __ubuntu_derivatives_translation() {
     linuxmint_17_ubuntu_base="14.04"
     linuxmint_18_ubuntu_base="16.04"
     linuxmint_19_ubuntu_base="18.04"
+    linuxmint_20_ubuntu_base="20.04"
     linaro_12_ubuntu_base="12.04"
     elementary_os_02_ubuntu_base="12.04"
     neon_16_ubuntu_base="16.04"


### PR DESCRIPTION
### What does this PR do?
Adds support for Linux Mint 20
### What issues does this PR fix or reference?
#1501 
### Previous Behavior
Installation failed and produced the following:
```
 *  INFO: Running version: 2020.06.23
 *  INFO: Executed by: /bin/sh
 *  INFO: Command line: './bootstrap-salt.sh '

 *  INFO: System Information:
 *  INFO:   CPU:          GenuineIntel
 *  INFO:   CPU Arch:     x86_64
 *  INFO:   OS Name:      Linux
 *  INFO:   OS Version:   5.4.0-51-generic
 *  INFO:   Distribution: Linuxmint 20

./salt.sh: 1: eval: linuxmint_20_ubuntu_base: parameter not set
```

### New Behavior
Installation succeeds (Redacted logs below as proof):


```
sudo ./salt.sh
 *  INFO: Running version: 2020.06.23
 *  INFO: Executed by: /bin/sh
 *  INFO: Command line: './salt.sh '

 *  INFO: System Information:
 *  INFO:   CPU:          GenuineIntel
 *  INFO:   CPU Arch:     x86_64
 *  INFO:   OS Name:      Linux
 *  INFO:   OS Version:   5.4.0-51-generic
 *  INFO:   Distribution: Linuxmint 20

 *  INFO: Installing minion
 *  INFO: Found function install_ubuntu_stable_deps
 *  INFO: Found function config_salt
 *  INFO: Found function preseed_master
 *  INFO: Found function install_ubuntu_stable
 *  INFO: Found function install_ubuntu_stable_post
 *  INFO: Found function install_ubuntu_restart_daemons
 *  INFO: Found function daemons_running
 *  INFO: Found function install_ubuntu_check_services
 *  INFO: Running install_ubuntu_stable_deps()
Hit:1 http://mirrors.evowise.com/linuxmint/packages ulyana Release
Get:2 http://security.ubuntu.com/ubuntu focal-security InRelease [107 kB]
Hit:3 http://archive.ubuntu.com/ubuntu focal InRelease
Hit:4 http://archive.canonical.com/ubuntu focal InRelease
Get:5 http://archive.ubuntu.com/ubuntu focal-updates InRelease [111 kB]
Get:6 http://archive.ubuntu.com/ubuntu focal-backports InRelease [98.3 kB]
Fetched 317 kB in 2s (150 kB/s)
Reading package lists...
Reading package lists...
Building dependency tree...
Reading state information...
gnupg is already the newest version (2.2.19-3ubuntu2).
wget is already the newest version (1.20.3-1ubuntu1).
ca-certificates is already the newest version (20190110ubuntu1.1).
The following NEW packages will be installed:
  apt-transport-https
0 upgraded, 1 newly installed, 0 to remove and 0 not upgraded.
Need to get 1,708 B of archives.
After this operation, 160 kB of additional disk space will be used.
Get:1 http://archive.ubuntu.com/ubuntu focal-updates/universe amd64 apt-transport-https all 2.0.2ubuntu0.1 [1,708 B]
Fetched 1,708 B in 0s (5,426 B/s)
                                 Selecting previously unselected package apt-transport-https.
(Reading database ... 338549 files and directories currently installed.)
Preparing to unpack .../apt-transport-https_2.0.2ubuntu0.1_all.deb ...
Unpacking apt-transport-https (2.0.2ubuntu0.1) ...
Setting up apt-transport-https (2.0.2ubuntu0.1) ...
Warning: apt-key output should not be parsed (stdout is not a terminal)
OK
Hit:1 http://mirrors.evowise.com/linuxmint/packages ulyana Release
Hit:2 http://archive.canonical.com/ubuntu focal InRelease
Get:3 http://security.ubuntu.com/ubuntu focal-security InRelease [107 kB]
Get:4 https://repo.saltstack.com/py3/ubuntu/20.04/amd64/latest focal InRelease [2,119 B]
Hit:5 http://archive.ubuntu.com/ubuntu focal InRelease
Get:6 http://archive.ubuntu.com/ubuntu focal-updates InRelease [111 kB]
Get:7 https://repo.saltstack.com/py3/ubuntu/20.04/amd64/latest focal/main amd64 Packages [2,310 B]
Get:8 http://archive.ubuntu.com/ubuntu focal-backports InRelease [98.3 kB]
Fetched 321 kB in 2s (201 kB/s)
Reading package lists...
Hit:1 http://mirrors.evowise.com/linuxmint/packages ulyana Release
Hit:2 https://repo.saltstack.com/py3/ubuntu/20.04/amd64/latest focal InRelease
Get:3 http://security.ubuntu.com/ubuntu focal-security InRelease [107 kB]
Hit:4 http://archive.canonical.com/ubuntu focal InRelease
Hit:5 http://archive.ubuntu.com/ubuntu focal InRelease
Get:6 http://archive.ubuntu.com/ubuntu focal-updates InRelease [111 kB]
Get:7 http://archive.ubuntu.com/ubuntu focal-backports InRelease [98.3 kB]
Fetched 317 kB in 2s (174 kB/s)
Reading package lists...
Reading package lists...
Building dependency tree...
Reading state information...
pciutils is already the newest version (1:3.6.4-1).
procps is already the newest version (2:3.3.16-1ubuntu2).
python3-requests is already the newest version (2.22.0-2ubuntu1).
python3-yaml is already the newest version (5.3.1-1).
python3-apt is already the newest version (2.0.0ubuntu0.20.04.1).
0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
 *  INFO: Running install_ubuntu_stable()
Reading package lists...
Building dependency tree...
Reading state information...
The following additional packages will be installed:
  debconf-utils python3-croniter python3-gnupg python3-jinja2 python3-msgpack
  python3-pycryptodome python3-zmq salt-common
Suggested packages:
  python-jinja2-doc python3-twisted python3-augeas
The following NEW packages will be installed:
  debconf-utils python3-croniter python3-gnupg python3-jinja2 python3-msgpack
  python3-pycryptodome python3-zmq salt-common salt-minion
0 upgraded, 9 newly installed, 0 to remove and 0 not upgraded.
Need to get 11.6 MB of archives.
After this operation, 50.3 MB of additional disk space will be used.
Get:1 https://repo.saltstack.com/py3/ubuntu/20.04/amd64/latest focal/main amd64 salt-common all 3001.1+ds-1 [5,873 kB]
Get:2 http://archive.ubuntu.com/ubuntu focal/universe amd64 debconf-utils all 1.5.73 [57.2 kB]
Get:3 https://repo.saltstack.com/py3/ubuntu/20.04/amd64/latest focal/main amd64 salt-minion all 3001.1+ds-1 [28.3 kB]
Get:4 http://archive.ubuntu.com/ubuntu focal/main amd64 python3-croniter all 0.3.29-2ubuntu1 [16.5 kB]
Get:5 http://archive.ubuntu.com/ubuntu focal/universe amd64 python3-gnupg all 0.4.5-2 [18.3 kB]
Get:6 http://archive.ubuntu.com/ubuntu focal/main amd64 python3-jinja2 all 2.10.1-2 [95.5 kB]
Get:7 http://archive.ubuntu.com/ubuntu focal/main amd64 python3-msgpack amd64 0.6.2-1 [73.5 kB]
Get:8 http://archive.ubuntu.com/ubuntu focal/main amd64 python3-pycryptodome amd64 3.6.1-2build4 [5,102 kB]
Get:9 http://archive.ubuntu.com/ubuntu focal/universe amd64 python3-zmq amd64 18.1.1-3 [294 kB]
Fetched 11.6 MB in 2s (6,310 kB/s)
                                  Selecting previously unselected package debconf-utils.
(Reading database ... 338553 files and directories currently installed.)
Preparing to unpack .../0-debconf-utils_1.5.73_all.deb ...
Unpacking debconf-utils (1.5.73) ...
Selecting previously unselected package python3-croniter.
Preparing to unpack .../1-python3-croniter_0.3.29-2ubuntu1_all.deb ...
Unpacking python3-croniter (0.3.29-2ubuntu1) ...
Selecting previously unselected package python3-gnupg.
Preparing to unpack .../2-python3-gnupg_0.4.5-2_all.deb ...
Unpacking python3-gnupg (0.4.5-2) ...
Selecting previously unselected package python3-jinja2.
Preparing to unpack .../3-python3-jinja2_2.10.1-2_all.deb ...
Unpacking python3-jinja2 (2.10.1-2) ...
Selecting previously unselected package python3-msgpack.
Preparing to unpack .../4-python3-msgpack_0.6.2-1_amd64.deb ...
Unpacking python3-msgpack (0.6.2-1) ...
Selecting previously unselected package python3-pycryptodome.
Preparing to unpack .../5-python3-pycryptodome_3.6.1-2build4_amd64.deb ...
Unpacking python3-pycryptodome (3.6.1-2build4) ...
Selecting previously unselected package python3-zmq.
Preparing to unpack .../6-python3-zmq_18.1.1-3_amd64.deb ...
Unpacking python3-zmq (18.1.1-3) ...
Selecting previously unselected package salt-common.
Preparing to unpack .../7-salt-common_3001.1+ds-1_all.deb ...
Unpacking salt-common (3001.1+ds-1) ...
Selecting previously unselected package salt-minion.
Preparing to unpack .../8-salt-minion_3001.1+ds-1_all.deb ...
Unpacking salt-minion (3001.1+ds-1) ...
Setting up python3-gnupg (0.4.5-2) ...
Setting up python3-pycryptodome (3.6.1-2build4) ...
/usr/lib/python3/dist-packages/Cryptodome/SelfTest/Random/test_random.py:103: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if sys.version_info[0] is 3:
Setting up python3-croniter (0.3.29-2ubuntu1) ...
Setting up python3-jinja2 (2.10.1-2) ...
Setting up python3-zmq (18.1.1-3) ...
Setting up debconf-utils (1.5.73) ...
Setting up python3-msgpack (0.6.2-1) ...
Setting up salt-common (3001.1+ds-1) ...
Setting up salt-minion (3001.1+ds-1) ...
Created symlink /etc/systemd/system/multi-user.target.wants/salt-minion.service → /lib/systemd/system/salt-minion.service.
Processing triggers for man-db (2.9.1-1) ...
Processing triggers for systemd (245.4-4ubuntu3.2) ...
 *  INFO: Running install_ubuntu_stable_post()
 *  INFO: Running install_ubuntu_check_services()
 *  INFO: Running install_ubuntu_restart_daemons()
 *  INFO: Running daemons_running()
 *  INFO: Salt installed!
```