### PR TITLE
onedir install - correct version regex

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -639,7 +639,7 @@ elif [ "$ITYPE" = "onedir" ]; then
         if [ "$(echo "$1" | grep -E '^(latest)$')" != "" ]; then
             ONEDIR_REV="$1"
             shift
-        elif [ "$(echo "$1" | grep -E '^([3-9][0-9]{3}(\.[0-9]*))')" != "" ]; then
+        elif [ "$(echo "$1" | grep -E '^([3-9][0-9]{3}(\.[0-9]*)?)')" != "" ]; then
             # Handle the 3xxx.0 version as 3xxx archive (pin to minor) and strip the fake ".0" suffix
             ONEDIR_REV=$(echo "$1" | sed -E 's/^([3-9][0-9]{3})\.0$/\1/')
             shift

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -636,15 +636,13 @@ elif [ "$ITYPE" = "onedir" ]; then
     if [ "$#" -eq 0 ];then
         ONEDIR_REV="latest"
     else
-        if [ "$(echo "$1" | grep -E '^(latest)$')" != "" ]; then
+        if [ "$(echo "$1" | grep -E '^(latest|3005)$')" != "" ]; then
             ONEDIR_REV="$1"
-            shift
-	elif [ "$(echo "$1" | grep -E '^([3-9][0-9]{3}?-[0-9]$)')" != "" ]; then
-            ONEDIR_REV="minor/$1"
             shift
         elif [ "$(echo "$1" | grep -E '^([3-9][0-9]{3}(\.[0-9]*)?)')" != "" ]; then
             # Handle the 3xxx.0 version as 3xxx archive (pin to minor) and strip the fake ".0" suffix
             ONEDIR_REV=$(echo "$1" | sed -E 's/^([3-9][0-9]{3})\.0$/\1/')
+            ONEDIR_REV="minor/$ONEDIR_REV"
             shift
         else
             echo "Unknown stable version: $1 (valid: 3005, latest.)"

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -639,7 +639,7 @@ elif [ "$ITYPE" = "onedir" ]; then
         if [ "$(echo "$1" | grep -E '^(latest)$')" != "" ]; then
             ONEDIR_REV="$1"
             shift
-        elif [ "$(echo "$1" | grep -E '^([3-9][0-9]{3}(\.[0-9]))')" != "" ]; then
+        elif [ "$(echo "$1" | grep -E '^([3-9][0-9]{3}(\.[0-9]*))')" != "" ]; then
             # Handle the 3xxx.0 version as 3xxx archive (pin to minor) and strip the fake ".0" suffix
             ONEDIR_REV=$(echo "$1" | sed -E 's/^([3-9][0-9]{3})\.0$/\1/')
             shift

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -639,10 +639,9 @@ elif [ "$ITYPE" = "onedir" ]; then
         if [ "$(echo "$1" | grep -E '^(latest)$')" != "" ]; then
             ONEDIR_REV="$1"
             shift
-        elif [ "$(echo "$1" | grep -E '^([3-9][0-9]{3}?-[0-9]$)')" != "" ]; then
+        elif [ "$(echo "$1" | grep -E '^([3-9][0-9]{3}(\.[0-9]))')" != "" ]; then
             # Handle the 3xxx.0 version as 3xxx archive (pin to minor) and strip the fake ".0" suffix
-            #ONEDIR_REV=$(echo "$1" | sed -E 's/^([3-9][0-9]{3})\.0$/\1/')
-            ONEDIR_REV="minor/$1"
+            ONEDIR_REV=$(echo "$1" | sed -E 's/^([3-9][0-9]{3})\.0$/\1/')
             shift
         else
             echo "Unknown stable version: $1 (valid: 3005, latest.)"

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -5287,6 +5287,15 @@ install_red_hat_enterprise_workstation_testing_post() {
 #   Oracle Linux Install Functions
 #
 install_oracle_linux_stable_deps() {
+    # Install Oracle's EPEL.
+    if [ ${_EPEL_REPOS_INSTALLED} -eq $BS_FALSE ]; then
+        _EPEL_REPO=oracle-epel-release-el${DISTRO_MAJOR_VERSION}
+        if ! rpm -q "${_EPEL_REPO}" > /dev/null; then
+            __yum_install_noinput "${_EPEL_REPO}"
+        fi
+        _EPEL_REPOS_INSTALLED=$BS_TRUE
+    fi
+
     install_centos_stable_deps || return 1
     return 0
 }

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -639,6 +639,9 @@ elif [ "$ITYPE" = "onedir" ]; then
         if [ "$(echo "$1" | grep -E '^(latest)$')" != "" ]; then
             ONEDIR_REV="$1"
             shift
+	elif [ "$(echo "$1" | grep -E '^([3-9][0-9]{3}?-[0-9]$)')" != "" ]; then
+            ONEDIR_REV="minor/$1"
+            shift
         elif [ "$(echo "$1" | grep -E '^([3-9][0-9]{3}(\.[0-9]*)?)')" != "" ]; then
             # Handle the 3xxx.0 version as 3xxx archive (pin to minor) and strip the fake ".0" suffix
             ONEDIR_REV=$(echo "$1" | sed -E 's/^([3-9][0-9]{3})\.0$/\1/')

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -639,10 +639,10 @@ elif [ "$ITYPE" = "onedir" ]; then
         if [ "$(echo "$1" | grep -E '^(latest)$')" != "" ]; then
             ONEDIR_REV="$1"
             shift
-        elif [ "$(echo "$1" | grep -E '^([3-9][0-9]{3}(\.[0-9]*)?)$')" != "" ]; then
+        elif [ "$(echo "$1" | grep -E '^([3-9][0-9]{3}?-[0-9]$)')" != "" ]; then
             # Handle the 3xxx.0 version as 3xxx archive (pin to minor) and strip the fake ".0" suffix
-            ONEDIR_REV=$(echo "$1" | sed -E 's/^([3-9][0-9]{3})\.0$/\1/')
-            ONEDIR_REV="minor/$ONEDIR_REV"
+            #ONEDIR_REV=$(echo "$1" | sed -E 's/^([3-9][0-9]{3})\.0$/\1/')
+            ONEDIR_REV="minor/$1"
             shift
         else
             echo "Unknown stable version: $1 (valid: 3005, latest.)"
@@ -669,7 +669,7 @@ elif [ "$ITYPE" = "onedir_rc" ]; then
             ONEDIR_REV="minor/$1"
             shift
         else
-            echo "Unknown stable version: $1 (valid: 3005, latest.)"
+            echo "Unknown stable version: $1 (valid: 3005-1, latest.)"
             exit 1
         fi
     fi
@@ -4491,7 +4491,7 @@ enabled=1
 enabled_metadata=1
 _eof
 
-        fetch_url="${HTTP_VAL}://${_REPO_URL}/${_ONEDIR_DIR}/${__PY_VERSION_REPO}/redhat/${DISTRO_MAJOR_VERSION}/${CPU_ARCH_L}/"
+        fetch_url="${HTTP_VAL}://${_REPO_URL}/${_ONEDIR_DIR}/${__PY_VERSION_REPO}/redhat/${DISTRO_MAJOR_VERSION}/${CPU_ARCH_L}/${ONEDIR_REV}/"
         for key in $gpg_key; do
             __rpm_import_gpg "${fetch_url}${key}" || return 1
         done


### PR DESCRIPTION
### What does this PR do?
This PR fixes an issue with the regex where it was looking for versions in format `3005-1` when it should be looking for `3005.1`

This is adjusting the regex to the same as the stable install.

This also fixes the ability to call the function with 3005.0 and have it resolve to 3005 as is done in the stable install.


