### PR TITLE
ci(almalinux-8): add testing for `3003`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,6 +44,144 @@ jobs:
           shellcheck -s sh -f tty bootstrap-salt.sh
 
 
+  py3-stable-3003-almalinux-8:
+    name: AlmaLinux 8 v3003 Py3 Stable
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    needs: lint
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Setup Ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 2.6.x
+
+      - name: Install Bundler
+        run: |
+          gem install bundler
+
+      - name: Setup Bundle
+        run: |
+          bundle install --with docker --without opennebula ec2 windows vagrant
+
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+
+      - name: Install Python Dependencies
+        run: |
+          pip install -U pip
+          pip install -r tests/requirements.txt
+
+      - name: Create Test Container
+        run: |
+          bundle exec kitchen create py3-stable-3003-almalinux-8 || bundle exec kitchen create py3-stable-3003-almalinux-8
+
+      - name: Test Bootstrap In Test Container
+        run: |
+          bundle exec kitchen verify py3-stable-3003-almalinux-8
+
+      - name: Destroy Test Container
+        if: always()
+        run: |
+          bundle exec kitchen destroy py3-stable-3003-almalinux-8
+
+
+  py3-git-3003-almalinux-8:
+    name: AlmaLinux 8 v3003 Py3 Git
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    needs: lint
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Setup Ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 2.6.x
+
+      - name: Install Bundler
+        run: |
+          gem install bundler
+
+      - name: Setup Bundle
+        run: |
+          bundle install --with docker --without opennebula ec2 windows vagrant
+
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+
+      - name: Install Python Dependencies
+        run: |
+          pip install -U pip
+          pip install -r tests/requirements.txt
+
+      - name: Create Test Container
+        run: |
+          bundle exec kitchen create py3-git-3003-almalinux-8 || bundle exec kitchen create py3-git-3003-almalinux-8
+
+      - name: Test Bootstrap In Test Container
+        run: |
+          bundle exec kitchen verify py3-git-3003-almalinux-8
+
+      - name: Destroy Test Container
+        if: always()
+        run: |
+          bundle exec kitchen destroy py3-git-3003-almalinux-8
+
+
+  py3-stable-3003-0-almalinux-8:
+    name: AlmaLinux 8 v3003.0 Py3 Stable
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    needs: lint
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Setup Ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 2.6.x
+
+      - name: Install Bundler
+        run: |
+          gem install bundler
+
+      - name: Setup Bundle
+        run: |
+          bundle install --with docker --without opennebula ec2 windows vagrant
+
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+
+      - name: Install Python Dependencies
+        run: |
+          pip install -U pip
+          pip install -r tests/requirements.txt
+
+      - name: Create Test Container
+        run: |
+          bundle exec kitchen create py3-stable-3003-0-almalinux-8 || bundle exec kitchen create py3-stable-3003-0-almalinux-8
+
+      - name: Test Bootstrap In Test Container
+        run: |
+          bundle exec kitchen verify py3-stable-3003-0-almalinux-8
+
+      - name: Destroy Test Container
+        if: always()
+        run: |
+          bundle exec kitchen destroy py3-stable-3003-0-almalinux-8
+
+
   py3-git-master-almalinux-8:
     name: AlmaLinux 8 Master Py3 Git
     runs-on: ubuntu-latest

--- a/.github/workflows/templates/generate.py
+++ b/.github/workflows/templates/generate.py
@@ -31,6 +31,7 @@ LINUX_DISTROS = [
 OSX = WINDOWS = []
 
 STABLE_DISTROS = [
+    "almalinux-8",
     "amazon-2",
     "centos-7",
     "centos-8",
@@ -112,12 +113,10 @@ BLACKLIST_3002_0 = [
 ]
 
 BLACKLIST_3003 = [
-    "almalinux-8",
     "rockylinux-8",
 ]
 
 BLACKLIST_3003_0 = [
-    "almalinux-8",
     "amazon-2",
     "gentoo",
     "gentoo-systemd",


### PR DESCRIPTION
### What does this PR do?

[Support for AlmaLinux](https://github.com/saltstack/salt/pull/59404) was added in [`3003`](https://github.com/saltstack/salt/blame/527b0c1182cb581cd1f635f01386044b6df64341/doc/topics/releases/3003.rst#L46).  This testing should have been included by #1566.

Realised this while testing updates for the [salt-image-builder](https://gitlab.com/myii/salt-image-builder/-/pipelines/353564588) and got clarification from @whytewolf in Slack.