### PR TITLE
use SHA-256 key for Red Hat / CentOS relesaes 9 and over.

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -4412,6 +4412,8 @@ __install_saltstack_rhel_repository() {
     base_url="${HTTP_VAL}://${_REPO_URL}/${__PY_VERSION_REPO}/redhat/${DISTRO_MAJOR_VERSION}/\$basearch/${repo_rev}/"
     if [ "${DISTRO_MAJOR_VERSION}" -eq 7 ]; then
         gpg_key="SALTSTACK-GPG-KEY.pub base/RPM-GPG-KEY-CentOS-7"
+    elif [ "${DISTRO_MAJOR_VERSION}" -ge 9 ]; then
+        gpg_key="SALTSTACK-GPG-KEY2.pub"
     else
         gpg_key="SALTSTACK-GPG-KEY.pub"
     fi
@@ -4466,6 +4468,8 @@ __install_saltstack_rhel_tiamat_repository() {
     base_url="${HTTP_VAL}://${_REPO_URL}/${_TIAMAT_DIR}/${__PY_VERSION_REPO}/redhat/${DISTRO_MAJOR_VERSION}/\$basearch/${TIAMAT_REV}/"
     if [ "${DISTRO_MAJOR_VERSION}" -eq 7 ]; then
         gpg_key="SALTSTACK-GPG-KEY.pub base/RPM-GPG-KEY-CentOS-7"
+    elif [ "${DISTRO_MAJOR_VERSION}" -ge 9 ]; then
+        gpg_key="SALTSTACK-GPG-KEY2.pub"
     else
         gpg_key="SALTSTACK-GPG-KEY.pub"
     fi


### PR DESCRIPTION
### What does this PR do?

use SHA-256 key for Red Hat / CentOS relesaes 9 and over.