### PR TITLE
bootstrap-salt.ps1: Keep all command-line parameters when UAC is enabled

### DIFF
--- a/bootstrap-salt.ps1
+++ b/bootstrap-salt.ps1
@@ -138,6 +138,7 @@ If (!(Get-IsAdministrator)) {
             $parameters = "$parameters -{0} '{1}'" -f $boundParam.Key, $boundParam.Value
         }
         $newProcess.Arguments = $myInvocation.MyCommand.Definition, $parameters
+
         # Specify the current working directory
         $newProcess.WorkingDirectory = "$script_path"
 

--- a/bootstrap-salt.ps1
+++ b/bootstrap-salt.ps1
@@ -133,13 +133,11 @@ If (!(Get-IsAdministrator)) {
 
         # Specify the current script path and name as a parameter`
         $parameters = ""
-        If($minion -ne "not-specified") {$parameters = "-minion $minion"}
-        If($master -ne "not-specified") {$parameters = "$parameters -master $master"}
-        If($runservice -eq $false) {$parameters = "$parameters -runservice false"}
-        If($version -ne '') {$parameters = "$parameters -version $version"}
-        If($pythonVersion -ne "") {$parameters = "$parameters -pythonVersion $pythonVersion"}
+        foreach ($boundParam in $PSBoundParameters.GetEnumerator())
+        {
+            $parameters = "$parameters -{0} '{1}'" -f $boundParam.Key, $boundParam.Value
+        }
         $newProcess.Arguments = $myInvocation.MyCommand.Definition, $parameters
-
         # Specify the current working directory
         $newProcess.WorkingDirectory = "$script_path"
 


### PR DESCRIPTION
### What does this PR do?
See title

### What issues does this PR fix or reference?
Fixes #61246

### New Behavior
The --repourl, --ConfigureOnly and all other parameters will work on Windows when UAC is enabled. 

### Tested on
I tested this change against Windows 2012R2 and Windows 2019.
 