### PR TITLE
fix(opensuse): fix & add CI for openSUSE Tumbleweed

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3264,6 +3264,190 @@ jobs:
           bundle exec kitchen destroy latest-opensuse-15
 
 
+  py3-git-3001-opensuse-tumbleweed:
+    name: Opensuse Tumbleweed v3001 Py3 Git
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    needs: lint
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Setup Ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 2.6.x
+
+      - name: Install Bundler
+        run: |
+          gem install bundler
+
+      - name: Setup Bundle
+        run: |
+          bundle install --with docker --without opennebula ec2 windows vagrant
+
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+
+      - name: Install Python Dependencies
+        run: |
+          pip install -U pip
+          pip install -r tests/requirements.txt
+
+      - name: Create Test Container
+        run: |
+          bundle exec kitchen create py3-git-3001-opensuse-tumbleweed || bundle exec kitchen create py3-git-3001-opensuse-tumbleweed
+
+      - name: Test Bootstrap In Test Container
+        run: |
+          bundle exec kitchen verify py3-git-3001-opensuse-tumbleweed
+
+      - name: Destroy Test Container
+        if: always()
+        run: |
+          bundle exec kitchen destroy py3-git-3001-opensuse-tumbleweed
+
+
+  py3-git-3002-opensuse-tumbleweed:
+    name: Opensuse Tumbleweed v3002 Py3 Git
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    needs: lint
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Setup Ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 2.6.x
+
+      - name: Install Bundler
+        run: |
+          gem install bundler
+
+      - name: Setup Bundle
+        run: |
+          bundle install --with docker --without opennebula ec2 windows vagrant
+
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+
+      - name: Install Python Dependencies
+        run: |
+          pip install -U pip
+          pip install -r tests/requirements.txt
+
+      - name: Create Test Container
+        run: |
+          bundle exec kitchen create py3-git-3002-opensuse-tumbleweed || bundle exec kitchen create py3-git-3002-opensuse-tumbleweed
+
+      - name: Test Bootstrap In Test Container
+        run: |
+          bundle exec kitchen verify py3-git-3002-opensuse-tumbleweed
+
+      - name: Destroy Test Container
+        if: always()
+        run: |
+          bundle exec kitchen destroy py3-git-3002-opensuse-tumbleweed
+
+
+  py3-git-master-opensuse-tumbleweed:
+    name: Opensuse Tumbleweed Master Py3 Git
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    needs: lint
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Setup Ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 2.6.x
+
+      - name: Install Bundler
+        run: |
+          gem install bundler
+
+      - name: Setup Bundle
+        run: |
+          bundle install --with docker --without opennebula ec2 windows vagrant
+
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+
+      - name: Install Python Dependencies
+        run: |
+          pip install -U pip
+          pip install -r tests/requirements.txt
+
+      - name: Create Test Container
+        run: |
+          bundle exec kitchen create py3-git-master-opensuse-tumbleweed || bundle exec kitchen create py3-git-master-opensuse-tumbleweed
+
+      - name: Test Bootstrap In Test Container
+        run: |
+          bundle exec kitchen verify py3-git-master-opensuse-tumbleweed
+
+      - name: Destroy Test Container
+        if: always()
+        run: |
+          bundle exec kitchen destroy py3-git-master-opensuse-tumbleweed
+
+
+  latest-opensuse-tumbleweed:
+    name: Opensuse Tumbleweed Latest packaged release
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    needs: lint
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Setup Ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 2.6.x
+
+      - name: Install Bundler
+        run: |
+          gem install bundler
+
+      - name: Setup Bundle
+        run: |
+          bundle install --with docker --without opennebula ec2 windows vagrant
+
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+
+      - name: Install Python Dependencies
+        run: |
+          pip install -U pip
+          pip install -r tests/requirements.txt
+
+      - name: Create Test Container
+        run: |
+          bundle exec kitchen create latest-opensuse-tumbleweed || bundle exec kitchen create latest-opensuse-tumbleweed
+
+      - name: Test Bootstrap In Test Container
+        run: |
+          bundle exec kitchen verify latest-opensuse-tumbleweed
+
+      - name: Destroy Test Container
+        if: always()
+        run: |
+          bundle exec kitchen destroy latest-opensuse-tumbleweed
+
+
   py3-stable-3000-ubuntu-1604:
     name: Ubuntu 16.04 v3000 Py3 Stable
     runs-on: ubuntu-latest

--- a/.github/workflows/templates/generate.py
+++ b/.github/workflows/templates/generate.py
@@ -18,6 +18,7 @@ LINUX_DISTROS = [
     "gentoo",
     "gentoo-systemd",
     "opensuse-15",
+    "opensuse-tumbleweed",
     "ubuntu-1604",
     "ubuntu-1804",
     "ubuntu-2004",
@@ -49,12 +50,14 @@ PY2_BLACKLIST = [
     "gentoo",
     "gentoo-systemd",
     "opensuse-15",
+    "opensuse-tumbleweed",
     "ubuntu-2004",
 ]
 
 BLACKLIST_3000 = [
     "debian-11",
     "fedora-33",
+    "opensuse-tumbleweed",
     "ubuntu-2004",
 ]
 
@@ -113,6 +116,7 @@ DISTRO_DISPLAY_NAMES = {
     "gentoo": "Gentoo",
     "gentoo-systemd": "Gentoo (systemd)",
     "opensuse-15": "Opensuse 15",
+    "opensuse-tumbleweed": "Opensuse Tumbleweed",
     "ubuntu-1604": "Ubuntu 16.04",
     "ubuntu-1804": "Ubuntu 18.04",
     "ubuntu-2004": "Ubuntu 20.04",

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -95,6 +95,16 @@ platforms:
         - systemctl enable sshd.service
     provisioner:
       salt_bootstrap_options: -MPfq -y -x python2 git %s
+  - name: opensuse-tumbleweed
+    driver_config:
+      image: opensuse/tumbleweed:latest
+      run_command: /usr/lib/systemd/systemd
+      provision_command:
+        - zypper --non-interactive install --auto-agree-with-licenses dbus-1
+        - zypper --non-interactive install --auto-agree-with-licenses sudo openssh which curl systemd
+        - systemctl enable sshd.service
+    provisioner:
+      salt_bootstrap_options: -MPfq -y -x python3 git %s
   - name: ubuntu-20.04
     driver_config:
       run_command: /lib/systemd/systemd
@@ -129,6 +139,7 @@ suites:
     excludes:
       - arch
       - opensuse-15
+      - opensuse-tumbleweed
       - debian-10
       - debian-11
       - fedora-32
@@ -143,6 +154,7 @@ suites:
       salt_bootstrap_options: -x python3 -MPfq git %s
     excludes:
       - debian-11
+      - opensuse-tumbleweed
       - ubuntu-2004
   - name: py3-git-3001
     provisioner:
@@ -159,6 +171,7 @@ suites:
     excludes:
       - debian-11
       - opensuse-15
+      - opensuse-tumbleweed
       - arch
       - ubuntu-2004
   - name: py3-stable-3001-0
@@ -167,6 +180,7 @@ suites:
       salt_bootstrap_options: -x python3 -MP stable 3001.0
     excludes:
       - opensuse-15
+      - opensuse-tumbleweed
       - debian-11
       - fedora-32
       - fedora-33
@@ -180,6 +194,7 @@ suites:
     excludes:
       - debian-11
       - opensuse-15
+      - opensuse-tumbleweed
       - arch
   - name: py3-stable-3002-0
     provisioner:
@@ -187,6 +202,7 @@ suites:
       salt_bootstrap_options: -x python3 -MP stable 3002.0
     excludes:
       - opensuse-15
+      - opensuse-tumbleweed
       - debian-11
       - fedora-32
       - fedora-33
@@ -199,6 +215,7 @@ suites:
       salt_bootstrap_options: -x python3 -MP stable %s
     excludes:
       - opensuse-15
+      - opensuse-tumbleweed
       - arch
   - name: py3-git-master
     provisioner:

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -6463,6 +6463,9 @@ install_opensuse_git_deps() {
         if [ "$_INSTALL_CLOUD" -eq $BS_TRUE ]; then
             __PACKAGES="${__PACKAGES} python-apache-libcloud"
         fi
+    # Check for Tumbleweed
+    elif [ "${DISTRO_MAJOR_VERSION}" -ge 20210101 ]; then
+        __PACKAGES="python3-pip"
     else
         __PACKAGES="python-pip python-setuptools gcc"
     fi
@@ -6544,7 +6547,7 @@ install_opensuse_git_post() {
         [ $fname = "minion" ] && [ "$_INSTALL_MINION" -eq $BS_FALSE ] && continue
         [ $fname = "syndic" ] && [ "$_INSTALL_SYNDIC" -eq $BS_FALSE ] && continue
 
-        if [ -f /bin/systemctl ]; then
+        if command -v systemctl; then
             use_usr_lib=$BS_FALSE
 
             if [ "${DISTRO_MAJOR_VERSION}" -ge 15 ]; then


### PR DESCRIPTION
### What does this PR do?

When `systemd` is installed on Tumbleweed, `systemctl` is actually
located at `/usr/bin/systemctl`.  It appears that the same applies for
openSUSE Leap except that a symlink is also provided there, i.e.
`/bin/systemctl` => `/usr/bin/systemctl`.

Tumbleweed installs Python 3.8, which was first supported in `3001` (Sodium).
Hence, testing on `2019.2` and `3000` is not possible.

When provisioning in Kitchen, another package is supplied compared to
openSUSE Leap:

* `systemd`: It appears that this is implicitly installed in Leap as a
  dependency of the `openssh` package; this doesn't apply in Tumbleweed,
  so it is installed explicitly.

### What issues does this PR fix or reference?

### Previous Behavior

Installation on Tumbleweed failed.

```shell
 *  INFO: Running install_opensuse_git_post()
cp: cannot create regular file '/etc/init.d/salt-minion': No such file or directory
chmod: cannot access '/etc/init.d/salt-minion': No such file or directory
Failed to get unit file state for salt-minion.service: No such file or directory
Failed to preset unit, unit salt-minion.service does not exist.
```

### ~CI~

~Since the CI seems to be failing here, this is a link to the subset of GitHub
Actions that I tested this with:~

* ~https://github.com/myii/salt-bootstrap/actions/runs/499468242~
