### PR TITLE
Don't attempt to stable install on Red Hat onedir only systems

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1829,14 +1829,8 @@ else
     fi
 fi
 
-i# Red Hat variants after 9.x not supported by stable type
+# Red Hat variants after 9.x not supported by stable type
 if [ "$(echo "${DISTRO_NAME_L}" | grep -E '(centos|red_hat|scientific|almalinux|rocky)')" != "" ] && [ "$ITYPE" = "stable" ] && [ "$DISTRO_MAJOR_VERSION" -ge 9 ]; then
-    echoerror "${DISTRO_NAME} ${DISTRO_VERSION} not supported by stable type, use type onedir."
-    exit 1
-fi
-
-# Debian after 11.x not supported by stable type
-if [ "$(echo "${DISTRO_NAME_L}" | grep -E '(debian)')" != "" ] && [ "$ITYPE" = "stable" ] && [ "$DISTRO_MAJOR_VERSION" -ge 11 ]; then
     echoerror "${DISTRO_NAME} ${DISTRO_VERSION} not supported by stable type, use type onedir."
     exit 1
 fi

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1835,12 +1835,6 @@ if [ "$(echo "${DISTRO_NAME_L}" | grep -E '(centos|red_hat|scientific|almalinux|
     exit 1
 fi
 
-# Ubuntu after 22.x not supported by stable type
-if [ "$(echo "${DISTRO_NAME_L}" | grep -E '(ubuntu)')" != "" ] && [ "$ITYPE" = "stable" ] && [ "$DISTRO_MAJOR_VERSION" -ge 22 ]; then
-    echoerror "${DISTRO_NAME} ${DISTRO_VERSION} not supported by stable type, use type onedir."
-    exit 1
-fi
-
 # For Ubuntu derivatives, pretend to be their Ubuntu base version
 __ubuntu_derivatives_translation
 

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1829,6 +1829,24 @@ else
     fi
 fi
 
+i# Red Hat variants after 9.x not supported by stable type
+if [ "$(echo "${DISTRO_NAME_L}" | grep -E '(centos|red_hat|scientific|almalinux|rocky)')" != "" ] && [ "$ITYPE" = "stable" ] && [ "$DISTRO_MAJOR_VERSION" -ge 9 ]; then
+    echoerror "${DISTRO_NAME} ${DISTRO_VERSION} not supported by stable type, use type onedir."
+    exit 1
+fi
+
+# Debian after 11.x not supported by stable type
+if [ "$(echo "${DISTRO_NAME_L}" | grep -E '(debian)')" != "" ] && [ "$ITYPE" = "stable" ] && [ "$DISTRO_MAJOR_VERSION" -ge 11 ]; then
+    echoerror "${DISTRO_NAME} ${DISTRO_VERSION} not supported by stable type, use type onedir."
+    exit 1
+fi
+
+# Ubuntu after 22.x not supported by stable type
+if [ "$(echo "${DISTRO_NAME_L}" | grep -E '(ubuntu)')" != "" ] && [ "$ITYPE" = "stable" ] && [ "$DISTRO_MAJOR_VERSION" -ge 22 ]; then
+    echoerror "${DISTRO_NAME} ${DISTRO_VERSION} not supported by stable type, use type onedir."
+    exit 1
+fi
+
 # For Ubuntu derivatives, pretend to be their Ubuntu base version
 __ubuntu_derivatives_translation
 


### PR DESCRIPTION
### What does this PR do?
Classic packages, done via stable install type, is no longer supported on later versions of Red Hat variants.  If the bootstrap script is run with stable type on those systems, log an error and exit.