### PR TITLE
feat(macos): add CI testing using Kitchen's `exec` driver

### DIFF
--- a/.github/workflows/kitchen.macos.yml
+++ b/.github/workflows/kitchen.macos.yml
@@ -1,0 +1,132 @@
+# yamllint disable rule:line-length
+---
+name: 'Kitchen (MacOS)'
+'on': ['push', 'pull_request']
+
+env:
+  KITCHEN_LOCAL_YAML: 'kitchen.macos.yml'
+
+jobs:
+  generate-actions-workflow:
+    name: 'Generate The Actions Workflow'
+    runs-on: 'ubuntu-latest'
+    steps:
+      - uses: 'actions/checkout@v1'
+      - name: 'Set up Python 3.7'
+        uses: 'actions/setup-python@v1'
+        with:
+          python-version: 3.7
+      - name: 'Install Pre-Commit'
+        run: |
+          pip install -U pip
+          pip install pre-commit
+          pre-commit install
+      - name: 'Generate Workflow Actions'
+        run: |
+          pre-commit run -av generate-actions-workflow
+  lint:
+    name: 'Lint'
+    runs-on: 'ubuntu-latest'
+    needs: 'generate-actions-workflow'
+    container: 'koalaman/shellcheck-alpine:v0.6.0'
+    steps:
+      - uses: 'actions/checkout@v1'
+      - name: 'ShellCheck'
+        run: |
+          shellcheck -s sh -f tty bootstrap-salt.sh
+  test-12:
+    runs-on: 'macos-12'
+    timeout-minutes: 20
+    needs: 'lint'
+    strategy:
+      fail-fast: false
+      matrix:
+        instance:
+          - latest-macos-12
+          - py3-stable-3004-macos-12
+          - py3-stable-3003-macos-12
+          - py3-stable-3002-macos-12
+    steps:
+      - name: 'Check out code'
+        uses: 'actions/checkout@v2'
+      - name: 'Set up Bundler cache'
+        uses: 'actions/cache@v1'
+        with:
+          path: 'vendor/bundle'
+          key: "${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}"
+          restore-keys: "${{ runner.os }}-gems-"
+      - name: 'Run Bundler'
+        run: |
+          ruby --version
+          bundle config path vendor/bundle
+          bundle install --jobs 4 --retry 3
+      - name: 'Install Python Dependencies'
+        run: |
+          pip3 install -U pip
+          pip3 install -r tests/requirements.txt
+      - name: 'Run Test Kitchen'
+        run: 'bundle exec kitchen test ${{ matrix.instance }}'
+  test-11:
+    runs-on: 'macos-11'
+    timeout-minutes: 20
+    needs: 'lint'
+    strategy:
+      fail-fast: false
+      matrix:
+        instance:
+          - latest-macos-11
+          - py3-stable-3004-macos-11
+          - py3-stable-3003-macos-11
+          - py3-stable-3002-macos-11
+    steps:
+      - name: 'Check out code'
+        uses: 'actions/checkout@v2'
+      - name: 'Set up Bundler cache'
+        uses: 'actions/cache@v1'
+        with:
+          path: 'vendor/bundle'
+          key: "${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}"
+          restore-keys: "${{ runner.os }}-gems-"
+      - name: 'Run Bundler'
+        run: |
+          ruby --version
+          bundle config path vendor/bundle
+          bundle install --jobs 4 --retry 3
+      - name: 'Install Python Dependencies'
+        run: |
+          pip3 install -U pip
+          pip3 install -r tests/requirements.txt
+      - name: 'Run Test Kitchen'
+        run: 'bundle exec kitchen test ${{ matrix.instance }}'
+  test-1015:
+    runs-on: 'macos-10.15'
+    timeout-minutes: 20
+    needs: 'lint'
+    strategy:
+      fail-fast: false
+      matrix:
+        instance:
+          - latest-macos-1015
+          - py3-stable-3004-macos-1015
+          - py3-stable-3003-macos-1015
+          - py3-stable-3002-macos-1015
+    steps:
+      - name: 'Check out code'
+        uses: 'actions/checkout@v2'
+      - name: 'Set up Bundler cache'
+        uses: 'actions/cache@v1'
+        with:
+          path: 'vendor/bundle'
+          key: "${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}"
+          restore-keys: "${{ runner.os }}-gems-"
+      - name: 'Run Bundler'
+        run: |
+          ruby --version
+          bundle config path vendor/bundle
+          bundle install --jobs 4 --retry 3
+      - name: 'Install Python Dependencies'
+        run: |
+          pip3 install -U pip
+          pip3 install -r tests/requirements.txt
+      - name: 'Run Test Kitchen'
+        run: 'bundle exec kitchen test ${{ matrix.instance }}'

--- a/kitchen.macos.yml
+++ b/kitchen.macos.yml
@@ -1,0 +1,36 @@
+---
+driver:
+  name: exec
+
+provisioner:
+  sudo: true
+  salt_bootstrap_options: -MP stable %s
+  salt_call_command: /opt/salt/bin/salt-call
+  init_environment: |
+    echo 'auto_accept: true' > /tmp/auto-accept-keys.conf
+    sudo mkdir -p /etc/salt/master.d
+    sudo mv /tmp/auto-accept-keys.conf /etc/salt/master.d/auto-accept-keys.conf
+    brew install coreutils
+    sh -c 't=$(gshuf -i 1-15 -n 1); echo Sleeping $t seconds; sleep $t'
+
+platforms:
+  - name: macos-12
+  - name: macos-11
+  - name: macos-1015
+
+suites:
+  - name: py3-stable-3002
+    provisioner:
+      salt_version: 3002.8
+  - name: py3-stable-3003
+    provisioner:
+      salt_version: 3003.4
+  - name: py3-stable-3004
+    provisioner:
+      salt_version: 3004.1
+  - name: latest
+    provisioner:
+      salt_version: latest
+
+verifier:
+  command: pytest --cache-clear -v -s -ra --log-cli-level=debug -k "not test_ping" tests/integration/

--- a/kitchen.vagrant.yml
+++ b/kitchen.vagrant.yml
@@ -9,8 +9,8 @@ driver:
   gui: false
   ssh:
     shell: /bin/sh
-  <% unless ENV['CI'] %>
   linked_clone: true
+  <% unless ENV['CI'] %>
   synced_folders:
     - - '.kitchen/kitchen-vagrant/%{instance_name}/vagrant'
       - '/vagrant'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,11 @@ log = logging.getLogger(__name__)
 
 @pytest.fixture(scope="session")
 def host():
+    if os.environ.get("RUNNER_OS", "") == "macOS":
+        # Adjust the `PATH` so that the `salt-call` executable can be found
+        os.environ["PATH"] = "/opt/salt/bin{}{}".format(os.pathsep, os.environ["PATH"])
+        return testinfra.get_host("local://", sudo=True)
+
     if os.environ.get("KITCHEN_USERNAME") == "vagrant" or "windows" in os.environ.get(
         "KITCHEN_INSTANCE"
     ):

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,4 @@
-testinfra
+pytest-testinfra
 paramiko
 pywinrm; sys.platform == 'win32'
 six>=1.10.0


### PR DESCRIPTION
### What does this PR do?

Similar to PRs #1548 & #1549.

Add CI testing for MacOS (Catalina 10.15, Big Sur 11 & Monterey 12) using Kitchen's `exec` driver.

Preparing these to use in the SaltStack Formulas org so proposing it here as well.

I'll use inline comments to mention any noteworthy points.

---

#### test(requirements): update `testinfra` => `pytest-testinfra`

This commit has been added to resolve this `DeprecationWarning`:

```console
/usr/local/lib/python3.9/site-packages/_testinfra_renamed.py:5:
DeprecationWarning: testinfra package has been renamed to pytest-testinfra.
Please `pip install pytest-testinfra` and `pip uninstall testinfra` and
update your package requirements to avoid this message
```
