### PR TITLE
Handle Vagrant's `grains_config` option (same as `bootstrap-salt.sh`)

### DIFF
--- a/bootstrap-salt.ps1
+++ b/bootstrap-salt.ps1
@@ -195,9 +195,8 @@ New-Item C:\tmp\ -ItemType directory -Force | Out-Null
 # Check if minion keys have been uploaded, copy to correct location
 If (Test-Path C:\tmp\minion.pem) {
     New-Item C:\salt\conf\pki\minion\ -ItemType Directory -Force | Out-Null
-    # Copy minion keys & config to correct location
-    cp C:\tmp\minion.pem C:\salt\conf\pki\minion\
-    cp C:\tmp\minion.pub C:\salt\conf\pki\minion\
+    Copy-Item -Path C:\tmp\minion.pem -Destination C:\salt\conf\pki\minion\ -Force | Out-Null
+    Copy-Item -Path C:\tmp\minion.pub -Destination C:\salt\conf\pki\minion\ -Force | Out-Null
     $ConfiguredAnything = $True
 }
 

--- a/bootstrap-salt.ps1
+++ b/bootstrap-salt.ps1
@@ -210,6 +210,13 @@ If (Test-Path C:\tmp\minion) {
     $ConfiguredAnything = $True
 }
 
+# Check if grains config has been uploaded
+If (Test-Path C:\tmp\grains) {
+    New-Item C:\salt\conf\ -ItemType Directory -Force | Out-Null
+    Copy-Item -Path C:\tmp\grains -Destination C:\salt\conf\ -Force | Out-Null
+    $ConfiguredAnything = $True
+}
+
 If ($ConfigureOnly -and !$ConfiguredAnything) {
     Write-Output "No configuration or keys were copied over. No configuration was done!"
     exit 0

--- a/bootstrap-salt.ps1
+++ b/bootstrap-salt.ps1
@@ -98,7 +98,7 @@ Param(
     [string]$master = "not-specified",
 
     [Parameter(Mandatory=$false,ValueFromPipeline=$true)]
-    [string]$repourl= "https://repo.saltproject.io/windows"
+    [string]$repourl= "https://repo.saltproject.io/windows",
 
     [Parameter(Mandatory=$false,ValueFromPipeline=$true)]
     [switch]$ConfigureOnly


### PR DESCRIPTION
### What does this PR do?

Handles Vagrant's `grains_config` option in the same way as `bootstrap-salt.sh`.
Vagrant will use this bootstrap script as part of its Salt provisioner (see hashicorp/vagrant#12127).

The same operation is performed here in `bootstrap-salt.sh`:
https://github.com/saltstack/salt-bootstrap/blob/da0f0733edf121d9b5e1bd5a8219309c38e975d9/bootstrap-salt.sh#L7600-L7605

Another commit makes the copy command used to copy the minion keys consistent with the other copy commands.

### What issues does this PR fix or reference?

### Previous Behavior
None

### New Behavior
Copies the file `grains` to `C:\salt\conf`