### PR TITLE
SUSE Fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
       distro-slug: freebsd-131
       display-name: FreeBSD 13.1
       timeout: 20
-      runs-on: macos-10.15
+      runs-on: macos-11
       instances: '["git-master", "latest"]'
 
 
@@ -141,7 +141,7 @@ jobs:
       distro-slug: freebsd-123
       display-name: FreeBSD 12.3
       timeout: 20
-      runs-on: macos-10.15
+      runs-on: macos-11
       instances: '["git-master", "latest"]'
 
 
@@ -156,24 +156,9 @@ jobs:
       distro-slug: openbsd-7
       display-name: OpenBSD 7
       timeout: 20
-      runs-on: macos-10.15
+      runs-on: macos-11
       instances: '["latest"]'
 
-
-
-  macos-1015:
-    name: macOS 10.15
-    if: github.event_name == 'push' || needs.collect-changed-files.outputs.run-tests == 'true'
-    uses: ./.github/workflows/test-macos.yml
-    needs:
-      - lint
-      - generate-actions-workflow
-    with:
-      distro-slug: macos-1015
-      display-name: macOS 10.15
-      timeout: 20
-      runs-on: macos-10.15
-      instances: '["stable-3003", "stable-3004", "stable-3005", "stable-3006", "latest"]'
 
 
   macos-11:
@@ -417,7 +402,7 @@ jobs:
       distro-slug: gentoo
       display-name: Gentoo
       timeout: 90
-      instances: '["git-master", "latest", "default"]'
+      instances: '["git-master", "latest"]'
 
 
   gentoo-systemd:
@@ -431,7 +416,7 @@ jobs:
       distro-slug: gentoo-systemd
       display-name: Gentoo (systemd)
       timeout: 90
-      instances: '["git-master", "latest", "default"]'
+      instances: '["git-master", "latest"]'
 
 
   opensuse-15:
@@ -585,7 +570,6 @@ jobs:
       - freebsd-131
       - freebsd-123
       - openbsd-7
-      - macos-1015
       - macos-11
       - macos-12
       - windows-2019

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
       distro-slug: freebsd-131
       display-name: FreeBSD 13.1
       timeout: 20
-      runs-on: macos-11
+      runs-on: macos-12
       instances: '["git-master", "latest"]'
 
 
@@ -141,7 +141,7 @@ jobs:
       distro-slug: freebsd-123
       display-name: FreeBSD 12.3
       timeout: 20
-      runs-on: macos-11
+      runs-on: macos-12
       instances: '["git-master", "latest"]'
 
 
@@ -156,7 +156,7 @@ jobs:
       distro-slug: openbsd-7
       display-name: OpenBSD 7
       timeout: 20
-      runs-on: macos-11
+      runs-on: macos-12
       instances: '["latest"]'
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -402,7 +402,7 @@ jobs:
       distro-slug: gentoo
       display-name: Gentoo
       timeout: 90
-      instances: '["git-master", "latest"]'
+      instances: '["git-master"]'
 
 
   gentoo-systemd:
@@ -416,7 +416,7 @@ jobs:
       distro-slug: gentoo-systemd
       display-name: Gentoo (systemd)
       timeout: 90
-      instances: '["git-master", "latest"]'
+      instances: '["git-master"]'
 
 
   opensuse-15:

--- a/.github/workflows/templates/generate.py
+++ b/.github/workflows/templates/generate.py
@@ -318,7 +318,10 @@ GIT_DISTRO_BLACKLIST = [
     "rockylinux-8",
 ]
 
-LATEST_PKG_BLACKLIST = []
+LATEST_PKG_BLACKLIST = [
+    "gentoo",
+    "gentoo-systemd",
+]
 
 DISTRO_DISPLAY_NAMES = {
     "almalinux-8": "AlmaLinux 8",

--- a/.github/workflows/templates/generate.py
+++ b/.github/workflows/templates/generate.py
@@ -389,7 +389,7 @@ def generate_test_jobs():
 
     for distro in BSD:
         test_jobs += "\n"
-        runs_on = "macos-11"
+        runs_on = "macos-12"
         runs_on = f"\n      runs-on: {runs_on}"
         ifcheck = "\n    if: github.event_name == 'push' || needs.collect-changed-files.outputs.run-tests == 'true'"
         uses = "./.github/workflows/test-bsd.yml"

--- a/.github/workflows/templates/generate.py
+++ b/.github/workflows/templates/generate.py
@@ -38,7 +38,6 @@ WINDOWS = [
 ]
 
 OSX = [
-    "macos-1015",
     "macos-11",
     "macos-12",
 ]
@@ -61,8 +60,6 @@ STABLE_DISTROS = [
     "fedora-36",
     "fedora-37",
     "fedora-38",
-    "gentoo",
-    "gentoo-systemd",
     "opensuse-15",
     "opensuse-tumbleweed",
     "oraclelinux-7",
@@ -389,7 +386,7 @@ def generate_test_jobs():
 
     for distro in BSD:
         test_jobs += "\n"
-        runs_on = "macos-10.15"
+        runs_on = "macos-11"
         runs_on = f"\n      runs-on: {runs_on}"
         ifcheck = "\n    if: github.event_name == 'push' || needs.collect-changed-files.outputs.run-tests == 'true'"
         uses = "./.github/workflows/test-bsd.yml"

--- a/.github/workflows/test-bsd.yml
+++ b/.github/workflows/test-bsd.yml
@@ -55,7 +55,6 @@ jobs:
         run: |
           brew update
           brew upgrade vagrant || brew install vagrant
-          brew install virtualbox
 
       - name: Setup Vagrant Cache
         uses: actions/cache@v3

--- a/.github/workflows/test-bsd.yml
+++ b/.github/workflows/test-bsd.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Update Vagrant
         run: |
           brew update
-          brew upgrade vagrant
+          brew upgrade vagrant || brew install vagrant
 
       - name: Setup Vagrant Cache
         uses: actions/cache@v3

--- a/.github/workflows/test-bsd.yml
+++ b/.github/workflows/test-bsd.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           brew update
           brew upgrade vagrant || brew install vagrant
-          brew install -cask virtualbox
+          brew install virtualbox
 
       - name: Setup Vagrant Cache
         uses: actions/cache@v3

--- a/.github/workflows/test-bsd.yml
+++ b/.github/workflows/test-bsd.yml
@@ -55,6 +55,7 @@ jobs:
         run: |
           brew update
           brew upgrade vagrant || brew install vagrant
+          brew install -cask virtualbox
 
       - name: Setup Vagrant Cache
         uses: actions/cache@v3


### PR DESCRIPTION
### What does this PR do?
Updating the bootstrap script with fixes to install properly on SUSE.  Since we are not building onedir packages and providing them in the Salt project repo, we fall back to the previous stable installs and use the SUSE repos.  Removing _DOWNSTREAM_PKG_REPO as it is no longer used.