### PR TITLE
Fix missing functions for post-installation on EL clones

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -5345,6 +5345,11 @@ install_oracle_linux_git_post() {
     return 0
 }
 
+install_oracle_linux_onedir_post() {
+    install_centos_onedir_post || return 1
+    return 0
+}
+
 install_oracle_linux_testing_post() {
     install_centos_testing_post || return 1
     return 0
@@ -5415,6 +5420,11 @@ install_almalinux_stable_post() {
 
 install_almalinux_git_post() {
     install_centos_git_post || return 1
+    return 0
+}
+
+install_almalinux_onedir_post() {
+    install_centos_onedir_post || return 1
     return 0
 }
 
@@ -5491,6 +5501,11 @@ install_rocky_linux_git_post() {
     return 0
 }
 
+install_rocky_linux_onedir_post() {
+    install_centos_onedir_post || return 1
+    return 0
+}
+
 install_rocky_linux_testing_post() {
     install_centos_testing_post || return 1
     return 0
@@ -5561,6 +5576,11 @@ install_scientific_linux_stable_post() {
 
 install_scientific_linux_git_post() {
     install_centos_git_post || return 1
+    return 0
+}
+
+install_scientific_linux_onedir_post() {
+    install_centos_onedir_post || return 1
     return 0
 }
 


### PR DESCRIPTION
### What does this PR do?
Fixes missing functions or post-installation on EL clones

### What issues does this PR fix or reference?
Resolves: #1876

### Previous Behavior
```
 * DEBUG: INSTALL_FUNC=install_almalinux_onedir
 * DEBUG: install_almalinux_8_onedir_post not found....
 * DEBUG: install_almalinux_8_6_onedir_post not found....
 * DEBUG: install_almalinux_8_post not found....
 * DEBUG: install_almalinux_8_6_post not found....
 * DEBUG: install_almalinux_onedir_post not found....
 * DEBUG: install_almalinux_post not found....
```

### New Behavior
```
 *  INFO: Running install_almalinux_onedir_post()
```
