### PR TITLE
Gentoo - relax setuptools version upper bound

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2739,9 +2739,14 @@ EOM
         echodebug "Installed pip version: $(${_pip_cmd} --version)"
     fi
 
-    # We also lock setuptools to <45 which is the latest release to support both py2 and py3
-    echodebug "Running '${_pip_cmd} install wheel setuptools>=${_MINIMUM_SETUPTOOLS_VERSION},<45'"
-    ${_pip_cmd} install ${_POST_NEON_PIP_INSTALL_ARGS} wheel "setuptools>=${_MINIMUM_SETUPTOOLS_VERSION},<45"
+    _setuptools_dep="setuptools>=${_MINIMUM_SETUPTOOLS_VERSION}"
+    if [ "$_PY_MAJOR_VERSION" -eq 2 ]; then
+        # We also lock setuptools to <45 which is the latest release to support both py2 and py3
+        _setuptools_dep="${_setuptools_dep},<45"
+    fi
+
+    echodebug "Running '${_pip_cmd} install wheel ${_setuptools_dep}'"
+    ${_pip_cmd} install ${_POST_NEON_PIP_INSTALL_ARGS} wheel "${_setuptools_dep}"
 
     echoinfo "Installing salt using ${_py_exe}"
     cd "${_SALT_GIT_CHECKOUT_DIR}" || return 1

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -89,13 +89,13 @@ platforms:
         - sed -i 's/^PubkeyAcceptedKeyTypes.*$/&,ssh-rsa/' /etc/crypto-policies/back-ends/opensshserver.config
   - name: gentoo
     driver_config:
-      image: ksmanis/stage3:latest
+      image: gentoo/stage3:latest
       run_command: /sbin/init
       provision_command:
         - rc-update add sshd default
   - name: gentoo-systemd
     driver_config:
-      image: ksmanis/stage3:systemd
+      image: gentoo/stage3:systemd
       run_command: /lib/systemd/systemd
       provision_command:
         - systemctl enable sshd.service


### PR DESCRIPTION
Signed-off-by: Ivo Jánský <ivo.jansky@gmail.com>

### What does this PR do?
Removes upper bound constraint on setuptools when using Python 3. The constraint is still enabled for Python 2 as setuptools-45 is the last version supporting both Python 2 and Python 3.

It fixes Arch and Gentoo git installation methods.
