### PR TITLE
use https for fetching gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,4 @@ source "https://rubygems.org"
 
 gem 'test-kitchen', '>= 2.0.1'
 gem 'kitchen-salt', '>= 0.5'
-gem 'kitchen-docker', github: 'test-kitchen/kitchen-docker'
+gem 'kitchen-docker', git: 'https://github.com/test-kitchen/kitchen-docker.git'


### PR DESCRIPTION
### What does this PR do?
Fetches gems over https to avoid warning.
