### PR TITLE
ci(freebsd): replace `13.0` with newly released `13.1` box

### DIFF
--- a/.github/workflows/kitchen.vagrant.yml
+++ b/.github/workflows/kitchen.vagrant.yml
@@ -41,10 +41,10 @@ jobs:
       fail-fast: false
       matrix:
         instance:
-          - py3-git-master-freebsd-130
+          - py3-git-master-freebsd-131
           - py3-git-master-freebsd-123
           # - py3-git-master-openbsd-6
-          - latest-freebsd-130
+          - latest-freebsd-131
           - latest-freebsd-123
           - latest-openbsd-6
     steps:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,16 +10,17 @@ GEM
   specs:
     bcrypt_pbkdf (1.1.0)
     builder (3.2.4)
-    chef-utils (17.9.52)
+    chef-utils (17.10.0)
       concurrent-ruby
-    concurrent-ruby (1.1.9)
+    concurrent-ruby (1.1.10)
     ed25519 (1.3.0)
     erubi (1.10.0)
     ffi (1.15.5)
     gssapi (1.3.1)
       ffi (>= 1.0.1)
-    gyoku (1.3.1)
+    gyoku (1.4.0)
       builder (>= 2.1.2)
+      rexml (~> 3.0)
     hashie (5.0.0)
     httpclient (2.8.3)
     kitchen-salt (0.7.2)
@@ -33,14 +34,14 @@ GEM
       tty-box (~> 0.6)
       tty-prompt (~> 0.20)
     little-plugger (1.1.4)
-    logging (2.3.0)
+    logging (2.3.1)
       little-plugger (~> 1.1)
       multi_json (~> 1.14)
-    mixlib-install (3.12.16)
+    mixlib-install (3.12.19)
       mixlib-shellout
       mixlib-versioning
       thor
-    mixlib-shellout (3.2.5)
+    mixlib-shellout (3.2.7)
       chef-utils
     mixlib-versioning (1.2.12)
     multi_json (1.15.0)
@@ -52,6 +53,7 @@ GEM
     nori (2.6.0)
     pastel (0.8.0)
       tty-color (~> 0.5)
+    rexml (3.2.5)
     rubyntlm (0.6.3)
     rubyzip (2.3.2)
     strings (0.2.1)
@@ -74,7 +76,7 @@ GEM
       winrm-elevated (~> 1.0)
       winrm-fs (~> 1.1)
     thor (1.2.1)
-    tomlrb (2.0.1)
+    tomlrb (2.0.3)
     tty-box (0.7.0)
       pastel (~> 0.8)
       strings (~> 0.2.0)
@@ -112,7 +114,7 @@ GEM
     wisper (2.0.1)
 
 PLATFORMS
-  ruby
+  x86_64-linux
 
 DEPENDENCIES
   kitchen-docker!
@@ -121,4 +123,4 @@ DEPENDENCIES
   test-kitchen (>= 3.2.2)
 
 BUNDLED WITH
-   2.1.2
+   2.2.26

--- a/kitchen.vagrant.yml
+++ b/kitchen.vagrant.yml
@@ -27,9 +27,9 @@ provisioner:
   sudo: true
 
 platforms:
-  - name: freebsd-130
+  - name: freebsd-131
     driver:
-      box: bento/freebsd-13.0
+      box: bento/freebsd-13.1
   - name: freebsd-123
     driver:
       box: bento/freebsd-12.3

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -128,7 +128,7 @@ suites:
       - arch
       - gentoo
       - gentoo-systemd
-      - freebsd-130
+      - freebsd-131
       - freebsd-123
       - openbsd-6
   - name: py3-stable-3003-0
@@ -141,14 +141,14 @@ suites:
       - arch
       - gentoo
       - gentoo-systemd
-      - freebsd-130
+      - freebsd-131
       - freebsd-123
       - openbsd-6
     excludes:
       - opensuse-15
       - opensuse-tumbleweed
       - arch
-      - freebsd-130
+      - freebsd-131
       - freebsd-123
       - openbsd-6
   - name: py3-stable-3003
@@ -159,7 +159,7 @@ suites:
       - opensuse-15
       - opensuse-tumbleweed
       - arch
-      - freebsd-130
+      - freebsd-131
       - freebsd-123
       - openbsd-6
   - name: py3-stable-3004-0
@@ -172,7 +172,7 @@ suites:
       - arch
       - gentoo
       - gentoo-systemd
-      - freebsd-130
+      - freebsd-131
       - freebsd-123
       - openbsd-6
   - name: py3-stable-3004
@@ -183,7 +183,7 @@ suites:
       - opensuse-15
       - opensuse-tumbleweed
       - arch
-      - freebsd-130
+      - freebsd-131
       - freebsd-123
       - openbsd-6
   - name: py3-git-master

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ log = logging.getLogger(__name__)
 
 @pytest.fixture(scope="session")
 def host():
-    if os.environ.get("RUNNER_OS", "") == "macOS":
+    if os.environ.get("RUNNER_OS", "") == "macOS" and os.environ.get("KITCHEN_LOCAL_YAML", "") == "kitchen.macos.yml":
         # Adjust the `PATH` so that the `salt-call` executable can be found
         os.environ["PATH"] = "/opt/salt/bin{}{}".format(os.pathsep, os.environ["PATH"])
         return testinfra.get_host("local://", sudo=True)


### PR DESCRIPTION
### What does this PR do?

CI updates:

1. Replace FreeBSD 13.0 with 13.1:
    * https://app.vagrantup.com/bento/boxes/freebsd-13.1
2. Commit: test(conftest): adjust `PATH` on macOS jobs only (not Vagrant)
    * Noticed that the FreeBSD `git` jobs have been failing.
    * Realised that checking for a `macOS` runner wasn't sufficient, since that's used for both macOS and Vagrant-based testing -- so included a check for the specific `KITCHEN_LOCAL_YAML` being used as well.
3. Commit: chore(gemfile.lock): update to latest gem versions
    * As mentioned in the commit message.