### PR TITLE
Add Ubuntu 21.04 support using Ubuntu 20.04 packages

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -436,7 +436,7 @@ Debian and derivatives
 ~~~~~~~~~~~~~~~~~~~~~~
 
 - Cumulus Linux 2/3
-- Debian GNU/Linux 7/8/9/10
+- Debian GNU/Linux 9/10
 - Devuan GNU/Linux 1/2
 - Kali Linux 1.0 (based on Debian 7)
 - Linux Mint Debian Edition 1 (based on Debian 8)
@@ -490,7 +490,7 @@ Ubuntu and derivatives
 
 - KDE neon (based on Ubuntu 18.04)
 - Linux Mint 17/18
-- Ubuntu 14.04/16.04/18.04 and subsequent non-LTS releases (see below)
+- Ubuntu 16.04/18.04/20.04 and subsequent non-LTS releases (see below)
 
 Ubuntu Best Effort Support: Non-LTS Releases
 ********************************************

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2907,7 +2907,8 @@ __enable_universe_repository() {
 
 __install_saltstack_ubuntu_repository() {
     # Workaround for latest non-LTS ubuntu
-    if { [ "$DISTRO_MAJOR_VERSION" -eq 20 ] && [ "$DISTRO_MINOR_VERSION" -eq 10 ]; }; then
+    if { [ "$DISTRO_MAJOR_VERSION" -eq 20 ] && [ "$DISTRO_MINOR_VERSION" -eq 10 ]; } || \
+       { [ "$DISTRO_MAJOR_VERSION" -eq 21 ] && [ "$DISTRO_MINOR_VERSION" -eq 04 ]; }; then
         echowarn "Non-LTS Ubuntu detected, but stable packages requested. Trying packages for previous LTS release. You may experience problems."
         UBUNTU_VERSION=20.04
         UBUNTU_CODENAME="focal"


### PR DESCRIPTION
### What does this PR do?
Adds support for Ubuntu 21.04 using Ubuntu 20.04 LTS repository packages

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-bootstrap/issues/1555

### Previous Behavior
Script will fail because it will not detect 21.04 as a non-LTS release, and will attempt to use a nonexistent repository for packages. 

### New Behavior
Script will succeed using the Ubuntu 20.04 saltstack repo. This is the expected behavior because non-LTS releases only get best-effort support using the previous LTS release's repositories
