### PR TITLE
don't output info if using the default -x value

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -691,7 +691,9 @@ if [ -n "$_PY_EXE" ]; then
         exit 1
     fi
 
-    echoinfo "Detected -x option. Using $_PY_EXE to install Salt."
+    if [ "$_PY_EXE" != "python3" ]; then
+        echoinfo "Detected -x option. Using $_PY_EXE to install Salt."
+    fi
 else
     _PY_PKG_VER=""
     _PY_MAJOR_VERSION=""


### PR DESCRIPTION
### What does this PR do?
gets rid of the message

```
 *  INFO: Detected -x option. Using python3 to install Salt.
 ```
 if they are using the default value
