### PR TITLE
ci(proxy): fix setting up WinRM

### DIFF
--- a/.github/workflows/kitchen.windows.yml
+++ b/.github/workflows/kitchen.windows.yml
@@ -74,10 +74,8 @@ jobs:
           New-LocalUser $env:machine_user -Password $password
           Add-LocalGroupMember -Group "Administrators" -Member $env:machine_user
       - name: 'Set up WinRM'
-        run: >
-          Set-WSManQuickConfig -Force;
-          Set-WSManInstance -ResourceURI winrm/config/service
-          -ValueSet @{AllowUnencrypted="true"}
+        run: |
+          Set-WSManQuickConfig -Force
       - name: 'Run Bundler'
         run: |
           ruby --version
@@ -131,10 +129,8 @@ jobs:
           New-LocalUser $env:machine_user -Password $password
           Add-LocalGroupMember -Group "Administrators" -Member $env:machine_user
       - name: 'Set up WinRM'
-        run: >
-          Set-WSManQuickConfig -Force;
-          Set-WSManInstance -ResourceURI winrm/config/service
-          -ValueSet @{AllowUnencrypted="true"}
+        run: |
+          Set-WSManQuickConfig -Force
       - name: 'Run Bundler'
         run: |
           ruby --version

--- a/kitchen.windows.yml
+++ b/kitchen.windows.yml
@@ -29,6 +29,7 @@ suites:
   - name: latest
     provisioner:
       salt_version: latest
+      salt_call_command: c:\Program Files\Salt Project\Salt\salt-call.bat
 
 verifier:
   command: pytest --cache-clear -v -s -ra --log-cli-level=debug -k "not test_ping" tests/integration/


### PR DESCRIPTION
### What does this PR do?

Fixes the CI for Windows `proxy`-based testing.  Here's an example of the currently broken CI:

* https://github.com/saltstack/salt-bootstrap/actions/runs/1575784507

Same fix as provided (by @dafyddj) for the SaltStack Formulas organisation:

* https://github.com/myii/ssf-formula/pull/392

Already tested in my fork:

* https://github.com/myii/salt-bootstrap/actions/runs/1596639339