### PR TITLE
feat(bsd): add CI testing using Kitchen's `vagrant` driver

### DIFF
--- a/.github/workflows/kitchen.vagrant.yml
+++ b/.github/workflows/kitchen.vagrant.yml
@@ -1,0 +1,87 @@
+---
+name: 'Kitchen Vagrant (FreeBSD & OpenBSD)'
+'on': ['push', 'pull_request']
+
+env:
+  KITCHEN_LOCAL_YAML: 'kitchen.vagrant.yml'
+
+jobs:
+  generate-actions-workflow:
+    name: 'Generate The Actions Workflow'
+    runs-on: 'ubuntu-latest'
+    steps:
+      - uses: 'actions/checkout@v1'
+      - name: 'Set up Python 3.7'
+        uses: 'actions/setup-python@v1'
+        with:
+          python-version: 3.7
+      - name: 'Install Pre-Commit'
+        run: |
+          pip install -U pip
+          pip install pre-commit
+          pre-commit install
+      - name: 'Generate Workflow Actions'
+        run: |
+          pre-commit run -av generate-actions-workflow
+  lint:
+    name: 'Lint'
+    runs-on: 'ubuntu-latest'
+    needs: 'generate-actions-workflow'
+    container: 'koalaman/shellcheck-alpine:v0.6.0'
+    steps:
+      - uses: 'actions/checkout@v1'
+      - name: 'ShellCheck'
+        run: |
+          shellcheck -s sh -f tty bootstrap-salt.sh
+  test:
+    runs-on: 'macos-10.15'
+    timeout-minutes: 20
+    needs: 'lint'
+    strategy:
+      fail-fast: false
+      matrix:
+        instance:
+          - py3-git-3000-freebsd-130
+          - py3-git-3000-freebsd-122
+          - py3-git-3000-freebsd-114
+          # - py3-git-3000-openbsd-6
+          - py3-git-3001-freebsd-130
+          - py3-git-3001-freebsd-122
+          - py3-git-3001-freebsd-114
+          # - py3-git-3001-openbsd-6
+          - py3-git-3002-freebsd-130
+          - py3-git-3002-freebsd-122
+          - py3-git-3002-freebsd-114
+          # - py3-git-3002-openbsd-6
+          - py3-git-master-freebsd-130
+          - py3-git-master-freebsd-122
+          - py3-git-master-freebsd-114
+          # - py3-git-master-openbsd-6
+          - latest-freebsd-130
+          - latest-freebsd-122
+          - latest-freebsd-114
+          - latest-openbsd-6
+    steps:
+      - name: 'Check out code'
+        uses: 'actions/checkout@v2'
+      - name: 'Set up Bundler cache'
+        uses: 'actions/cache@v1'
+        with:
+          path: 'vendor/bundle'
+          key: "${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}"
+          restore-keys: "${{ runner.os }}-gems-"
+      - name: 'Run Bundler'
+        run: |
+          ruby --version
+          bundle config path vendor/bundle
+          bundle install --jobs 4 --retry 3
+      - name: 'Set up Python 3.7'
+        uses: 'actions/setup-python@v1'
+        with:
+          python-version: '3.7'
+      - name: 'Install Python Dependencies'
+        run: |
+          pip install -U pip
+          pip install -r tests/requirements.txt
+      - name: 'Run Test Kitchen'
+        run: 'bundle exec kitchen test ${{ matrix.instance }}'

--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,7 @@ source "https://rubygems.org"
 gem 'test-kitchen', '>= 2.0.1'
 gem 'kitchen-salt', '>= 0.5'
 gem 'kitchen-docker', git: 'https://github.com/test-kitchen/kitchen-docker.git'
+
+group :vagrant do
+  gem 'kitchen-vagrant'
+end

--- a/kitchen.vagrant.yml
+++ b/kitchen.vagrant.yml
@@ -1,0 +1,47 @@
+---
+driver:
+  name: vagrant
+  vm_hostname: salt
+  username: vagrant
+  cache_directory: false
+  customize:
+    usbxhci: 'off'
+  gui: false
+  linked_clone: true
+  ssh:
+    shell: /bin/sh
+
+provisioner:
+  init_environment: |
+    echo 'auto_accept: true' > /tmp/auto-accept-keys.conf
+    sudo mkdir -p /usr/local/etc/salt/master.d
+    sudo mv /tmp/auto-accept-keys.conf /usr/local/etc/salt/master.d/auto-accept-keys.conf
+    sudo pkg install -y shuf
+    sh -c 't=$(shuf -i 1-15 -n 1); echo Sleeping $t seconds; sleep $t'
+  sudo: true
+
+platforms:
+  - name: freebsd-130
+    driver:
+      box: bento/freebsd-13.0
+  - name: freebsd-122
+    driver:
+      box: bento/freebsd-12.2
+  - name: freebsd-114
+    driver:
+      box: bento/freebsd-11.4
+  - name: openbsd-6
+    driver:
+      box: generic/openbsd6
+      ssh:
+        shell: /bin/ksh
+    provisioner:
+      init_environment: |
+        echo 'auto_accept: true' > /tmp/auto-accept-keys.conf
+        sudo mkdir -p /etc/salt/master.d
+        sudo mv /tmp/auto-accept-keys.conf /etc/salt/master.d/auto-accept-keys.conf
+        sudo pkg_add coreutils
+        sh -c 't=$(gshuf -i 1-15 -n 1); echo Sleeping $t seconds; sleep $t'
+
+verifier:
+  command: pytest --cache-clear -v -s -ra --log-cli-level=debug -k "not test_ping" tests/integration/

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -144,6 +144,10 @@ suites:
       - debian-11
       - gentoo
       - gentoo-systemd
+      - freebsd-130
+      - freebsd-122
+      - freebsd-114
+      - openbsd-6
   - name: py2-git-master
     provisioner:
       salt_version: master
@@ -152,6 +156,10 @@ suites:
       - debian-11
       - gentoo
       - gentoo-systemd
+      - freebsd-130
+      - freebsd-122
+      - freebsd-114
+      - openbsd-6
   - name: py2-stable-3000
     provisioner:
       salt_version: 3000
@@ -168,6 +176,10 @@ suites:
       - gentoo-systemd
       - ubuntu-2004
       - ubuntu-2104
+      - freebsd-130
+      - freebsd-122
+      - freebsd-114
+      - openbsd-6
 
   - name: py3-git-3000
     provisioner:
@@ -197,6 +209,10 @@ suites:
       - arch
       - ubuntu-2004
       - ubuntu-2104
+      - freebsd-130
+      - freebsd-122
+      - freebsd-114
+      - openbsd-6
   - name: py3-stable-3001-0
     provisioner:
       salt_version: 3001
@@ -211,6 +227,10 @@ suites:
       - gentoo
       - gentoo-systemd
       - ubuntu-2104
+      - freebsd-130
+      - freebsd-122
+      - freebsd-114
+      - openbsd-6
   - name: py3-stable-3001
     provisioner:
       salt_version: 3001
@@ -221,6 +241,10 @@ suites:
       - opensuse-tumbleweed
       - arch
       - ubuntu-2104
+      - freebsd-130
+      - freebsd-122
+      - freebsd-114
+      - openbsd-6
   - name: py3-stable-3002-0
     provisioner:
       salt_version: 3002
@@ -234,6 +258,10 @@ suites:
       - arch
       - gentoo
       - gentoo-systemd
+      - freebsd-130
+      - freebsd-122
+      - freebsd-114
+      - openbsd-6
   - name: py3-stable-3002
     provisioner:
       salt_version: 3002
@@ -242,6 +270,10 @@ suites:
       - opensuse-15
       - opensuse-tumbleweed
       - arch
+      - freebsd-130
+      - freebsd-122
+      - freebsd-114
+      - openbsd-6
   - name: py3-git-master
     provisioner:
       salt_version: master


### PR DESCRIPTION
### What does this PR do?

Add CI testing for FreeBSD (12.2 & 11.4) and OpenBSD (6.8) using Kitchen's `vagrant` driver.  These have been configured for local testing as well.

Already using these in the SaltStack Formulas org so proposing it here as well.

I'll use inline comments to mention any noteworthy points.