### PR TITLE
ci(kitchen): add `ssh-rsa` to `PubkeyAcceptedAlgorithms` on Gentoo

### DIFF
--- a/kitchen.vagrant.yml
+++ b/kitchen.vagrant.yml
@@ -7,9 +7,15 @@ driver:
   customize:
     usbxhci: 'off'
   gui: false
-  linked_clone: true
   ssh:
     shell: /bin/sh
+  <% unless ENV['CI'] %>
+  linked_clone: true
+  synced_folders:
+    - - '.kitchen/kitchen-vagrant/%{instance_name}/vagrant'
+      - '/vagrant'
+      - 'create: true, disabled: false'
+  <% end %>
 
 provisioner:
   init_environment: |
@@ -32,6 +38,7 @@ platforms:
       box: generic/openbsd6
       ssh:
         shell: /bin/ksh
+      synced_folders: []
     provisioner:
       init_environment: |
         echo 'auto_accept: true' > /tmp/auto-accept-keys.conf

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -75,12 +75,14 @@ platforms:
       run_command: /sbin/init
       provision_command:
         - rc-update add sshd default
+        - echo "PubkeyAcceptedAlgorithms +ssh-rsa" | tee -a /etc/ssh/sshd_config
   - name: gentoo-systemd
     driver:
       image: gentoo/stage3:systemd
       run_command: /lib/systemd/systemd
       provision_command:
         - systemctl enable sshd.service
+        - echo "PubkeyAcceptedAlgorithms +ssh-rsa" | tee -a /etc/ssh/sshd_config
   - name: opensuse-15
     driver:
       image: opensuse/leap:15.3


### PR DESCRIPTION
### Additional commit

In addition to below, this PR also includes a commit to add conditional local settings for Vagrant, including `synced_folders`.

---

### What does this PR do?

Similar to the situation on Fedora, Arch and Tumbleweed (e.g. #1603).

Now needed for Gentoo, which is coming with a newer version of OpenSSH (`8.8`).

Avoids the following issue:

```
       Waiting for SSH service on localhost:49153, retrying in 3 seconds
       Waiting for SSH service on localhost:49153, retrying in 3 seconds
       Waiting for SSH service on localhost:49153, retrying in 3 seconds
       Waiting for SSH service on localhost:49153, retrying in 3 seconds
       Waiting for SSH service on localhost:49153, retrying in 3 seconds
       Waiting for SSH service on localhost:49153, retrying in 3 seconds
       Waiting for SSH service on localhost:49153, retrying in 3 seconds
       Waiting for SSH service on localhost:49153, retrying in 3 seconds
       Waiting for SSH service on localhost:49153, retrying in 3 seconds
       Waiting for SSH service on localhost:49153, retrying in 3 seconds
       Waiting for SSH service on localhost:49153, retrying in 3 seconds
       Waiting for SSH service on localhost:49153, retrying in 3 seconds
```

* https://github.com/myii/salt-bootstrap/actions/runs/1657030053 (before)
* https://github.com/myii/salt-bootstrap/actions/runs/1657063524 (after)