### PR TITLE
Gentoo - use ksmanis/stage3 image

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -82,22 +82,16 @@ platforms:
         - sed -i 's/^PubkeyAcceptedKeyTypes.*$/&,ssh-rsa/' /etc/crypto-policies/back-ends/opensshserver.config
   - name: gentoo
     driver_config:
-      image: gentoo/stage3:latest
+      image: ksmanis/stage3:latest
       run_command: /sbin/init
       provision_command:
         - rc-update add sshd default
-        - emerge --update --deep --with-bdeps=y --newuse --quiet @world
-        - emerge --depclean --quiet
-        - eselect python set python3.8
   - name: gentoo-systemd
     driver_config:
-      image: gentoo/stage3:systemd
+      image: ksmanis/stage3:systemd
       run_command: /lib/systemd/systemd
       provision_command:
         - systemctl enable sshd.service
-        - emerge --update --deep --with-bdeps=y --newuse --quiet @world
-        - emerge --depclean --quiet
-        - eselect python set python3.8
   - name: opensuse-15
     driver_config:
       image: opensuse/leap:15.1

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -7083,7 +7083,7 @@ __gentoo_pre_dep() {
     if [ -n "${EXTRA_PYTHON_TARGET:-}" ]; then
         if ! emerge --info | sed 's/.*\(PYTHON_TARGETS="[^"]*"\).*/\1/' | grep -q "${EXTRA_PYTHON_TARGET}" ; then
             echo "PYTHON_TARGETS=\"\${PYTHON_TARGETS} ${EXTRA_PYTHON_TARGET}\"" >> /etc/portage/make.conf
-            emerge --update --deep --with-bdeps=y --newuse --quiet @world
+            emerge --deep --with-bdeps=y --newuse --quiet @world
         fi
     fi
 }
@@ -7198,6 +7198,8 @@ install_gentoo_git() {
         elif [ "${_POST_NEON_INSTALL}" -eq $BS_FALSE ]; then
             # Tornado 4.3 ebuild supports only Python 3.6, use Python 3.6 as the default Python 3 interpreter
             _PYEXE=python3.6
+        else
+            _PYEXE=$(emerge --info | grep -oE 'PYTHON_SINGLE_TARGET="[^"]*"' | sed -e 's/"//g' -e 's/_/./g' | cut -d= -f2)
         fi
     fi
 


### PR DESCRIPTION
Use an alternative image until gentoo/stage3 gets pushed to Docker Hub again.

### What does this PR do?
It uses the [ksmanis/stage3](https://hub.docker.com/r/ksmanis/stage3) image instead of the outdated [gentoo/stage3](https://hub.docker.com/r/gentoo/stage3). The use of the alternative image should be reverted back to gentoo/stage3 once updated images get deployed again - see https://github.com/gentoo/gentoo-docker-images/pull/100

It also sets python3 according to the PYTHON_SINGLE_TARGET portage variable.