### PR TITLE
ci(freebsd): replace `12.2` with newly released `12.3` box

### DIFF
--- a/.github/workflows/kitchen.vagrant.yml
+++ b/.github/workflows/kitchen.vagrant.yml
@@ -42,19 +42,19 @@ jobs:
       matrix:
         instance:
           - py3-git-3001-freebsd-130
-          - py3-git-3001-freebsd-122
+          - py3-git-3001-freebsd-123
           # - py3-git-3001-openbsd-6
           - py3-git-3002-freebsd-130
-          - py3-git-3002-freebsd-122
+          - py3-git-3002-freebsd-123
           # - py3-git-3002-openbsd-6
           - py3-git-3003-freebsd-130
-          - py3-git-3003-freebsd-122
+          - py3-git-3003-freebsd-123
           # - py3-git-3003-openbsd-6
           - py3-git-master-freebsd-130
-          - py3-git-master-freebsd-122
+          - py3-git-master-freebsd-123
           # - py3-git-master-openbsd-6
           - latest-freebsd-130
-          - latest-freebsd-122
+          - latest-freebsd-123
           - latest-openbsd-6
     steps:
       - name: 'Check out code'

--- a/.github/workflows/kitchen.windows.yml
+++ b/.github/workflows/kitchen.windows.yml
@@ -36,18 +36,18 @@ jobs:
       - name: 'ShellCheck'
         run: |
           shellcheck -s sh -f tty bootstrap-salt.sh
-  test-2019:
-    runs-on: 'windows-2019'
+  test-2022:
+    runs-on: 'windows-2022'
     timeout-minutes: 20
     needs: 'lint'
     strategy:
       fail-fast: false
       matrix:
         instance:
-          - py3-stable-3001-windows-2019
-          - py3-stable-3002-windows-2019
-          - py3-stable-3003-windows-2019
-          - latest-windows-2019
+          - py3-stable-3001-windows-2022
+          - py3-stable-3002-windows-2022
+          - py3-stable-3003-windows-2022
+          - latest-windows-2022
     steps:
       - name: 'Check out code'
         uses: 'actions/checkout@v2'
@@ -91,18 +91,18 @@ jobs:
           pip install -r tests/requirements.txt
       - name: 'Run Test Kitchen'
         run: 'bundle exec kitchen test ${{ matrix.instance }}'
-  test-2016:
-    runs-on: 'windows-2016'
+  test-2019:
+    runs-on: 'windows-2019'
     timeout-minutes: 20
     needs: 'lint'
     strategy:
       fail-fast: false
       matrix:
         instance:
-          - py3-stable-3001-windows-2016
-          - py3-stable-3002-windows-2016
-          - py3-stable-3003-windows-2016
-          - latest-windows-2016
+          - py3-stable-3001-windows-2019
+          - py3-stable-3002-windows-2019
+          - py3-stable-3003-windows-2019
+          - latest-windows-2019
     steps:
       - name: 'Check out code'
         uses: 'actions/checkout@v2'

--- a/kitchen.vagrant.yml
+++ b/kitchen.vagrant.yml
@@ -24,9 +24,9 @@ platforms:
   - name: freebsd-130
     driver:
       box: bento/freebsd-13.0
-  - name: freebsd-122
+  - name: freebsd-123
     driver:
-      box: bento/freebsd-12.2
+      box: bento/freebsd-12.3
   - name: openbsd-6
     driver:
       box: generic/openbsd6

--- a/kitchen.windows.yml
+++ b/kitchen.windows.yml
@@ -13,8 +13,8 @@ provisioner:
   init_environment: ''
 
 platforms:
+  - name: windows-2022
   - name: windows-2019
-  - name: windows-2016
 
 suites:
   - name: py3-stable-3001

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -141,7 +141,7 @@ suites:
       - gentoo-systemd
       - ubuntu-2104
       - freebsd-130
-      - freebsd-122
+      - freebsd-123
       - openbsd-6
   - name: py3-stable-3001
     provisioner:
@@ -154,7 +154,7 @@ suites:
       - arch
       - ubuntu-2104
       - freebsd-130
-      - freebsd-122
+      - freebsd-123
       - openbsd-6
   - name: py3-stable-3002-0
     provisioner:
@@ -169,7 +169,7 @@ suites:
       - gentoo
       - gentoo-systemd
       - freebsd-130
-      - freebsd-122
+      - freebsd-123
       - openbsd-6
   - name: py3-stable-3003-0
     provisioner:
@@ -183,7 +183,7 @@ suites:
       - gentoo
       - gentoo-systemd
       - freebsd-130
-      - freebsd-122
+      - freebsd-123
       - openbsd-6
   - name: py3-stable-3002
     provisioner:
@@ -194,7 +194,7 @@ suites:
       - opensuse-tumbleweed
       - arch
       - freebsd-130
-      - freebsd-122
+      - freebsd-123
       - openbsd-6
   - name: py3-stable-3003
     provisioner:
@@ -205,7 +205,7 @@ suites:
       - opensuse-tumbleweed
       - arch
       - freebsd-130
-      - freebsd-122
+      - freebsd-123
       - openbsd-6
   - name: py3-git-master
     provisioner:


### PR DESCRIPTION
### What does this PR do?

CI updates:

1. Replace FreeBSD 12.2 with 12.3:
    * https://app.vagrantup.com/bento/boxes/freebsd-12.3
1. Update the Windows `proxy`-based testing to use `windows-2022` instead of `windows-2016` (which will be deprecated soon):
    * https://github.com/actions/virtual-environments/issues/4312