### PR TITLE
Fix bootstrap on Gentoo.

### DIFF
--- a/.github/workflows/main-branch-only.yml
+++ b/.github/workflows/main-branch-only.yml
@@ -11,7 +11,7 @@ jobs:
   py3-stable-2019-2-gentoo:
     name: Gentoo v2019.2 Py3 Stable
     runs-on: ubuntu-latest
-    timeout-minutes: 70
+    timeout-minutes: 90
 
 
 
@@ -57,7 +57,7 @@ jobs:
   py3-git-2019-2-gentoo:
     name: Gentoo v2019.2 Py3 Git
     runs-on: ubuntu-latest
-    timeout-minutes: 70
+    timeout-minutes: 90
 
 
 
@@ -103,7 +103,7 @@ jobs:
   py3-stable-3000-gentoo:
     name: Gentoo v3000 Py3 Stable
     runs-on: ubuntu-latest
-    timeout-minutes: 70
+    timeout-minutes: 90
 
 
 
@@ -149,7 +149,7 @@ jobs:
   py3-git-3000-gentoo:
     name: Gentoo v3000 Py3 Git
     runs-on: ubuntu-latest
-    timeout-minutes: 70
+    timeout-minutes: 90
 
 
 
@@ -195,7 +195,7 @@ jobs:
   py3-stable-3001-gentoo:
     name: Gentoo v3001 Py3 Stable
     runs-on: ubuntu-latest
-    timeout-minutes: 70
+    timeout-minutes: 90
 
 
 
@@ -241,7 +241,7 @@ jobs:
   py3-git-3001-gentoo:
     name: Gentoo v3001 Py3 Git
     runs-on: ubuntu-latest
-    timeout-minutes: 70
+    timeout-minutes: 90
 
 
 
@@ -287,7 +287,7 @@ jobs:
   py3-stable-3002-gentoo:
     name: Gentoo v3002 Py3 Stable
     runs-on: ubuntu-latest
-    timeout-minutes: 70
+    timeout-minutes: 90
 
 
 
@@ -333,7 +333,7 @@ jobs:
   py3-git-3002-gentoo:
     name: Gentoo v3002 Py3 Git
     runs-on: ubuntu-latest
-    timeout-minutes: 70
+    timeout-minutes: 90
 
 
 
@@ -379,7 +379,7 @@ jobs:
   py3-git-master-gentoo:
     name: Gentoo Master Py3 Git
     runs-on: ubuntu-latest
-    timeout-minutes: 70
+    timeout-minutes: 90
 
 
 
@@ -425,7 +425,7 @@ jobs:
   latest-gentoo:
     name: Gentoo Latest packaged release
     runs-on: ubuntu-latest
-    timeout-minutes: 70
+    timeout-minutes: 90
 
 
 
@@ -471,7 +471,7 @@ jobs:
   py3-stable-2019-2-gentoo-systemd:
     name: Gentoo (systemd) v2019.2 Py3 Stable
     runs-on: ubuntu-latest
-    timeout-minutes: 70
+    timeout-minutes: 90
 
 
 
@@ -517,7 +517,7 @@ jobs:
   py3-git-2019-2-gentoo-systemd:
     name: Gentoo (systemd) v2019.2 Py3 Git
     runs-on: ubuntu-latest
-    timeout-minutes: 70
+    timeout-minutes: 90
 
 
 
@@ -563,7 +563,7 @@ jobs:
   py3-stable-3000-gentoo-systemd:
     name: Gentoo (systemd) v3000 Py3 Stable
     runs-on: ubuntu-latest
-    timeout-minutes: 70
+    timeout-minutes: 90
 
 
 
@@ -609,7 +609,7 @@ jobs:
   py3-git-3000-gentoo-systemd:
     name: Gentoo (systemd) v3000 Py3 Git
     runs-on: ubuntu-latest
-    timeout-minutes: 70
+    timeout-minutes: 90
 
 
 
@@ -655,7 +655,7 @@ jobs:
   py3-stable-3001-gentoo-systemd:
     name: Gentoo (systemd) v3001 Py3 Stable
     runs-on: ubuntu-latest
-    timeout-minutes: 70
+    timeout-minutes: 90
 
 
 
@@ -701,7 +701,7 @@ jobs:
   py3-git-3001-gentoo-systemd:
     name: Gentoo (systemd) v3001 Py3 Git
     runs-on: ubuntu-latest
-    timeout-minutes: 70
+    timeout-minutes: 90
 
 
 
@@ -747,7 +747,7 @@ jobs:
   py3-stable-3002-gentoo-systemd:
     name: Gentoo (systemd) v3002 Py3 Stable
     runs-on: ubuntu-latest
-    timeout-minutes: 70
+    timeout-minutes: 90
 
 
 
@@ -793,7 +793,7 @@ jobs:
   py3-git-3002-gentoo-systemd:
     name: Gentoo (systemd) v3002 Py3 Git
     runs-on: ubuntu-latest
-    timeout-minutes: 70
+    timeout-minutes: 90
 
 
 
@@ -839,7 +839,7 @@ jobs:
   py3-git-master-gentoo-systemd:
     name: Gentoo (systemd) Master Py3 Git
     runs-on: ubuntu-latest
-    timeout-minutes: 70
+    timeout-minutes: 90
 
 
 
@@ -885,7 +885,7 @@ jobs:
   latest-gentoo-systemd:
     name: Gentoo (systemd) Latest packaged release
     runs-on: ubuntu-latest
-    timeout-minutes: 70
+    timeout-minutes: 90
 
 
 

--- a/.github/workflows/main-branch-only.yml
+++ b/.github/workflows/main-branch-only.yml
@@ -11,7 +11,7 @@ jobs:
   py3-stable-2019-2-gentoo:
     name: Gentoo v2019.2 Py3 Stable
     runs-on: ubuntu-latest
-    timeout-minutes: 50
+    timeout-minutes: 70
 
 
 
@@ -57,7 +57,7 @@ jobs:
   py3-git-2019-2-gentoo:
     name: Gentoo v2019.2 Py3 Git
     runs-on: ubuntu-latest
-    timeout-minutes: 50
+    timeout-minutes: 70
 
 
 
@@ -103,7 +103,7 @@ jobs:
   py3-stable-3000-gentoo:
     name: Gentoo v3000 Py3 Stable
     runs-on: ubuntu-latest
-    timeout-minutes: 50
+    timeout-minutes: 70
 
 
 
@@ -149,7 +149,7 @@ jobs:
   py3-git-3000-gentoo:
     name: Gentoo v3000 Py3 Git
     runs-on: ubuntu-latest
-    timeout-minutes: 50
+    timeout-minutes: 70
 
 
 
@@ -195,7 +195,7 @@ jobs:
   py3-stable-3001-gentoo:
     name: Gentoo v3001 Py3 Stable
     runs-on: ubuntu-latest
-    timeout-minutes: 50
+    timeout-minutes: 70
 
 
 
@@ -241,7 +241,7 @@ jobs:
   py3-git-3001-gentoo:
     name: Gentoo v3001 Py3 Git
     runs-on: ubuntu-latest
-    timeout-minutes: 50
+    timeout-minutes: 70
 
 
 
@@ -284,56 +284,10 @@ jobs:
           bundle exec kitchen destroy py3-git-3001-gentoo
 
 
-  py3-stable-3001-0-gentoo:
-    name: Gentoo v3001.0 Py3 Stable
-    runs-on: ubuntu-latest
-    timeout-minutes: 50
-
-
-
-    steps:
-      - uses: actions/checkout@v1
-      - name: Setup Ruby
-        uses: actions/setup-ruby@v1
-        with:
-          ruby-version: 2.6.x
-
-      - name: Install Bundler
-        run: |
-          gem install bundler
-
-      - name: Setup Bundle
-        run: |
-          bundle install --with docker --without opennebula ec2 windows vagrant
-
-      - name: Set up Python 3.7
-        uses: actions/setup-python@v1
-        with:
-          python-version: 3.7
-
-      - name: Install Python Dependencies
-        run: |
-          pip install -U pip
-          pip install -r tests/requirements.txt
-
-      - name: Create Test Container
-        run: |
-          bundle exec kitchen create py3-stable-3001-0-gentoo || bundle exec kitchen create py3-stable-3001-0-gentoo
-
-      - name: Test Bootstrap In Test Container
-        run: |
-          bundle exec kitchen verify py3-stable-3001-0-gentoo
-
-      - name: Destroy Test Container
-        if: always()
-        run: |
-          bundle exec kitchen destroy py3-stable-3001-0-gentoo
-
-
   py3-stable-3002-gentoo:
     name: Gentoo v3002 Py3 Stable
     runs-on: ubuntu-latest
-    timeout-minutes: 50
+    timeout-minutes: 70
 
 
 
@@ -379,7 +333,7 @@ jobs:
   py3-git-3002-gentoo:
     name: Gentoo v3002 Py3 Git
     runs-on: ubuntu-latest
-    timeout-minutes: 50
+    timeout-minutes: 70
 
 
 
@@ -422,56 +376,10 @@ jobs:
           bundle exec kitchen destroy py3-git-3002-gentoo
 
 
-  py3-stable-3002-0-gentoo:
-    name: Gentoo v3002.0 Py3 Stable
-    runs-on: ubuntu-latest
-    timeout-minutes: 50
-
-
-
-    steps:
-      - uses: actions/checkout@v1
-      - name: Setup Ruby
-        uses: actions/setup-ruby@v1
-        with:
-          ruby-version: 2.6.x
-
-      - name: Install Bundler
-        run: |
-          gem install bundler
-
-      - name: Setup Bundle
-        run: |
-          bundle install --with docker --without opennebula ec2 windows vagrant
-
-      - name: Set up Python 3.7
-        uses: actions/setup-python@v1
-        with:
-          python-version: 3.7
-
-      - name: Install Python Dependencies
-        run: |
-          pip install -U pip
-          pip install -r tests/requirements.txt
-
-      - name: Create Test Container
-        run: |
-          bundle exec kitchen create py3-stable-3002-0-gentoo || bundle exec kitchen create py3-stable-3002-0-gentoo
-
-      - name: Test Bootstrap In Test Container
-        run: |
-          bundle exec kitchen verify py3-stable-3002-0-gentoo
-
-      - name: Destroy Test Container
-        if: always()
-        run: |
-          bundle exec kitchen destroy py3-stable-3002-0-gentoo
-
-
   py3-git-master-gentoo:
     name: Gentoo Master Py3 Git
     runs-on: ubuntu-latest
-    timeout-minutes: 50
+    timeout-minutes: 70
 
 
 
@@ -517,7 +425,7 @@ jobs:
   latest-gentoo:
     name: Gentoo Latest packaged release
     runs-on: ubuntu-latest
-    timeout-minutes: 50
+    timeout-minutes: 70
 
 
 
@@ -563,7 +471,7 @@ jobs:
   py3-stable-2019-2-gentoo-systemd:
     name: Gentoo (systemd) v2019.2 Py3 Stable
     runs-on: ubuntu-latest
-    timeout-minutes: 50
+    timeout-minutes: 70
 
 
 
@@ -609,7 +517,7 @@ jobs:
   py3-git-2019-2-gentoo-systemd:
     name: Gentoo (systemd) v2019.2 Py3 Git
     runs-on: ubuntu-latest
-    timeout-minutes: 50
+    timeout-minutes: 70
 
 
 
@@ -655,7 +563,7 @@ jobs:
   py3-stable-3000-gentoo-systemd:
     name: Gentoo (systemd) v3000 Py3 Stable
     runs-on: ubuntu-latest
-    timeout-minutes: 50
+    timeout-minutes: 70
 
 
 
@@ -701,7 +609,7 @@ jobs:
   py3-git-3000-gentoo-systemd:
     name: Gentoo (systemd) v3000 Py3 Git
     runs-on: ubuntu-latest
-    timeout-minutes: 50
+    timeout-minutes: 70
 
 
 
@@ -747,7 +655,7 @@ jobs:
   py3-stable-3001-gentoo-systemd:
     name: Gentoo (systemd) v3001 Py3 Stable
     runs-on: ubuntu-latest
-    timeout-minutes: 50
+    timeout-minutes: 70
 
 
 
@@ -793,7 +701,7 @@ jobs:
   py3-git-3001-gentoo-systemd:
     name: Gentoo (systemd) v3001 Py3 Git
     runs-on: ubuntu-latest
-    timeout-minutes: 50
+    timeout-minutes: 70
 
 
 
@@ -836,56 +744,10 @@ jobs:
           bundle exec kitchen destroy py3-git-3001-gentoo-systemd
 
 
-  py3-stable-3001-0-gentoo-systemd:
-    name: Gentoo (systemd) v3001.0 Py3 Stable
-    runs-on: ubuntu-latest
-    timeout-minutes: 50
-
-
-
-    steps:
-      - uses: actions/checkout@v1
-      - name: Setup Ruby
-        uses: actions/setup-ruby@v1
-        with:
-          ruby-version: 2.6.x
-
-      - name: Install Bundler
-        run: |
-          gem install bundler
-
-      - name: Setup Bundle
-        run: |
-          bundle install --with docker --without opennebula ec2 windows vagrant
-
-      - name: Set up Python 3.7
-        uses: actions/setup-python@v1
-        with:
-          python-version: 3.7
-
-      - name: Install Python Dependencies
-        run: |
-          pip install -U pip
-          pip install -r tests/requirements.txt
-
-      - name: Create Test Container
-        run: |
-          bundle exec kitchen create py3-stable-3001-0-gentoo-systemd || bundle exec kitchen create py3-stable-3001-0-gentoo-systemd
-
-      - name: Test Bootstrap In Test Container
-        run: |
-          bundle exec kitchen verify py3-stable-3001-0-gentoo-systemd
-
-      - name: Destroy Test Container
-        if: always()
-        run: |
-          bundle exec kitchen destroy py3-stable-3001-0-gentoo-systemd
-
-
   py3-stable-3002-gentoo-systemd:
     name: Gentoo (systemd) v3002 Py3 Stable
     runs-on: ubuntu-latest
-    timeout-minutes: 50
+    timeout-minutes: 70
 
 
 
@@ -931,7 +793,7 @@ jobs:
   py3-git-3002-gentoo-systemd:
     name: Gentoo (systemd) v3002 Py3 Git
     runs-on: ubuntu-latest
-    timeout-minutes: 50
+    timeout-minutes: 70
 
 
 
@@ -974,56 +836,10 @@ jobs:
           bundle exec kitchen destroy py3-git-3002-gentoo-systemd
 
 
-  py3-stable-3002-0-gentoo-systemd:
-    name: Gentoo (systemd) v3002.0 Py3 Stable
-    runs-on: ubuntu-latest
-    timeout-minutes: 50
-
-
-
-    steps:
-      - uses: actions/checkout@v1
-      - name: Setup Ruby
-        uses: actions/setup-ruby@v1
-        with:
-          ruby-version: 2.6.x
-
-      - name: Install Bundler
-        run: |
-          gem install bundler
-
-      - name: Setup Bundle
-        run: |
-          bundle install --with docker --without opennebula ec2 windows vagrant
-
-      - name: Set up Python 3.7
-        uses: actions/setup-python@v1
-        with:
-          python-version: 3.7
-
-      - name: Install Python Dependencies
-        run: |
-          pip install -U pip
-          pip install -r tests/requirements.txt
-
-      - name: Create Test Container
-        run: |
-          bundle exec kitchen create py3-stable-3002-0-gentoo-systemd || bundle exec kitchen create py3-stable-3002-0-gentoo-systemd
-
-      - name: Test Bootstrap In Test Container
-        run: |
-          bundle exec kitchen verify py3-stable-3002-0-gentoo-systemd
-
-      - name: Destroy Test Container
-        if: always()
-        run: |
-          bundle exec kitchen destroy py3-stable-3002-0-gentoo-systemd
-
-
   py3-git-master-gentoo-systemd:
     name: Gentoo (systemd) Master Py3 Git
     runs-on: ubuntu-latest
-    timeout-minutes: 50
+    timeout-minutes: 70
 
 
 
@@ -1069,7 +885,7 @@ jobs:
   latest-gentoo-systemd:
     name: Gentoo (systemd) Latest packaged release
     runs-on: ubuntu-latest
-    timeout-minutes: 50
+    timeout-minutes: 70
 
 
 

--- a/.github/workflows/templates/generate.py
+++ b/.github/workflows/templates/generate.py
@@ -76,10 +76,14 @@ BLACKLIST_3001 = [
 
 BLACKLIST_3001_0 = [
     "debian-11",
+    "gentoo",
+    "gentoo-systemd",
 ]
 
 BLACKLIST_3002_0 = [
     "debian-11",
+    "gentoo",
+    "gentoo-systemd",
 ]
 
 SALT_BRANCHES = [
@@ -131,8 +135,8 @@ DISTRO_DISPLAY_NAMES = {
 
 TIMEOUT_DEFAULT = 20
 TIMEOUT_OVERRIDES = {
-    "gentoo": 50,
-    "gentoo-systemd": 50,
+    "gentoo": 70,
+    "gentoo-systemd": 70,
 }
 BRANCH_ONLY_OVERRIDES = [
     "gentoo",

--- a/.github/workflows/templates/generate.py
+++ b/.github/workflows/templates/generate.py
@@ -135,8 +135,8 @@ DISTRO_DISPLAY_NAMES = {
 
 TIMEOUT_DEFAULT = 20
 TIMEOUT_OVERRIDES = {
-    "gentoo": 70,
-    "gentoo-systemd": 70,
+    "gentoo": 90,
+    "gentoo-systemd": 90,
 }
 BRANCH_ONLY_OVERRIDES = [
     "gentoo",

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -86,14 +86,18 @@ platforms:
       run_command: /sbin/init
       provision_command:
         - rc-update add sshd default
-        - emerge --update --deep --with-bdeps=y --newuse @world
+        - emerge --update --deep --with-bdeps=y --newuse --quiet @world
+        - emerge --depclean --quiet
+        - eselect python set python3.8
   - name: gentoo-systemd
     driver_config:
       image: gentoo/stage3:systemd
       run_command: /lib/systemd/systemd
       provision_command:
         - systemctl enable sshd.service
-        - emerge --update --deep --with-bdeps=y --newuse @world
+        - emerge --update --deep --with-bdeps=y --newuse --quiet @world
+        - emerge --depclean --quiet
+        - eselect python set python3.8
   - name: opensuse-15
     driver_config:
       image: opensuse/leap:15.1

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -231,6 +231,8 @@ suites:
       - fedora-32
       - fedora-33
       - arch
+      - gentoo
+      - gentoo-systemd
   - name: py3-stable-3001
     provisioner:
       salt_version: 3001
@@ -251,6 +253,8 @@ suites:
       - fedora-32
       - fedora-33
       - arch
+      - gentoo
+      - gentoo-systemd
   - name: py3-stable-3002
     provisioner:
       salt_version: 3002

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -7147,7 +7147,7 @@ install_gentoo_git_deps() {
             dev-python/pycryptodome
             dev-python/py
             dev-python/requests
-            dev-python/msgpack
+            <dev-python/msgpack-1.0
             dev-python/jinja
             dev-python/pyasn1
             dev-python/markupsafe


### PR DESCRIPTION
### What does this PR do?
This PR fixes builds on Gentoo that have been failing recently. It addresses several issues that have accumulated:
- Gentoo Docker are not rebuilt nightly due to https://github.com/gentoo/gentoo-docker-images/issues/97, which leads to longer build times.
- Gentoo switched to Python 3.8 as the default python3 version.

### What issues does this PR fix or reference.
N/A

### Previous Behavior
- Salt 2019 GIT builds used latest msgpack even though they should be using msgpack <1.0.
- Salt 3000 GIT builds did not work with Python 3.8.
- Build time capped at 50 minutes.

### New Behavior
- Salt 2019 GIT builds use msgpack <1.0.
- Salt 3000 GIT builds use Python 3.7.
- Tests for x.0 versions on Gentoo are removed as Gentoo does not keep x.0 ebuilds.
- Running a full system update when bootstraping test containers is followed by depclean and setting default Python version to 3.8. _The full system update, depclean, and setting the Python version should be removed once Gentoo has fresh images on Docker Hub._
- The build timeout increases from 50 to 90 minutes. _This is a temporary necessity, which should be reverted once Gentoo has fresh builds on Docker Hub._
