### PR TITLE
feat(windows): add CI testing using Kitchen's `proxy` driver

### DIFF
--- a/.github/workflows/kitchen.windows.yml
+++ b/.github/workflows/kitchen.windows.yml
@@ -1,0 +1,150 @@
+---
+name: 'Kitchen (Windows)'
+'on': ['push', 'pull_request']
+
+env:
+  machine_user: kitchen
+  machine_pass: Password1
+  machine_port: 5985
+  KITCHEN_LOCAL_YAML: 'kitchen.windows.yml'
+
+jobs:
+  generate-actions-workflow:
+    name: 'Generate The Actions Workflow'
+    runs-on: 'ubuntu-latest'
+    steps:
+      - uses: 'actions/checkout@v1'
+      - name: 'Set up Python 3.7'
+        uses: 'actions/setup-python@v1'
+        with:
+          python-version: 3.7
+      - name: 'Install Pre-Commit'
+        run: |
+          pip install -U pip
+          pip install pre-commit
+          pre-commit install
+      - name: 'Generate Workflow Actions'
+        run: |
+          pre-commit run -av generate-actions-workflow
+  lint:
+    name: 'Lint'
+    runs-on: 'ubuntu-latest'
+    needs: 'generate-actions-workflow'
+    container: 'koalaman/shellcheck-alpine:v0.6.0'
+    steps:
+      - uses: 'actions/checkout@v1'
+      - name: 'ShellCheck'
+        run: |
+          shellcheck -s sh -f tty bootstrap-salt.sh
+  test-2019:
+    runs-on: 'windows-2019'
+    timeout-minutes: 20
+    needs: 'lint'
+    strategy:
+      fail-fast: false
+      matrix:
+        instance:
+          - py3-stable-3001-windows-2019
+          - py3-stable-3002-windows-2019
+          - latest-windows-2019
+    steps:
+      - name: 'Check out code'
+        uses: 'actions/checkout@v2'
+      - name: 'Install Chef'
+        uses: 'actionshub/chef-install@1.1.0'
+        with:
+          project: 'chef'
+          version: '16.10.8'
+      - name: 'Add Chef bindir to PATH'
+        uses: 'myci-actions/export-env-var-powershell@1'
+        with:
+          name: 'PATH'
+          value: "C:\\opscode\\chef\\bin;\
+                  C:\\opscode\\chef\\embedded\\bin;$env:PATH"
+      - name: 'Set up Bundler cache'
+        uses: 'actions/cache@v1'
+        with:
+          path: 'vendor/bundle'
+          key: "${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}"
+          restore-keys: "${{ runner.os }}-gems-"
+      - name: 'Set up test user'
+        run: |
+          $password = ConvertTo-SecureString $env:machine_pass -AsPlainText -Force
+          New-LocalUser $env:machine_user -Password $password
+          Add-LocalGroupMember -Group "Administrators" -Member $env:machine_user
+      - name: 'Set up WinRM'
+        run: >
+          Set-WSManQuickConfig -Force;
+          Set-WSManInstance -ResourceURI winrm/config/service
+          -ValueSet @{AllowUnencrypted="true"}
+      - name: 'Run Bundler'
+        run: |
+          ruby --version
+          bundle config path vendor/bundle
+          bundle install --jobs 4 --retry 3
+      - name: 'Set up Python 3.7'
+        uses: 'actions/setup-python@v1'
+        with:
+          python-version: '3.7'
+      - name: 'Install Python Dependencies'
+        run: |
+          pip install -U pip
+          pip install -r tests/requirements.txt
+      - name: 'Run Test Kitchen'
+        run: 'bundle exec kitchen test ${{ matrix.instance }}'
+  test-2016:
+    runs-on: 'windows-2016'
+    timeout-minutes: 20
+    needs: 'lint'
+    strategy:
+      fail-fast: false
+      matrix:
+        instance:
+          - py3-stable-3001-windows-2016
+          - py3-stable-3002-windows-2016
+          - latest-windows-2016
+    steps:
+      - name: 'Check out code'
+        uses: 'actions/checkout@v2'
+      - name: 'Install Chef'
+        uses: 'actionshub/chef-install@1.1.0'
+        with:
+          project: 'chef'
+          version: '16.10.8'
+      - name: 'Add Chef bindir to PATH'
+        uses: 'myci-actions/export-env-var-powershell@1'
+        with:
+          name: 'PATH'
+          value: "C:\\opscode\\chef\\bin;\
+                  C:\\opscode\\chef\\embedded\\bin;$env:PATH"
+      - name: 'Set up Bundler cache'
+        uses: 'actions/cache@v1'
+        with:
+          path: 'vendor/bundle'
+          key: "${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}"
+          restore-keys: "${{ runner.os }}-gems-"
+      - name: 'Set up test user'
+        run: |
+          $password = ConvertTo-SecureString $env:machine_pass -AsPlainText -Force
+          New-LocalUser $env:machine_user -Password $password
+          Add-LocalGroupMember -Group "Administrators" -Member $env:machine_user
+      - name: 'Set up WinRM'
+        run: >
+          Set-WSManQuickConfig -Force;
+          Set-WSManInstance -ResourceURI winrm/config/service
+          -ValueSet @{AllowUnencrypted="true"}
+      - name: 'Run Bundler'
+        run: |
+          ruby --version
+          bundle config path vendor/bundle
+          bundle install --jobs 4 --retry 3
+      - name: 'Set up Python 3.7'
+        uses: 'actions/setup-python@v1'
+        with:
+          python-version: '3.7'
+      - name: 'Install Python Dependencies'
+        run: |
+          pip install -U pip
+          pip install -r tests/requirements.txt
+      - name: 'Run Test Kitchen'
+        run: 'bundle exec kitchen test ${{ matrix.instance }}'

--- a/kitchen.windows.yml
+++ b/kitchen.windows.yml
@@ -1,0 +1,31 @@
+---
+driver:
+  name: proxy
+  host: localhost
+  reset_command: "exit 0"
+  port: 5985
+  username: kitchen
+  password: Password1
+
+provisioner:
+  salt_bootstrap_url: D:/a/salt-bootstrap/salt-bootstrap/bootstrap-salt.ps1
+  salt_bootstrap_options: -pythonVersion 3 -version %s
+  init_environment: ''
+
+platforms:
+  - name: windows-2019
+  - name: windows-2016
+
+suites:
+  - name: py3-stable-3001
+    provisioner:
+      salt_version: 3001.7
+  - name: py3-stable-3002
+    provisioner:
+      salt_version: 3002
+  - name: latest
+    provisioner:
+      salt_version: latest
+
+verifier:
+  command: pytest --cache-clear -v -s -ra --log-cli-level=debug -k "not test_ping" tests/integration/

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,9 @@ log = logging.getLogger(__name__)
 
 @pytest.fixture(scope="session")
 def host():
-    if os.environ.get("KITCHEN_USERNAME") == "vagrant":
+    if os.environ.get("KITCHEN_USERNAME") == "vagrant" or "windows" in os.environ.get(
+        "KITCHEN_INSTANCE"
+    ):
         if "windows" in os.environ.get("KITCHEN_INSTANCE"):
             return testinfra.get_host(
                 "winrm://{KITCHEN_USERNAME}:{KITCHEN_PASSWORD}@{KITCHEN_HOSTNAME}:{KITCHEN_PORT}".format(

--- a/tests/integration/test_installation.py
+++ b/tests/integration/test_installation.py
@@ -1,25 +1,33 @@
 # -*- coding: utf-8 -*-
 import json
+import os
 import pytest
 import logging
 import pprint
+from contextlib import nullcontext
 
 log = logging.getLogger(__name__)
 
 
+def selected_context_manager(host):
+    if "windows" in os.environ.get("KITCHEN_INSTANCE"):
+        return nullcontext()
+    return host.sudo()
+
+
 def test_ping(host):
-    with host.sudo():
+    with selected_context_manager(host):
         assert host.salt("test.ping", "--timeout=120")
 
 
 def test_target_python_version(host, target_python_version):
-    with host.sudo():
+    with selected_context_manager(host):
         ret = host.salt("grains.item", "pythonversion", "--timeout=120")
         assert ret["pythonversion"][0] == target_python_version
 
 
 def test_target_salt_version(host, target_salt_version):
-    with host.sudo():
+    with selected_context_manager(host):
         ret = host.salt("grains.item", "saltversion", "--timeout=120")
         if target_salt_version.endswith(".0"):
             assert ret["saltversion"] == ".".join(target_salt_version.split(".")[:-1])


### PR DESCRIPTION
### What does this PR do?

Add CI testing employing the Windows runners provided by GitHub (2019 & 2016) using Kitchen's `proxy` driver.

Already using these in the SaltStack Formulas org (thanks to the excellent contributions made by @dafyddj) so proposing it here as well.

I'll use inline comments to mention any noteworthy points.