### PR TITLE
update openbsd to 7, seems like 6 (6.9) is no longer available.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,16 +145,16 @@ jobs:
       instances: '["git-master", "latest"]'
 
 
-  openbsd-6:
-    name: OpenBSD 6
+  openbsd-7:
+    name: OpenBSD 7
     if: github.event_name == 'push' || needs.collect-changed-files.outputs.run-tests == 'true'
     uses: ./.github/workflows/test-bsd.yml
     needs:
       - lint
       - generate-actions-workflow
     with:
-      distro-slug: openbsd-6
-      display-name: OpenBSD 6
+      distro-slug: openbsd-7
+      display-name: OpenBSD 7
       timeout: 20
       runs-on: macos-10.15
       instances: '["latest"]'
@@ -528,7 +528,7 @@ jobs:
       - generate-actions-workflow
       - freebsd-131
       - freebsd-123
-      - openbsd-6
+      - openbsd-7
       - macos-1015
       - macos-11
       - macos-12

--- a/.github/workflows/templates/generate.py
+++ b/.github/workflows/templates/generate.py
@@ -42,7 +42,7 @@ OSX = [
 BSD = [
     "freebsd-131",
     "freebsd-123",
-    "openbsd-6",
+    "openbsd-7",
 ]
 
 STABLE_DISTROS = [
@@ -168,7 +168,7 @@ DISTRO_DISPLAY_NAMES = {
     "macos-12": "macOS 12",
     "freebsd-131": "FreeBSD 13.1",
     "freebsd-123": "FreeBSD 12.3",
-    "openbsd-6": "OpenBSD 6",
+    "openbsd-7": "OpenBSD 7",
     "windows-2019": "Windows 2019",
     "windows-2022": "Windows 2022",
 }
@@ -223,7 +223,7 @@ def generate_test_jobs():
                 instances.append(salt_version)
                 continue
 
-            if distro == "openbsd-6":
+            if distro == "openbsd-7":
                 # Only test latest on OpenBSD 6
                 continue
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 
 gem 'test-kitchen', '>= 3.2.2'
 gem 'kitchen-salt', '>= 0.7.2'
-gem 'kitchen-docker', git: 'https://github.com/test-kitchen/kitchen-docker.git'
+gem 'kitchen-docker', :git => 'https://github.com/test-kitchen/kitchen-docker.git', :branch => 'main'
 
 group :vagrant do
   gem 'kitchen-vagrant'

--- a/kitchen.bsd.yml
+++ b/kitchen.bsd.yml
@@ -33,9 +33,9 @@ platforms:
   - name: freebsd-123
     driver:
       box: bento/freebsd-12.3
-  - name: openbsd-6
+  - name: openbsd-7
     driver:
-      box: generic/openbsd6
+      box: generic/openbsd7
       ssh:
         shell: /bin/ksh
       synced_folders: []

--- a/kitchen.bsd.yml
+++ b/kitchen.bsd.yml
@@ -39,6 +39,10 @@ platforms:
       ssh:
         shell: /bin/ksh
       synced_folders: []
+    transport:
+      name: ssh
+      username: vagrant
+      password: vagrant
     provisioner:
       init_environment: |
         echo 'auto_accept: true' > /tmp/auto-accept-keys.conf


### PR DESCRIPTION
### What does this PR do?
update openbsd to 7, seems like 6 (6.9) is no longer available.

### What issues does this PR fix or reference?
N/A