### PR TITLE
Adding support for Ubuntu new versions (22.04 -> 24.xx)

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -3022,11 +3022,16 @@ __enable_universe_repository() {
 __install_saltstack_ubuntu_repository() {
     # Workaround for latest non-LTS Ubuntu
     if { [ "$DISTRO_MAJOR_VERSION" -eq 20 ] && [ "$DISTRO_MINOR_VERSION" -eq 10 ]; } || \
-        # remove 22 version when salt packages for 22.04 are available
-        [ "$DISTRO_MAJOR_VERSION" -eq 21 ] ||  [ "$DISTRO_MAJOR_VERSION" -eq 22 ]; then
-        echowarn "Non-LTS Ubuntu detected, but stable packages requested. Trying packages for previous LTS release. You may experience problems."
+        [ "$DISTRO_MAJOR_VERSION" -eq 21 ] ; then
+        echowarn "Non-LTS Ubuntu detected (prior to 22.04 LTS), but stable packages requested. Trying packages for previous LTS release. You may experience problems."
         UBUNTU_VERSION=20.04
         UBUNTU_CODENAME="focal"
+    elif { [ "$DISTRO_MAJOR_VERSION" -eq 22 ] && [ "$DISTRO_MINOR_VERSION" -eq 10 ]; } || \
+        # remove 24 version when salt packages for 24.04 are available
+        [ "$DISTRO_MAJOR_VERSION" -eq 23 ] ||  [ "$DISTRO_MAJOR_VERSION" -eq 24 ]; then
+        echowarn "Non-LTS Ubuntu detected, but stable packages requested. Trying packages for previous LTS release. You may experience problems."
+        UBUNTU_VERSION=22.04
+        UBUNTU_CODENAME="jammy"
     else
         UBUNTU_VERSION=${DISTRO_VERSION}
         UBUNTU_CODENAME=${DISTRO_CODENAME}


### PR DESCRIPTION
### What does this PR do?
Reviewing the conditions from `__install_saltstack_ubuntu_repository()`: 
1. Versions >20.04 & <22.04 use the focal repo with the already existing warning about non LTS
2. Ubuntu 22.04/Jammy use the default as the repo is available 
3. Version > 22.04 to 24.xx use the jammy repo 

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-bootstrap/issues/1905

### Previous Behavior
Bootstraping saltstack on Ubuntu 22.04 (LTS) resulted in using focal repo.

### New Behavior
Bootstraping saltstack on Ubuntu 22.04 (LTS) use the jammy repo.
