### PR TITLE
Fix git master install on alpine 3.12+

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -5011,8 +5011,8 @@ install_alpine_linux_git_deps() {
             fi
         fi
     else
-        apk -U add python2 py2-pip py2-setuptools || return 1
-        _PY_EXE=python2
+        apk -U add python3 python3-dev py3-pip py3-setuptools g++ linux-headers zeromq-dev || return 1
+        _PY_EXE=python3
         return 0
     fi
 


### PR DESCRIPTION
### What does this PR do?
With default version 3003.3, you run into below issue
If you want to install from git master, it fails because py2-pip is unavailable - Alpine 3.11 was the last version to include py2-pip
This PR changes the git master process to python3 and adds all requirements for a successful build

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/55159
https://github.com/saltstack/salt/pull/60811
