### PR TITLE
Expanding cache to include vagrant boxes

### DIFF
--- a/.github/workflows/kitchen.vagrant.yml
+++ b/.github/workflows/kitchen.vagrant.yml
@@ -4,6 +4,7 @@ name: 'Kitchen Vagrant (FreeBSD & OpenBSD)'
 
 env:
   KITCHEN_LOCAL_YAML: 'kitchen.vagrant.yml'
+  VAGRANT_HOME: '.vagrant.d'
 
 jobs:
   generate-actions-workflow:
@@ -50,12 +51,14 @@ jobs:
     steps:
       - name: 'Check out code'
         uses: 'actions/checkout@v2'
-      - name: 'Set up Bundler cache'
-        uses: 'actions/cache@v1'
+      - name: 'Set up Bundler and Vagrant cache'
+        uses: 'actions/cache@v3'
         with:
-          path: 'vendor/bundle'
-          key: "${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}"
-          restore-keys: "${{ runner.os }}-gems-"
+          path: |
+            vendor/bundle
+            .kitchen/kitchen-vagrant
+            .vagrant.d/
+          key: "${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock','**/kitchen.vagrant.yml','**/.github/workflows/kitchen.vagrant.yml') }}"
       - name: 'Run Bundler'
         run: |
           ruby --version

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /.project
 *.sw?
 .vagrant
+.venv
 
 # Pycharm
 .idea


### PR DESCRIPTION
### What does this PR do?

Expanding cache to include vagrant boxes, so that vagrant boxes aren't needing to be redownloaded if not needed. This will help prevent hitting vagrantcloud API [request limits](https://www.vagrantup.com/vagrant-cloud/request-limits).

- Fixes #1851