### PR TITLE
ci(kitchen): add `ssh-rsa` to `PubkeyAcceptedAlgorithms` on Arch Linux

### DIFF
--- a/kitchen.yml
+++ b/kitchen.yml
@@ -42,6 +42,7 @@ platforms:
       provision_command:
         - pacman -Syu --noconfirm --needed systemd grep awk procps which
         - systemctl enable sshd
+        - echo "PubkeyAcceptedAlgorithms +ssh-rsa" | tee -a /etc/ssh/sshd_config
   - name: centos-8
   - name: centos-7
   - name: debian-9


### PR DESCRIPTION
### What does this PR do?

Similar to the situation on Fedora:

https://github.com/saltstack/salt-bootstrap/blob/c5a55a3fbbe668de03239751dd60e8c27538b2d3/kitchen.yml#L61

Now needed for Arch Linux, which is coming with a newer version of OpenSSH.

Avoids the following issue:

```
       Waiting for SSH service on localhost:49153, retrying in 3 seconds
       Waiting for SSH service on localhost:49153, retrying in 3 seconds
       Waiting for SSH service on localhost:49153, retrying in 3 seconds
       Waiting for SSH service on localhost:49153, retrying in 3 seconds
       Waiting for SSH service on localhost:49153, retrying in 3 seconds
       Waiting for SSH service on localhost:49153, retrying in 3 seconds
       Waiting for SSH service on localhost:49153, retrying in 3 seconds
       Waiting for SSH service on localhost:49153, retrying in 3 seconds
       Waiting for SSH service on localhost:49153, retrying in 3 seconds
       Waiting for SSH service on localhost:49153, retrying in 3 seconds
       Waiting for SSH service on localhost:49153, retrying in 3 seconds
       Waiting for SSH service on localhost:49153, retrying in 3 seconds
```

* https://github.com/myii/salt-bootstrap/runs/3770849266?check_suite_focus=true (before)
* https://github.com/myii/salt-bootstrap/runs/3770963064?check_suite_focus=true (after)