### PR TITLE
ci(centos-stream8): add platform

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1884,6 +1884,236 @@ jobs:
           bundle exec kitchen destroy latest-centos-8
 
 
+  py3-stable-3003-centos-stream8:
+    name: CentOS Stream 8 v3003 Py3 Stable
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    needs: lint
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Setup Ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 2.6.x
+
+      - name: Install Bundler
+        run: |
+          gem install bundler
+
+      - name: Setup Bundle
+        run: |
+          bundle install --with docker --without opennebula ec2 windows vagrant
+
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+
+      - name: Install Python Dependencies
+        run: |
+          pip install -U pip
+          pip install -r tests/requirements.txt
+
+      - name: Create Test Container
+        run: |
+          bundle exec kitchen create py3-stable-3003-centos-stream8 || bundle exec kitchen create py3-stable-3003-centos-stream8
+
+      - name: Test Bootstrap In Test Container
+        run: |
+          bundle exec kitchen verify py3-stable-3003-centos-stream8
+
+      - name: Destroy Test Container
+        if: always()
+        run: |
+          bundle exec kitchen destroy py3-stable-3003-centos-stream8
+
+
+  py3-git-3003-centos-stream8:
+    name: CentOS Stream 8 v3003 Py3 Git
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    needs: lint
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Setup Ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 2.6.x
+
+      - name: Install Bundler
+        run: |
+          gem install bundler
+
+      - name: Setup Bundle
+        run: |
+          bundle install --with docker --without opennebula ec2 windows vagrant
+
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+
+      - name: Install Python Dependencies
+        run: |
+          pip install -U pip
+          pip install -r tests/requirements.txt
+
+      - name: Create Test Container
+        run: |
+          bundle exec kitchen create py3-git-3003-centos-stream8 || bundle exec kitchen create py3-git-3003-centos-stream8
+
+      - name: Test Bootstrap In Test Container
+        run: |
+          bundle exec kitchen verify py3-git-3003-centos-stream8
+
+      - name: Destroy Test Container
+        if: always()
+        run: |
+          bundle exec kitchen destroy py3-git-3003-centos-stream8
+
+
+  py3-stable-3003-0-centos-stream8:
+    name: CentOS Stream 8 v3003.0 Py3 Stable
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    needs: lint
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Setup Ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 2.6.x
+
+      - name: Install Bundler
+        run: |
+          gem install bundler
+
+      - name: Setup Bundle
+        run: |
+          bundle install --with docker --without opennebula ec2 windows vagrant
+
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+
+      - name: Install Python Dependencies
+        run: |
+          pip install -U pip
+          pip install -r tests/requirements.txt
+
+      - name: Create Test Container
+        run: |
+          bundle exec kitchen create py3-stable-3003-0-centos-stream8 || bundle exec kitchen create py3-stable-3003-0-centos-stream8
+
+      - name: Test Bootstrap In Test Container
+        run: |
+          bundle exec kitchen verify py3-stable-3003-0-centos-stream8
+
+      - name: Destroy Test Container
+        if: always()
+        run: |
+          bundle exec kitchen destroy py3-stable-3003-0-centos-stream8
+
+
+  py3-git-master-centos-stream8:
+    name: CentOS Stream 8 Master Py3 Git
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    needs: lint
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Setup Ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 2.6.x
+
+      - name: Install Bundler
+        run: |
+          gem install bundler
+
+      - name: Setup Bundle
+        run: |
+          bundle install --with docker --without opennebula ec2 windows vagrant
+
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+
+      - name: Install Python Dependencies
+        run: |
+          pip install -U pip
+          pip install -r tests/requirements.txt
+
+      - name: Create Test Container
+        run: |
+          bundle exec kitchen create py3-git-master-centos-stream8 || bundle exec kitchen create py3-git-master-centos-stream8
+
+      - name: Test Bootstrap In Test Container
+        run: |
+          bundle exec kitchen verify py3-git-master-centos-stream8
+
+      - name: Destroy Test Container
+        if: always()
+        run: |
+          bundle exec kitchen destroy py3-git-master-centos-stream8
+
+
+  latest-centos-stream8:
+    name: CentOS Stream 8 Latest packaged release
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    needs: lint
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Setup Ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 2.6.x
+
+      - name: Install Bundler
+        run: |
+          gem install bundler
+
+      - name: Setup Bundle
+        run: |
+          bundle install --with docker --without opennebula ec2 windows vagrant
+
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+
+      - name: Install Python Dependencies
+        run: |
+          pip install -U pip
+          pip install -r tests/requirements.txt
+
+      - name: Create Test Container
+        run: |
+          bundle exec kitchen create latest-centos-stream8 || bundle exec kitchen create latest-centos-stream8
+
+      - name: Test Bootstrap In Test Container
+        run: |
+          bundle exec kitchen verify latest-centos-stream8
+
+      - name: Destroy Test Container
+        if: always()
+        run: |
+          bundle exec kitchen destroy latest-centos-stream8
+
+
   py3-stable-3001-debian-10:
     name: Debian 10 v3001 Py3 Stable
     runs-on: ubuntu-latest

--- a/.github/workflows/templates/generate.py
+++ b/.github/workflows/templates/generate.py
@@ -11,6 +11,7 @@ LINUX_DISTROS = [
     "arch",
     "centos-7",
     "centos-8",
+    "centos-stream8",
     "debian-10",
     "debian-11",
     "debian-9",
@@ -36,6 +37,7 @@ STABLE_DISTROS = [
     "amazon-2",
     "centos-7",
     "centos-8",
+    "centos-stream8",
     "debian-10",
     "debian-11",
     "debian-9",
@@ -54,6 +56,7 @@ STABLE_DISTROS = [
 
 BLACKLIST_3001 = [
     "almalinux-8",
+    "centos-stream8",
     "debian-11",
     "rockylinux-8",
     "ubuntu-2104",
@@ -62,6 +65,7 @@ BLACKLIST_3001 = [
 BLACKLIST_3001_0 = [
     "almalinux-8",
     "amazon-2",
+    "centos-stream8",
     "debian-11",
     "gentoo",
     "gentoo-systemd",
@@ -71,12 +75,14 @@ BLACKLIST_3001_0 = [
 
 BLACKLIST_3002 = [
     "almalinux-8",
+    "centos-stream8",
     "rockylinux-8",
 ]
 
 BLACKLIST_3002_0 = [
     "almalinux-8",
     "amazon-2",
+    "centos-stream8",
     "debian-11",
     "gentoo",
     "gentoo-systemd",
@@ -129,6 +135,7 @@ DISTRO_DISPLAY_NAMES = {
     "arch": "Arch",
     "centos-7": "CentOS 7",
     "centos-8": "CentOS 8",
+    "centos-stream8": "CentOS Stream 8",
     "debian-10": "Debian 10",
     "debian-11": "Debian 11",
     "debian-9": "Debian 9",

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -43,6 +43,9 @@ platforms:
         - pacman -Syu --noconfirm --needed systemd grep awk procps which
         - systemctl enable sshd
         - echo "PubkeyAcceptedAlgorithms +ssh-rsa" | tee -a /etc/ssh/sshd_config
+  - name: centos-stream8
+    driver:
+      image: quay.io/centos/centos:stream8
   - name: centos-8
   - name: centos-7
   - name: debian-9


### PR DESCRIPTION
### What does this PR do?

Add CentOS Stream 8 to the CI.

* We had a PR come through for adding CentOS Stream 8 configuration to the `systemd-formula`.
  - https://github.com/saltstack-formulas/systemd-formula/pull/71
* Found the Stream base images available on quay.io.
  - https://quay.io/repository/centos/centos?tab=tags
* Built some pre-salted images using our `salt-image-builder` to test the across formulas but to also identify the differences compared to the standard CentOS 8 image.
  - https://pastebin.com/0jiqMN7s -- the diff shows that there is a fairly significant difference between the base images.
  - Also did a comparison with the `centos:8` base image available in quay.io but that appears to be near-identical to the one in Docker Hub.
* Checked for when support for this platform was added to Salt.
  - https://github.com/saltstack/salt/commit/94a080a21deabb996bf1795017b13fe149dfa038 -- `v3004rc1 v3003.3 v3003.2 v3003.1 v3003 v3003rc1 v3003_docs`.
  - Set the blacklist in this PR accordingly.
