### PR TITLE
Add support for Raspbian 11

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1492,6 +1492,7 @@ __debian_derivatives_translation() {
     raspbian_8_debian_base="8.0"
     raspbian_9_debian_base="9.0"
     raspbian_10_debian_base="10.0"
+    raspbian_11_debian_base="11.0"
     bunsenlabs_9_debian_base="9.0"
     turnkey_9_debian_base="9.0"
 


### PR DESCRIPTION
Tested on my Raspberry Pi.

### What does this PR do?

Add support for Raspbian 11.

### What issues does this PR fix or reference?

n/a

### Previous Behavior

```
 *  INFO: Running version: 2021.09.17
 *  INFO: Executed by: 
 *  INFO: Command line: '/root/bootstrap-salt.sh [...]'

 *  INFO: System Information:
 *  INFO:   CPU:          
 *  INFO:   CPU Arch:     armv6l
 *  INFO:   OS Name:      Linux
 *  INFO:   OS Version:   5.10.63+
 *  INFO:   Distribution: Raspbian 11

 *  INFO: Installing minion
 *  INFO: Found function config_salt
 *  INFO: Found function preseed_master
 *  INFO: Found function daemons_running
 * ERROR: No dependencies installation function found. Exiting...
 ```

### New Behavior

Correct installation.