### PR TITLE
feat: add support and update CI for openSUSE Leap 15.4

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -6614,7 +6614,7 @@ install_opensuse_git_deps() {
         fi
     # Check for Tumbleweed
     elif [ "${DISTRO_MAJOR_VERSION}" -ge 20210101 ]; then
-        __PACKAGES="python3-pip"
+        __PACKAGES="python3-pip gcc-c++ python310-pyzmq-devel"
     else
         __PACKAGES="python-pip python-setuptools gcc"
     fi

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -6463,6 +6463,8 @@ __set_suse_pkg_repo() {
     # Set distro repo variable
     if [ "${DISTRO_MAJOR_VERSION}" -gt 2015 ]; then
         DISTRO_REPO="openSUSE_Tumbleweed"
+    elif [ "${DISTRO_MAJOR_VERSION}" -eq 15 ] && [ "${DISTRO_MINOR_VERSION}" -ge 4 ]; then
+        DISTRO_REPO="${DISTRO_MAJOR_VERSION}.${DISTRO_MINOR_VERSION}"
     elif [ "${DISTRO_MAJOR_VERSION}" -ge 42 ] || [ "${DISTRO_MAJOR_VERSION}" -eq 15 ]; then
         DISTRO_REPO="openSUSE_Leap_${DISTRO_MAJOR_VERSION}.${DISTRO_MINOR_VERSION}"
     else

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -81,7 +81,7 @@ platforms:
         - echo "PubkeyAcceptedAlgorithms +ssh-rsa" | tee -a /etc/ssh/sshd_config
   - name: opensuse-15
     driver:
-      image: opensuse/leap:15.3
+      image: opensuse/leap:15.4
       provision_command:
         - &opensuse_provision_command_01 zypper --non-interactive install --auto-agree-with-licenses dbus-1
         - &opensuse_provision_command_02 zypper --non-interactive install --auto-agree-with-licenses sudo openssh which curl systemd


### PR DESCRIPTION
### What does this PR do?

#### Commit: feat(bootstrap-salt): handle openSUSE downstream repo change for `15.4`

The difference between `15.3` and `15.4` can be seen here:

* https://download.opensuse.org/repositories/systemsmanagement:/saltstack/
  - `openSUSE_Leap_15.3`
  - `15.4` (i.e. not `openSUSE_Leap_15.4`)

#### Commit: ci(kitchen): update to openSUSE Leap 15.4

Update `15.3` to `15.4` in `kitchen.yml`.

#### Downstream repo testing working successfully

I've already tested the changes proposed here in the `salt-image-builder` repo, which uses the downstream repo for installing Salt:

* https://gitlab.com/myii/salt-image-builder/-/pipelines/566460159

The key section is shown in the CI log:

```console
 *  INFO: Running install_opensuse_15_stable_deps()
Adding repository 'Salt configuration management for openSUSE (15.4)' [......done]
Repository 'Salt configuration management for openSUSE (15.4)' successfully added

URI         : https://download.opensuse.org/repositories/systemsmanagement:/saltstack/15.4/
Enabled     : Yes
GPG Check   : Yes
Autorefresh : Yes
Priority    : 99 (default priority)

Repository priorities are without effect. All enabled repositories share the same priority.
Repository 'Update repository of openSUSE Backports' is up to date.
Repository 'Non-OSS Repository' is up to date.
Repository 'Main Repository' is up to date.
Repository 'Update repository with updates from SUSE Linux Enterprise 15' is up to date.
Repository 'Main Update Repository' is up to date.
Repository 'Update Repository (Non-Oss)' is up to date.
Retrieving repository 'Salt configuration management for openSUSE (15.4)' metadata [..

Automatically importing the following key:

  Repository:       Salt configuration management for openSUSE (15.4)
  Key Fingerprint:  50E6 0431 5448 5D99 0732 B5D6 ACAA 9CF7 E6E5 A213
  Key Name:         systemsmanagement OBS Project <systemsmanagement@build.opensuse.org>
  Key Algorithm:    RSA 2048
  Key Created:      Mon Oct 11 09:00:48 2021
  Key Expires:      Wed Dec 20 09:00:48 2023
  Rpm Name:         gpg-pubkey-e6e5a213-6163fd40



    Note: A GPG pubkey is clearly identified by it's fingerprint. Do not rely the keys name. If you
    are not sure whether the presented key is authentic, ask the repository provider or check his
    web site. Many provider maintain a web page showing the fingerprints of the GPG keys they are
    using.
.done]
Building repository 'Salt configuration management for openSUSE (15.4)' cache [....done]
All repositories have been refreshed.
```