### PR TITLE
Bump version to 2022.03.15 release

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,6 +27,6 @@ repos:
 
       - id: shellcheck
         name: Run ShellCheck against bootstrap-salt.sh
-        entry: koalaman/shellcheck-alpine:v0.6.0 shellcheck -s sh -f tty
+        entry: koalaman/shellcheck-alpine:v0.7.0 shellcheck -s sh -f tty
         files: 'bootstrap-salt\.sh'
         language: docker_image

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,17 @@
 Version TBD (In Progress on the Develop Branch):
 
+Version 2022.03.15:
+	* Add detection and functions for AlmaLinux and Rocky Linux (myii) #1803
+	* Copy configs to correct config dirs (v3004+) (dafyddj) #1798
+	* Support Non-LTS Ubuntu 21.04 & 21.10 (blindpirate) #1793
+	* Use native repositories for Debian 11 (jpacura) #1615
+	* Keep all command-line parameters when UAC is enabled (Simon-TheUser) #1613
+	* Add support for Raspbian (Jille) #1612
+	* Add openrc to alpine:latest dependencies (krionbsd) #1609
+	* Add CentOS 7 base key (bryceml) #1608
+	* Fix git master install on alpine 3.12+ (Nascire) #1604
+	* Sort help alphabetically (krionbsd) #1601
+
 Version 2021.09.17:
 	* Re-add Ubuntu-16 support as it's still supported with 3001 and 3002 (krionbsd) #1594
 	* Add oncoming 3004 release (krionbsd) #1593

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -14,7 +14,7 @@
 #
 #          BUGS: https://github.com/saltstack/salt-bootstrap/issues
 #
-#     COPYRIGHT: (c) 2012-2021 by the SaltStack Team, see AUTHORS.rst for more
+#     COPYRIGHT: (c) 2012-2022 by the SaltStack Team, see AUTHORS.rst for more
 #                details.
 #
 #       LICENSE: Apache 2.0
@@ -23,7 +23,7 @@
 #======================================================================================================================
 set -o nounset                              # Treat unset variables as an error
 
-__ScriptVersion="2021.09.17"
+__ScriptVersion="2022.03.15"
 __ScriptName="bootstrap-salt.sh"
 
 __ScriptFullName="$0"


### PR DESCRIPTION
### What does this PR do?
Bump version to 2022.03.15 release

I had to update `.pre-commit-config` in order to support spellchecks for committing from M1 Macs.