### PR TITLE
Refactor `kitchen.yml` and update openSUSE Leap from `15.1` => `15.3`

### DIFF
--- a/kitchen.yml
+++ b/kitchen.yml
@@ -9,6 +9,7 @@ driver:
     - sys_admin
   disable_upstart: false
   use_internal_docker_network: false
+  run_command: /usr/lib/systemd/systemd
 
 provisioner:
   name: salt_solo
@@ -29,30 +30,22 @@ provisioner:
 
 platforms:
   - name: almalinux-8
-    driver_config:
-      run_command: /usr/lib/systemd/systemd
   - name: amazon-2
     driver_config:
       image: amazonlinux:2
       platform: rhel
-      run_command: /usr/lib/systemd/systemd
       provision_command:
         - yum -y install procps-ng
   - name: arch
     driver_config:
       image: archlinux/archlinux
-      run_command: /usr/lib/systemd/systemd
       provision_command:
         - pacman -Syu --noconfirm --needed systemd grep awk procps which
         - systemctl enable sshd
     provisioner:
       salt_bootstrap_options: -MPfq -D -y -x python2 git %s
   - name: centos-8
-    driver_config:
-      run_command: /usr/lib/systemd/systemd
   - name: centos-7
-    driver_config:
-      run_command: /usr/lib/systemd/systemd
   - name: debian-9
     driver_config:
       run_command: /lib/systemd/systemd
@@ -66,21 +59,18 @@ platforms:
   - name: fedora-33
     driver_config:
       image: fedora:33
-      run_command: /usr/lib/systemd/systemd
       provision_command:
         - dnf -y install procps-ng
         - sed -i 's/^PubkeyAcceptedKeyTypes.*$/&,ssh-rsa/' /etc/crypto-policies/back-ends/opensshserver.config
   - name: fedora-34
     driver_config:
       image: fedora:34
-      run_command: /usr/lib/systemd/systemd
       provision_command:
         - dnf -y install procps-ng
         - sed -i 's/^PubkeyAcceptedKeyTypes.*$/&,ssh-rsa/' /etc/crypto-policies/back-ends/opensshserver.config
   - name: fedora-35
     driver_config:
       image: fedora:35
-      run_command: /usr/lib/systemd/systemd
       provision_command:
         - dnf -y install procps-ng
         - sed -i 's/^PubkeyAcceptedKeyTypes.*$/&,ssh-rsa/' /etc/crypto-policies/back-ends/opensshserver.config
@@ -99,7 +89,6 @@ platforms:
   - name: opensuse-15
     driver_config:
       image: opensuse/leap:15.1
-      run_command: /usr/lib/systemd/systemd
       provision_command:
         - zypper --non-interactive install --auto-agree-with-licenses dbus-1
         - zypper --non-interactive install --auto-agree-with-licenses sudo openssh which curl
@@ -109,7 +98,6 @@ platforms:
   - name: opensuse-tumbleweed
     driver_config:
       image: opensuse/tumbleweed:latest
-      run_command: /usr/lib/systemd/systemd
       provision_command:
         - zypper --non-interactive install --auto-agree-with-licenses dbus-1
         - zypper --non-interactive install --auto-agree-with-licenses sudo openssh which curl systemd
@@ -117,15 +105,10 @@ platforms:
     provisioner:
       salt_bootstrap_options: -MPfq -y -x python3 git %s
   - name: oraclelinux-8
-    driver_config:
-      run_command: /usr/lib/systemd/systemd
   - name: oraclelinux-7
-    driver_config:
-      run_command: /usr/lib/systemd/systemd
   - name: rockylinux-8
     driver_config:
       image: rockylinux/rockylinux
-      run_command: /usr/lib/systemd/systemd
   - name: ubuntu-21.04
     driver_config:
       run_command: /lib/systemd/systemd

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -85,10 +85,10 @@ platforms:
         - systemctl enable sshd.service
   - name: opensuse-15
     driver_config:
-      image: opensuse/leap:15.1
+      image: opensuse/leap:15.3
       provision_command:
         - zypper --non-interactive install --auto-agree-with-licenses dbus-1
-        - zypper --non-interactive install --auto-agree-with-licenses sudo openssh which curl
+        - zypper --non-interactive install --auto-agree-with-licenses sudo openssh which curl systemd
         - systemctl enable sshd.service
     provisioner:
       salt_bootstrap_options: -MPfq -y -x python2 git %s

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -42,8 +42,6 @@ platforms:
       provision_command:
         - pacman -Syu --noconfirm --needed systemd grep awk procps which
         - systemctl enable sshd
-    provisioner:
-      salt_bootstrap_options: -MPfq -D -y -x python2 git %s
   - name: centos-8
   - name: centos-7
   - name: debian-9
@@ -90,8 +88,6 @@ platforms:
         - zypper --non-interactive install --auto-agree-with-licenses dbus-1
         - zypper --non-interactive install --auto-agree-with-licenses sudo openssh which curl systemd
         - systemctl enable sshd.service
-    provisioner:
-      salt_bootstrap_options: -MPfq -y -x python2 git %s
   - name: opensuse-tumbleweed
     driver:
       image: opensuse/tumbleweed:latest
@@ -99,8 +95,6 @@ platforms:
         - zypper --non-interactive install --auto-agree-with-licenses dbus-1
         - zypper --non-interactive install --auto-agree-with-licenses sudo openssh which curl systemd
         - systemctl enable sshd.service
-    provisioner:
-      salt_bootstrap_options: -MPfq -y -x python3 git %s
   - name: oraclelinux-8
   - name: oraclelinux-7
   - name: rockylinux-8

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -31,13 +31,13 @@ provisioner:
 platforms:
   - name: almalinux-8
   - name: amazon-2
-    driver_config:
+    driver:
       image: amazonlinux:2
       platform: rhel
       provision_command:
         - yum -y install procps-ng
   - name: arch
-    driver_config:
+    driver:
       image: archlinux/archlinux
       provision_command:
         - pacman -Syu --noconfirm --needed systemd grep awk procps which
@@ -47,44 +47,44 @@ platforms:
   - name: centos-8
   - name: centos-7
   - name: debian-9
-    driver_config:
+    driver:
       run_command: /lib/systemd/systemd
   - name: debian-10
-    driver_config:
+    driver:
       run_command: /lib/systemd/systemd
   - name: debian-11
-    driver_config:
+    driver:
       image: debian:bullseye
       run_command: /lib/systemd/systemd
   - name: fedora-33
-    driver_config:
+    driver:
       provision_command:
         - dnf -y install procps-ng
         - sed -i 's/^PubkeyAcceptedKeyTypes.*$/&,ssh-rsa/' /etc/crypto-policies/back-ends/opensshserver.config
   - name: fedora-34
-    driver_config:
+    driver:
       provision_command:
         - dnf -y install procps-ng
         - sed -i 's/^PubkeyAcceptedKeyTypes.*$/&,ssh-rsa/' /etc/crypto-policies/back-ends/opensshserver.config
   - name: fedora-35
-    driver_config:
+    driver:
       provision_command:
         - dnf -y install procps-ng
         - sed -i 's/^PubkeyAcceptedKeyTypes.*$/&,ssh-rsa/' /etc/crypto-policies/back-ends/opensshserver.config
   - name: gentoo
-    driver_config:
+    driver:
       image: gentoo/stage3:latest
       run_command: /sbin/init
       provision_command:
         - rc-update add sshd default
   - name: gentoo-systemd
-    driver_config:
+    driver:
       image: gentoo/stage3:systemd
       run_command: /lib/systemd/systemd
       provision_command:
         - systemctl enable sshd.service
   - name: opensuse-15
-    driver_config:
+    driver:
       image: opensuse/leap:15.3
       provision_command:
         - zypper --non-interactive install --auto-agree-with-licenses dbus-1
@@ -93,7 +93,7 @@ platforms:
     provisioner:
       salt_bootstrap_options: -MPfq -y -x python2 git %s
   - name: opensuse-tumbleweed
-    driver_config:
+    driver:
       image: opensuse/tumbleweed:latest
       provision_command:
         - zypper --non-interactive install --auto-agree-with-licenses dbus-1
@@ -104,16 +104,16 @@ platforms:
   - name: oraclelinux-8
   - name: oraclelinux-7
   - name: rockylinux-8
-    driver_config:
+    driver:
       image: rockylinux/rockylinux
   - name: ubuntu-21.04
-    driver_config:
+    driver:
       run_command: /lib/systemd/systemd
   - name: ubuntu-20.04
-    driver_config:
+    driver:
       run_command: /lib/systemd/systemd
   - name: ubuntu-18.04
-    driver_config:
+    driver:
       run_command: /lib/systemd/systemd
 
 suites:

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -58,19 +58,16 @@ platforms:
       run_command: /lib/systemd/systemd
   - name: fedora-33
     driver_config:
-      image: fedora:33
       provision_command:
         - dnf -y install procps-ng
         - sed -i 's/^PubkeyAcceptedKeyTypes.*$/&,ssh-rsa/' /etc/crypto-policies/back-ends/opensshserver.config
   - name: fedora-34
     driver_config:
-      image: fedora:34
       provision_command:
         - dnf -y install procps-ng
         - sed -i 's/^PubkeyAcceptedKeyTypes.*$/&,ssh-rsa/' /etc/crypto-policies/back-ends/opensshserver.config
   - name: fedora-35
     driver_config:
-      image: fedora:35
       provision_command:
         - dnf -y install procps-ng
         - sed -i 's/^PubkeyAcceptedKeyTypes.*$/&,ssh-rsa/' /etc/crypto-policies/back-ends/opensshserver.config

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -56,19 +56,15 @@ platforms:
       run_command: /lib/systemd/systemd
   - name: fedora-33
     driver:
-      provision_command:
+      provision_command: &fedora_provision_command
         - dnf -y install procps-ng
         - sed -i 's/^PubkeyAcceptedKeyTypes.*$/&,ssh-rsa/' /etc/crypto-policies/back-ends/opensshserver.config
   - name: fedora-34
     driver:
-      provision_command:
-        - dnf -y install procps-ng
-        - sed -i 's/^PubkeyAcceptedKeyTypes.*$/&,ssh-rsa/' /etc/crypto-policies/back-ends/opensshserver.config
+      provision_command: *fedora_provision_command
   - name: fedora-35
     driver:
-      provision_command:
-        - dnf -y install procps-ng
-        - sed -i 's/^PubkeyAcceptedKeyTypes.*$/&,ssh-rsa/' /etc/crypto-policies/back-ends/opensshserver.config
+      provision_command: *fedora_provision_command
   - name: gentoo
     driver:
       image: gentoo/stage3:latest
@@ -84,17 +80,14 @@ platforms:
   - name: opensuse-15
     driver:
       image: opensuse/leap:15.3
-      provision_command:
+      provision_command: &opensuse_provision_command
         - zypper --non-interactive install --auto-agree-with-licenses dbus-1
         - zypper --non-interactive install --auto-agree-with-licenses sudo openssh which curl systemd
         - systemctl enable sshd.service
   - name: opensuse-tumbleweed
     driver:
       image: opensuse/tumbleweed:latest
-      provision_command:
-        - zypper --non-interactive install --auto-agree-with-licenses dbus-1
-        - zypper --non-interactive install --auto-agree-with-licenses sudo openssh which curl systemd
-        - systemctl enable sshd.service
+      provision_command: *opensuse_provision_command
   - name: oraclelinux-8
   - name: oraclelinux-7
   - name: rockylinux-8


### PR DESCRIPTION
### What does this PR do?

Clean up `kitchen.yml`, including less duplication and modernisation:

* Use the most common `run_command` of `/usr/lib/systemd/systemd` as a general setting.
* Remove unnecessary entries:
  - `image` for Fedora.
  - `salt_bootstrap_options` for openSUSE and Arch Linux.
* Use `driver` instead of `driver_config`:
  - https://github.com/test-kitchen/kitchen-azurerm/issues/69
  - https://github.com/test-kitchen/kitchen-azurerm/commit/55b768d0b3a32492c5f29b70e9490dc0be9f9570
* Update openSUSE Leap platform from `15.1` to `15.3`.
* Use YAML node anchors to remove further duplication:
  - Both Fedora and openSUSE `provision_command` entries are all duplicates that have been DRYed.

I kept the YAML node anchors change as a separate commit in case it needs to be removed; understandably, some folks prefer to avoid them.
