### PR TITLE
Add support for KDE neon based on Ubuntu 22.04

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -486,7 +486,7 @@ in combination with the ``git`` installation method.
 Ubuntu and derivatives
 ~~~~~~~~~~~~~~~~~~~~~~
 
-- KDE neon (based on Ubuntu 18.04)
+- KDE neon (based on Ubuntu 18.04/20.04/22.04)
 - Linux Mint 17/18
 - Ubuntu 14.04/16.04/18.04 and subsequent non-LTS releases (see below)
 

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1383,6 +1383,7 @@ __ubuntu_derivatives_translation() {
     neon_16_ubuntu_base="16.04"
     neon_18_ubuntu_base="18.04"
     neon_20_ubuntu_base="20.04"
+    neon_22_ubuntu_base="22.04"
     pop_22_ubuntu_base="22.04"
 
     # Translate Ubuntu derivatives to their base Ubuntu version


### PR DESCRIPTION
### What does this PR do?

Causes bootstrap to properly support Ubuntu 22.04 based versions of KDE neon.

### What issues does this PR fix or reference?

n/a

### Previous Behavior

```
 *  INFO: Executed by: shell pipe
 *  INFO: Command line: 'sh '

 *  INFO: System Information:
 *  INFO:   CPU:          GenuineIntel
 *  INFO:   CPU Arch:     x86_64
 *  INFO:   OS Name:      Linux
 *  INFO:   OS Version:   5.15.0-57-generic
 *  INFO:   Distribution: Neon 22.04

sh: 1: eval: neon_22_ubuntu_base: parameter not set
 *  INFO: Installing minion
100  320k  100  320k    0     0   906k      0 --:--:-- --:--:-- --:--:--  908k
 *  INFO: Found function config_salt
 *  INFO: Found function preseed_master
 *  INFO: Found function daemons_running
 * ERROR: No dependencies installation function found. Exiting...
```

### New Behavior

```
 *  INFO: Running version: 2022.10.04
 *  INFO: Executed by: bash
 *  INFO: Command line: '/tmp/bootstrap-salt.sh '

 *  INFO: System Information:
 *  INFO:   CPU:          GenuineIntel
 *  INFO:   CPU Arch:     x86_64
 *  INFO:   OS Name:      Linux
 *  INFO:   OS Version:   5.15.0-57-generic
 *  INFO:   Distribution: Neon 22.04

 *  INFO: Installing minion
 *  INFO: Found function install_ubuntu_stable_deps
 *  INFO: Found function config_salt
 *  INFO: Found function preseed_master
 *  INFO: Found function install_ubuntu_stable
 *  INFO: Found function install_ubuntu_stable_post
 *  INFO: Found function install_ubuntu_restart_daemons
 *  INFO: Found function daemons_running
 *  INFO: Found function install_ubuntu_check_services
 *  INFO: Running install_ubuntu_stable_deps()
[...]
 *  INFO: Running install_ubuntu_stable_post()
 *  INFO: Running install_ubuntu_check_services()
 *  INFO: Running install_ubuntu_restart_daemons()
 *  INFO: Running daemons_running()
 *  INFO: Salt installed!
```
