### PR TITLE
fix(arch): remove `python2-futures` package (moved to AUR) -- CI added for `latest-arch`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -642,6 +642,52 @@ jobs:
           bundle exec kitchen destroy py3-git-master-arch
 
 
+  latest-arch:
+    name: Arch Latest packaged release
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    needs: lint
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Setup Ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 2.6.x
+
+      - name: Install Bundler
+        run: |
+          gem install bundler
+
+      - name: Setup Bundle
+        run: |
+          bundle install --with docker --without opennebula ec2 windows vagrant
+
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+
+      - name: Install Python Dependencies
+        run: |
+          pip install -U pip
+          pip install -r tests/requirements.txt
+
+      - name: Create Test Container
+        run: |
+          bundle exec kitchen create latest-arch || bundle exec kitchen create latest-arch
+
+      - name: Test Bootstrap In Test Container
+        run: |
+          bundle exec kitchen verify latest-arch
+
+      - name: Destroy Test Container
+        if: always()
+        run: |
+          bundle exec kitchen destroy latest-arch
+
+
   py3-stable-3000-centos-7:
     name: CentOS 7 v3000 Py3 Stable
     runs-on: ubuntu-latest

--- a/.github/workflows/templates/generate.py
+++ b/.github/workflows/templates/generate.py
@@ -101,9 +101,7 @@ BRANCH_DISPLAY_NAMES = {
 
 STABLE_BRANCH_BLACKLIST = []
 
-LATEST_PKG_BLACKLIST = [
-    "arch",  # No packages are built
-]
+LATEST_PKG_BLACKLIST = []
 
 DISTRO_DISPLAY_NAMES = {
     "amazon-2": "Amazon 2",

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -5633,7 +5633,7 @@ install_arch_linux_git_deps() {
     if [ "${_POST_NEON_INSTALL}" -eq $BS_FALSE ]; then
         pacman -R --noconfirm python2-distribute
         pacman -Su --noconfirm --needed python2-crypto python2-setuptools python2-jinja \
-            python2-m2crypto python2-futures python2-markupsafe python2-msgpack python2-psutil \
+            python2-m2crypto python2-markupsafe python2-msgpack python2-psutil \
             python2-pyzmq zeromq python2-requests python2-systemd || return 1
 
         if [ -f "${_SALT_GIT_CHECKOUT_DIR}/requirements/base.txt" ]; then
@@ -5675,7 +5675,7 @@ install_arch_linux_stable() {
     pacman -S --noconfirm --needed bash || return 1
     pacman -Su --noconfirm || return 1
     # We can now resume regular salt update
-    pacman -Syu --noconfirm salt python2-futures || return 1
+    pacman -Syu --noconfirm salt || return 1
     return 0
 }
 

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -229,8 +229,6 @@ suites:
     provisioner:
       salt_version: latest
       salt_bootstrap_options: -MP stable %s
-    excludes:
-      - arch
 
 verifier:
   name: shell


### PR DESCRIPTION
### What does this PR do?

The `stable latest` build in the `salt-image-builder` started failing.

* https://gitlab.com/myii/salt-image-builder/-/jobs/1124156923

```
error: target not found: python2-futures
 core is up to date
 extra is up to date
 community is up to date
 * ERROR: Failed to run install_arch_linux_stable()!!!
```

The package has been moved to AUR:

* https://aur.archlinux.org/packages/python2-futures/
* https://aur.archlinux.org/cgit/aur.git/commit/?h=python2-futures&id=06dea3ff2267d052dbc3779c9a93d31766769c6b
  - `import from community`

The build is passing again with this workaround applied using `sed`:

* https://gitlab.com/saltstack-formulas/infrastructure/salt-image-builder/-/commit/83efb01cb8d12bfed121b003233afc7000300f06
* https://gitlab.com/myii/salt-image-builder/-/jobs/1124687557

---

Updated CI to include `latest-arch` (passing).