### PR TITLE
Add support for the -R flag on macOS.

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -388,7 +388,7 @@ __usage() {
         points to a repository that mirrors Salt packages located at
         repo.saltproject.io. The option passed with -R replaces the
         "repo.saltproject.io". If -R is passed, -r is also set. Currently only
-        works on CentOS/RHEL and Debian based distributions.
+        works on CentOS/RHEL and Debian based distributions and macOS.
     -s  Sleep time used when waiting for daemons to start, restart and when
         checking for the services running. Default: ${__DEFAULT_SLEEP}
     -S  Also install salt-syndic
@@ -8230,7 +8230,7 @@ __macosx_get_packagesite() {
     fi
 
     PKG="salt-${STABLE_REV}-${__PY_VERSION_REPO}-${DARWIN_ARCH}.pkg"
-    SALTPKGCONFURL="https://repo.saltproject.io/osx/${PKG}"
+    SALTPKGCONFURL="https://${_REPO_URL}/osx/${PKG}"
 }
 
 # Using a separate conf step to head for idempotent install...


### PR DESCRIPTION
### What does this PR do?
Allows macOS to bootstrap from alternate repos.

### What issues does this PR fix or reference?
Fixes #1870

### Previous Behavior
```sudo sh bootstrap-salt.sh -R archive.repo.saltproject.io -D stable 3004```

```
 *  INFO: Running install_macosx_stable_deps()
 *  INFO: Running install_macosx_stable()
 * ERROR: https://repo.saltproject.io/osx/salt-3004-py3-x86_64.pkg failed to download to /tmp/salt-3004-py3-x86_64.pkg
 * ERROR: Failed to run install_macosx_stable()!!!
```

### New Behavior
```sudo sh bootstrap-salt.sh -R archive.repo.saltproject.io -D stable 3004```

```
 *  INFO: Running install_macosx_stable_deps()
 *  INFO: Running install_macosx_stable()
installer: Package name is Salt 3004 (Python 3)
installer: Upgrading at base path /
installer: The upgrade was successful.
```