### PR TITLE
Support for dotZero in version beginning in 3006

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -639,10 +639,13 @@ elif [ "$ITYPE" = "onedir" ]; then
         if [ "$(echo "$1" | grep -E '^(latest|3005)$')" != "" ]; then
             ONEDIR_REV="$1"
             shift
-        elif [ "$(echo "$1" | grep -E '^([3-9][0-9]{3}(\.[0-9]*)?)')" != "" ]; then
-            # Handle the 3xxx.0 version as 3xxx archive (pin to minor) and strip the fake ".0" suffix
-            ONEDIR_REV=$(echo "$1" | sed -E 's/^([3-9][0-9]{3})\.0$/\1/')
+        elif [ "$(echo "$1" | grep -E '^(3005(\.[0-9]*)?)')" != "" ]; then
+            # Handle the 3005.0 version as 3005 archive (pin to minor) and strip the fake ".0" suffix
+            ONEDIR_REV=$(echo "$1" | sed -E 's/^(3005)\.0$/\1/')
             ONEDIR_REV="minor/$ONEDIR_REV"
+            shift
+        elif [ "$(echo "$1" | grep -E '^([3-9][0-9]{3}(\.[0-9]*)?)')" != "" ]; then
+            ONEDIR_REV="minor/$1"
             shift
         else
             echo "Unknown stable version: $1 (valid: 3005, latest.)"


### PR DESCRIPTION

### What does this PR do?
account for adding the .0 back into the release versions starting in 3006.

### What issues does this PR fix or reference?
#1873 

