### PR TITLE
Debian 11 (bullseye/testing) support using Debian 10 packages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2620,6 +2620,190 @@ jobs:
           bundle exec kitchen destroy latest-debian-10
 
 
+  py3-stable-3002-debian-11:
+    name: Debian 11 v3002 Py3 Stable
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    needs: lint
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Setup Ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 2.6.x
+
+      - name: Install Bundler
+        run: |
+          gem install bundler
+
+      - name: Setup Bundle
+        run: |
+          bundle install --with docker --without opennebula ec2 windows vagrant
+
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+
+      - name: Install Python Dependencies
+        run: |
+          pip install -U pip
+          pip install -r tests/requirements.txt
+
+      - name: Create Test Container
+        run: |
+          bundle exec kitchen create py3-stable-3002-debian-11 || bundle exec kitchen create py3-stable-3002-debian-11
+
+      - name: Test Bootstrap In Test Container
+        run: |
+          bundle exec kitchen verify py3-stable-3002-debian-11
+
+      - name: Destroy Test Container
+        if: always()
+        run: |
+          bundle exec kitchen destroy py3-stable-3002-debian-11
+
+
+  py3-git-3002-debian-11:
+    name: Debian 11 v3002 Py3 Git
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    needs: lint
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Setup Ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 2.6.x
+
+      - name: Install Bundler
+        run: |
+          gem install bundler
+
+      - name: Setup Bundle
+        run: |
+          bundle install --with docker --without opennebula ec2 windows vagrant
+
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+
+      - name: Install Python Dependencies
+        run: |
+          pip install -U pip
+          pip install -r tests/requirements.txt
+
+      - name: Create Test Container
+        run: |
+          bundle exec kitchen create py3-git-3002-debian-11 || bundle exec kitchen create py3-git-3002-debian-11
+
+      - name: Test Bootstrap In Test Container
+        run: |
+          bundle exec kitchen verify py3-git-3002-debian-11
+
+      - name: Destroy Test Container
+        if: always()
+        run: |
+          bundle exec kitchen destroy py3-git-3002-debian-11
+
+
+  py3-git-master-debian-11:
+    name: Debian 11 Master Py3 Git
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    needs: lint
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Setup Ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 2.6.x
+
+      - name: Install Bundler
+        run: |
+          gem install bundler
+
+      - name: Setup Bundle
+        run: |
+          bundle install --with docker --without opennebula ec2 windows vagrant
+
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+
+      - name: Install Python Dependencies
+        run: |
+          pip install -U pip
+          pip install -r tests/requirements.txt
+
+      - name: Create Test Container
+        run: |
+          bundle exec kitchen create py3-git-master-debian-11 || bundle exec kitchen create py3-git-master-debian-11
+
+      - name: Test Bootstrap In Test Container
+        run: |
+          bundle exec kitchen verify py3-git-master-debian-11
+
+      - name: Destroy Test Container
+        if: always()
+        run: |
+          bundle exec kitchen destroy py3-git-master-debian-11
+
+
+  latest-debian-11:
+    name: Debian 11 Latest packaged release
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    needs: lint
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Setup Ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 2.6.x
+
+      - name: Install Bundler
+        run: |
+          gem install bundler
+
+      - name: Setup Bundle
+        run: |
+          bundle install --with docker --without opennebula ec2 windows vagrant
+
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+
+      - name: Install Python Dependencies
+        run: |
+          pip install -U pip
+          pip install -r tests/requirements.txt
+
+      - name: Create Test Container
+        run: |
+          bundle exec kitchen create latest-debian-11 || bundle exec kitchen create latest-debian-11
+
+      - name: Test Bootstrap In Test Container
+        run: |
+          bundle exec kitchen verify latest-debian-11
+
+      - name: Destroy Test Container
+        if: always()
+        run: |
+          bundle exec kitchen destroy latest-debian-11
+
+
   py2-stable-2019-2-debian-9:
     name: Debian 9 v2019.2 Py2 Stable
     runs-on: ubuntu-latest

--- a/.github/workflows/templates/generate.py
+++ b/.github/workflows/templates/generate.py
@@ -12,6 +12,7 @@ LINUX_DISTROS = [
     "centos-7",
     "centos-8",
     "debian-10",
+    "debian-11",
     "debian-9",
     "fedora-32",
     "fedora-33",
@@ -30,6 +31,7 @@ STABLE_DISTROS = [
     "centos-7",
     "centos-8",
     "debian-10",
+    "debian-11",
     "debian-9",
     "fedora-32",
     "fedora-33",
@@ -43,6 +45,7 @@ STABLE_DISTROS = [
 PY2_BLACKLIST = [
     "centos-8",
     "debian-10",
+    "debian-11",
     "fedora-32",
     "fedora-33",
     "gentoo",
@@ -56,13 +59,27 @@ PY3_BLACKLIST = [
 ]
 
 BLACKLIST_2019 = [
+    "debian-11",
     "fedora-33",
     "ubuntu-2004",
 ]
 
 BLACKLIST_3000 = [
+    "debian-11",
     "fedora-33",
     "ubuntu-2004",
+]
+
+BLACKLIST_3001 = [
+    "debian-11",
+]
+
+BLACKLIST_3001_0 = [
+    "debian-11",
+]
+
+BLACKLIST_3002_0 = [
+    "debian-11",
 ]
 
 SALT_BRANCHES = [
@@ -100,6 +117,7 @@ DISTRO_DISPLAY_NAMES = {
     "centos-7": "CentOS 7",
     "centos-8": "CentOS 8",
     "debian-10": "Debian 10",
+    "debian-11": "Debian 11",
     "debian-9": "Debian 9",
     "fedora-32": "Fedora 32",
     "fedora-33": "Fedora 33",
@@ -219,6 +237,15 @@ def generate_test_jobs():
                         continue
 
                     if branch == "3000" and distro in BLACKLIST_3000:
+                        continue
+
+                    if branch == "3001" and distro in BLACKLIST_3001:
+                        continue
+
+                    if branch == "3001-0" and distro in BLACKLIST_3001_0:
+                        continue
+
+                    if branch == "3002-0" and distro in BLACKLIST_3002_0:
                         continue
 
                     if python_version == "py2" and distro in PY2_BLACKLIST:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -63,6 +63,10 @@ platforms:
   - name: debian-10
     driver_config:
       run_command: /lib/systemd/systemd
+  - name: debian-11
+    driver_config:
+      image: debian:bullseye
+      run_command: /lib/systemd/systemd
   - name: fedora-32
     driver_config:
       image: fedora:32
@@ -115,18 +119,24 @@ suites:
     provisioner:
       salt_version: 2019.2
     excludes:
+      - debian-10
+      - debian-11
       - gentoo
       - gentoo-systemd
   - name: py2-git-3000
     provisioner:
       salt_version: 3000
     excludes:
+      - debian-10
+      - debian-11
       - gentoo
       - gentoo-systemd
   - name: py2-git-master
     provisioner:
       salt_version: master
     excludes:
+      - debian-10
+      - debian-11
       - gentoo
       - gentoo-systemd
   - name: py2-stable-2019-2
@@ -138,6 +148,8 @@ suites:
       - opensuse-15
       - fedora-32
       - fedora-33
+      - debian-10
+      - debian-11
       - gentoo
       - gentoo-systemd
       - ubuntu-2004
@@ -148,6 +160,8 @@ suites:
     excludes:
       - arch
       - opensuse-15
+      - debian-10
+      - debian-11
       - fedora-32
       - fedora-33
       - gentoo
@@ -160,6 +174,7 @@ suites:
       salt_bootstrap_options: -x python3 -MPfq git %s
     excludes:
       - amazon-1
+      - debian-11
       - ubuntu-2004
   - name: py3-git-2019-2
     provisioner:
@@ -167,6 +182,7 @@ suites:
       salt_bootstrap_options: -x python3 -MPfq git %s
     excludes:
       - amazon-1
+      - debian-11
       - ubuntu-2004
   - name: py3-git-3001
     provisioner:
@@ -186,6 +202,7 @@ suites:
       salt_bootstrap_options: -x python3 -MP stable %s
     excludes:
       - amazon-1
+      - debian-11
       - opensuse-15
       - arch
       - ubuntu-2004
@@ -195,6 +212,7 @@ suites:
       salt_bootstrap_options: -x python3 -MP stable %s
     excludes:
       - amazon-1
+      - debian-11
       - opensuse-15
       - arch
       - ubuntu-2004
@@ -205,6 +223,7 @@ suites:
     excludes:
       - amazon-1
       - opensuse-15
+      - debian-11
       - fedora-32
       - fedora-33
       - arch
@@ -214,6 +233,7 @@ suites:
       salt_bootstrap_options: -x python3 -MP stable %s
     excludes:
       - amazon-1
+      - debian-11
       - opensuse-15
       - arch
   - name: py3-stable-3002-0
@@ -223,6 +243,7 @@ suites:
     excludes:
       - amazon-1
       - opensuse-15
+      - debian-11
       - fedora-32
       - fedora-33
       - arch

--- a/README.rst
+++ b/README.rst
@@ -300,9 +300,9 @@ repositories are not provided on `SaltStack's Debian repository`_ for Debian tes
 However, the bootstrap script will attempt to install the packages for the current stable
 version of Debian.
 
-For example, when installing Salt on Debian 10 (Buster), the bootstrap script will setup the
-repository for Debian 9 (Stretch) from `SaltStack's Debian repository`_ and install the
-Debian 9 packages.
+For example, when installing Salt on Debian 11 (Bullseye), the bootstrap script will setup the
+repository for Debian 10 (Buster) from `SaltStack's Debian repository`_ and install the
+Debian 10 packages.
 
 
 Red Hat family

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -900,6 +900,8 @@ __derive_debian_numeric_version() {
             NUMERIC_VERSION=$(__parse_version_string "9.0")
         elif [ "$INPUT_VERSION" = "buster/sid" ]; then
             NUMERIC_VERSION=$(__parse_version_string "10.0")
+        elif [ "$INPUT_VERSION" = "bullseye/sid" ]; then
+            NUMERIC_VERSION=$(__parse_version_string "11.0")
         else
             echowarn "Unable to parse the Debian Version (codename: '$INPUT_VERSION')"
         fi
@@ -1554,6 +1556,9 @@ __debian_codename_translation() {
             ;;
         "10")
             DISTRO_CODENAME="buster"
+            ;;
+        "11")
+            DISTRO_CODENAME="bullseye"
             ;;
         *)
             DISTRO_CODENAME="jessie"
@@ -3339,8 +3344,17 @@ install_ubuntu_check_services() {
 #   Debian Install Functions
 #
 __install_saltstack_debian_repository() {
-    DEBIAN_RELEASE="$DISTRO_MAJOR_VERSION"
-    DEBIAN_CODENAME="$DISTRO_CODENAME"
+    if [ "$DISTRO_MAJOR_VERSION" -eq 11 ]; then
+        # Packages for Debian 11 at repo.saltstack.com are not yet available
+        # Set up repository for Debian 10 for Debian 11 for now until support
+        # is available at repo.saltstack.com for Debian 11.
+        echowarn "Debian 11 distribution detected, but stable packages requested. Trying packages from Debian 10. You may experience problems."
+        DEBIAN_RELEASE="10"
+        DEBIAN_CODENAME="buster"
+    else
+        DEBIAN_RELEASE="$DISTRO_MAJOR_VERSION"
+        DEBIAN_CODENAME="$DISTRO_CODENAME"
+    fi
 
     __PY_VERSION_REPO="apt"
     if [ -n "$_PY_EXE" ] && [ "$_PY_MAJOR_VERSION" -eq 3 ]; then


### PR DESCRIPTION
### What does this PR do?
Adds support for Debian 11 (testing) using Debian 10 repository packages

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-bootstrap/issues/1513

### Previous Behavior
Script will fail to run because it reads the version as 'Debian 1', and will consider it end-of-life

### New Behavior
Install as if the system is Debian 10

Thanks to @rallytime for their Debian 10 introductory PR, which was used as a base for this PR. 
https://github.com/saltstack/salt-bootstrap/pull/1113