### PR TITLE
Added Pop!_OS as a Ubuntu derivative

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1370,7 +1370,7 @@ __gather_system_info() {
 #----------------------------------------------------------------------------------------------------------------------
 # shellcheck disable=SC2034
 __ubuntu_derivatives_translation() {
-    UBUNTU_DERIVATIVES="(trisquel|linuxmint|linaro|elementary_os|neon)"
+    UBUNTU_DERIVATIVES="(trisquel|linuxmint|linaro|elementary_os|neon|pop)"
     # Mappings
     trisquel_6_ubuntu_base="12.04"
     linuxmint_13_ubuntu_base="12.04"
@@ -1383,6 +1383,7 @@ __ubuntu_derivatives_translation() {
     neon_16_ubuntu_base="16.04"
     neon_18_ubuntu_base="18.04"
     neon_20_ubuntu_base="20.04"
+    pop_22_ubuntu_base="22.04"
 
     # Translate Ubuntu derivatives to their base Ubuntu version
     match=$(echo "$DISTRO_NAME_L" | grep -E ${UBUNTU_DERIVATIVES})


### PR DESCRIPTION
### What does this PR do?
This PR adds support for Pop!_OS as an Ubuntu derivative. Only added 22 as a variant of Ubuntu 22.04 since that's all I can test, other versions should work equally well.

### What issues does this PR fix or reference?
No open issues

### Previous Behavior
bootstrap script failed with the following message:
```
 *  INFO: Running version: 2022.10.04
 *  INFO: Executed by: sh
 *  INFO: Command line: '/tmp/bootstrap-salt.sh '

 *  INFO: System Information:
 *  INFO:   CPU:          GenuineIntel
 *  INFO:   CPU Arch:     x86_64
 *  INFO:   OS Name:      Linux
 *  INFO:   OS Version:   5.19.0-76051900-generic
 *  INFO:   Distribution: Pop 22.04

 *  INFO: Installing minion
 *  INFO: Found function config_salt
 *  INFO: Found function preseed_master
 *  INFO: Found function daemons_running
 * ERROR: No dependencies installation function found. Exiting...
 ```

### New Behavior
Salt installation is completed successfully
```
 *  INFO: Running install_ubuntu_stable_post()
 *  INFO: Running install_ubuntu_check_services()
 *  INFO: Running install_ubuntu_restart_daemons()
 *  INFO: Running daemons_running()
 *  INFO: Salt installed!
```
