### PR TITLE
Add old_stable type

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,7 +173,7 @@ jobs:
       display-name: macOS 11
       timeout: 20
       runs-on: macos-11
-      instances: '["stable-3005", "stable-3006", "latest"]'
+      instances: '["old-stable-3003", "old-stable-3004", "old-stable-3005", "stable-3006", "latest"]'
 
 
   macos-12:
@@ -188,7 +188,7 @@ jobs:
       display-name: macOS 12
       timeout: 20
       runs-on: macos-12
-      instances: '["stable-3005", "stable-3006", "latest"]'
+      instances: '["old-stable-3003", "old-stable-3004", "old-stable-3005", "stable-3006", "latest"]'
 
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,7 +277,7 @@ jobs:
       distro-slug: amazon-2
       display-name: Amazon 2
       timeout: 20
-      instances: '["old-stable-3003", "old-stable-3004", "old-stable-3005", "stable-3005", "onedir-3005", "stable-3006", "onedir-3006", "git-master", "latest", "default"]'
+      instances: '["old-stable-3003", "old-stable-3004", "old-stable-3005", "stable-3005", "onedir-3005", "stable-3006", "onedir-3006", "latest", "default"]'
 
 
   arch:
@@ -347,7 +347,7 @@ jobs:
       distro-slug: debian-10
       display-name: Debian 10
       timeout: 20
-      instances: '["old-stable-3003", "old-stable-3004", "old-stable-3005", "stable-3005", "onedir-3005", "stable-3006", "onedir-3006", "git-master", "latest", "default"]'
+      instances: '["old-stable-3003", "old-stable-3004", "old-stable-3005", "stable-3005", "onedir-3005", "stable-3006", "onedir-3006", "latest", "default"]'
 
 
   debian-11:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,7 +173,7 @@ jobs:
       display-name: macOS 10.15
       timeout: 20
       runs-on: macos-10.15
-      instances: '["stable-3003", "stable-3004", "stable-3005", "stable-3006", "latest"]'
+      instances: '["stable-3005", "stable-3006", "latest"]'
 
 
   macos-11:
@@ -188,7 +188,7 @@ jobs:
       display-name: macOS 11
       timeout: 20
       runs-on: macos-11
-      instances: '["stable-3003", "stable-3004", "stable-3005", "stable-3006", "latest"]'
+      instances: '["stable-3005", "stable-3006", "latest"]'
 
 
   macos-12:
@@ -203,7 +203,7 @@ jobs:
       display-name: macOS 12
       timeout: 20
       runs-on: macos-12
-      instances: '["stable-3003", "stable-3004", "stable-3005", "stable-3006", "latest"]'
+      instances: '["stable-3005", "stable-3006", "latest"]'
 
 
 
@@ -219,7 +219,7 @@ jobs:
       display-name: Windows 2019
       timeout: 20
       runs-on: windows-2019
-      instances: '["stable-3003", "stable-3004", "stable-3005", "stable-3006", "latest"]'
+      instances: '["stable-3005", "stable-3006", "latest"]'
 
 
   windows-2022:
@@ -234,7 +234,7 @@ jobs:
       display-name: Windows 2022
       timeout: 20
       runs-on: windows-2022
-      instances: '["stable-3003", "stable-3004", "stable-3005", "stable-3006", "latest"]'
+      instances: '["stable-3005", "stable-3006", "latest"]'
 
 
 
@@ -249,7 +249,7 @@ jobs:
       distro-slug: almalinux-8
       display-name: AlmaLinux 8
       timeout: 20
-      instances: '["old_stable-3003", "stable-3003", "old_stable-3004", "stable-3004", "old_stable-3005", "stable-3005", "onedir-3005", "stable-3006", "onedir-3006", "latest", "default"]'
+      instances: '["old_stable-3003", "old_stable-3004", "old_stable-3005", "stable-3005", "onedir-3005", "stable-3006", "onedir-3006", "latest", "default"]'
 
 
   almalinux-9:
@@ -277,7 +277,7 @@ jobs:
       distro-slug: amazon-2
       display-name: Amazon 2
       timeout: 20
-      instances: '["old_stable-3003", "stable-3003", "old_stable-3004", "stable-3004", "old_stable-3005", "stable-3005", "onedir-3005", "stable-3006", "onedir-3006", "git-master", "latest", "default"]'
+      instances: '["old_stable-3003", "old_stable-3004", "old_stable-3005", "stable-3005", "onedir-3005", "stable-3006", "onedir-3006", "git-master", "latest", "default"]'
 
 
   arch:
@@ -305,7 +305,7 @@ jobs:
       distro-slug: centos-7
       display-name: CentOS 7
       timeout: 20
-      instances: '["old_stable-3003", "stable-3003", "old_stable-3004", "stable-3004", "old_stable-3005", "stable-3005", "onedir-3005", "stable-3006", "onedir-3006", "latest", "default"]'
+      instances: '["old_stable-3003", "old_stable-3004", "old_stable-3005", "stable-3005", "onedir-3005", "stable-3006", "onedir-3006", "latest", "default"]'
 
 
   centos-stream8:
@@ -319,7 +319,7 @@ jobs:
       distro-slug: centos-stream8
       display-name: CentOS Stream 8
       timeout: 20
-      instances: '["old_stable-3003", "stable-3003", "old_stable-3004", "stable-3004", "old_stable-3005", "stable-3005", "onedir-3005", "stable-3006", "onedir-3006", "latest", "default"]'
+      instances: '["old_stable-3003", "old_stable-3004", "old_stable-3005", "stable-3005", "onedir-3005", "stable-3006", "onedir-3006", "latest", "default"]'
 
 
   centos-stream9:
@@ -347,7 +347,7 @@ jobs:
       distro-slug: debian-10
       display-name: Debian 10
       timeout: 20
-      instances: '["old_stable-3003", "stable-3003", "old_stable-3004", "stable-3004", "old_stable-3005", "stable-3005", "onedir-3005", "stable-3006", "onedir-3006", "git-master", "latest", "default"]'
+      instances: '["old_stable-3003", "old_stable-3004", "old_stable-3005", "stable-3005", "onedir-3005", "stable-3006", "onedir-3006", "git-master", "latest", "default"]'
 
 
   debian-11:
@@ -361,7 +361,7 @@ jobs:
       distro-slug: debian-11
       display-name: Debian 11
       timeout: 20
-      instances: '["old_stable-3004", "stable-3004", "old_stable-3005", "stable-3005", "onedir-3005", "stable-3006", "onedir-3006", "git-master", "latest", "default"]'
+      instances: '["old_stable-3004", "old_stable-3005", "stable-3005", "onedir-3005", "stable-3006", "onedir-3006", "git-master", "latest", "default"]'
 
 
   fedora-36:
@@ -473,7 +473,7 @@ jobs:
       distro-slug: oraclelinux-7
       display-name: Oracle Linux 7
       timeout: 20
-      instances: '["old_stable-3003", "stable-3003", "old_stable-3004", "stable-3004", "old_stable-3005", "stable-3005", "onedir-3005", "stable-3006", "onedir-3006", "latest", "default"]'
+      instances: '["old_stable-3003", "old_stable-3004", "old_stable-3005", "stable-3005", "onedir-3005", "stable-3006", "onedir-3006", "latest", "default"]'
 
 
   oraclelinux-8:
@@ -487,7 +487,7 @@ jobs:
       distro-slug: oraclelinux-8
       display-name: Oracle Linux 8
       timeout: 20
-      instances: '["old_stable-3003", "stable-3003", "old_stable-3004", "stable-3004", "old_stable-3005", "stable-3005", "onedir-3005", "stable-3006", "onedir-3006", "latest", "default"]'
+      instances: '["old_stable-3003", "old_stable-3004", "old_stable-3005", "stable-3005", "onedir-3005", "stable-3006", "onedir-3006", "latest", "default"]'
 
 
   photon-3:
@@ -529,7 +529,7 @@ jobs:
       distro-slug: rockylinux-8
       display-name: Rocky Linux 8
       timeout: 20
-      instances: '["old_stable-3004", "stable-3004", "old_stable-3005", "stable-3005", "onedir-3005", "stable-3006", "onedir-3006", "latest", "default"]'
+      instances: '["old_stable-3004", "old_stable-3005", "stable-3005", "onedir-3005", "stable-3006", "onedir-3006", "latest", "default"]'
 
 
   rockylinux-9:
@@ -557,7 +557,7 @@ jobs:
       distro-slug: ubuntu-2004
       display-name: Ubuntu 20.04
       timeout: 20
-      instances: '["old_stable-3003", "stable-3003", "old_stable-3004", "stable-3004", "old_stable-3005", "stable-3005", "onedir-3005", "stable-3006", "onedir-3006", "git-master", "latest", "default"]'
+      instances: '["old_stable-3003", "old_stable-3004", "old_stable-3005", "stable-3005", "onedir-3005", "stable-3006", "onedir-3006", "git-master", "latest", "default"]'
 
 
   ubuntu-2204:
@@ -571,7 +571,7 @@ jobs:
       distro-slug: ubuntu-2204
       display-name: Ubuntu 22.04
       timeout: 20
-      instances: '["stable-3004", "stable-3005", "onedir-3005", "stable-3006", "onedir-3006", "git-master", "latest", "default"]'
+      instances: '["stable-3005", "onedir-3005", "stable-3006", "onedir-3006", "git-master", "latest", "default"]'
 
 
   set-pipeline-exit-status:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
       display-name: FreeBSD 13.1
       timeout: 20
       runs-on: macos-12
-      instances: '["git-master", "latest"]'
+      instances: '["latest"]'
 
 
   freebsd-123:
@@ -142,7 +142,7 @@ jobs:
       display-name: FreeBSD 12.3
       timeout: 20
       runs-on: macos-12
-      instances: '["git-master", "latest"]'
+      instances: '["latest"]'
 
 
   openbsd-7:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,7 +249,7 @@ jobs:
       distro-slug: almalinux-8
       display-name: AlmaLinux 8
       timeout: 20
-      instances: '["stable-3003", "stable-3004", "stable-3005", "onedir-3005", "stable-3006", "onedir-3006", "latest", "default"]'
+      instances: '["old_stable-3003", "stable-3003", "old_stable-3004", "stable-3004", "old_stable-3005", "stable-3005", "onedir-3005", "stable-3006", "onedir-3006", "latest", "default"]'
 
 
   almalinux-9:
@@ -277,7 +277,7 @@ jobs:
       distro-slug: amazon-2
       display-name: Amazon 2
       timeout: 20
-      instances: '["stable-3003", "stable-3004", "stable-3005", "onedir-3005", "stable-3006", "onedir-3006", "git-master", "latest", "default"]'
+      instances: '["old_stable-3003", "stable-3003", "old_stable-3004", "stable-3004", "old_stable-3005", "stable-3005", "onedir-3005", "stable-3006", "onedir-3006", "git-master", "latest", "default"]'
 
 
   arch:
@@ -305,7 +305,7 @@ jobs:
       distro-slug: centos-7
       display-name: CentOS 7
       timeout: 20
-      instances: '["stable-3003", "stable-3004", "stable-3005", "onedir-3005", "stable-3006", "onedir-3006", "latest", "default"]'
+      instances: '["old_stable-3003", "stable-3003", "old_stable-3004", "stable-3004", "old_stable-3005", "stable-3005", "onedir-3005", "stable-3006", "onedir-3006", "latest", "default"]'
 
 
   centos-stream8:
@@ -319,7 +319,7 @@ jobs:
       distro-slug: centos-stream8
       display-name: CentOS Stream 8
       timeout: 20
-      instances: '["stable-3003", "stable-3004", "stable-3005", "onedir-3005", "stable-3006", "onedir-3006", "latest", "default"]'
+      instances: '["old_stable-3003", "stable-3003", "old_stable-3004", "stable-3004", "old_stable-3005", "stable-3005", "onedir-3005", "stable-3006", "onedir-3006", "latest", "default"]'
 
 
   centos-stream9:
@@ -347,7 +347,7 @@ jobs:
       distro-slug: debian-10
       display-name: Debian 10
       timeout: 20
-      instances: '["stable-3003", "stable-3004", "stable-3005", "onedir-3005", "stable-3006", "onedir-3006", "git-master", "latest", "default"]'
+      instances: '["old_stable-3003", "stable-3003", "old_stable-3004", "stable-3004", "old_stable-3005", "stable-3005", "onedir-3005", "stable-3006", "onedir-3006", "git-master", "latest", "default"]'
 
 
   debian-11:
@@ -361,7 +361,7 @@ jobs:
       distro-slug: debian-11
       display-name: Debian 11
       timeout: 20
-      instances: '["stable-3004", "stable-3005", "onedir-3005", "stable-3006", "onedir-3006", "git-master", "latest", "default"]'
+      instances: '["old_stable-3004", "stable-3004", "old_stable-3005", "stable-3005", "onedir-3005", "stable-3006", "onedir-3006", "git-master", "latest", "default"]'
 
 
   fedora-36:
@@ -473,7 +473,7 @@ jobs:
       distro-slug: oraclelinux-7
       display-name: Oracle Linux 7
       timeout: 20
-      instances: '["stable-3003", "stable-3004", "stable-3005", "onedir-3005", "stable-3006", "onedir-3006", "latest", "default"]'
+      instances: '["old_stable-3003", "stable-3003", "old_stable-3004", "stable-3004", "old_stable-3005", "stable-3005", "onedir-3005", "stable-3006", "onedir-3006", "latest", "default"]'
 
 
   oraclelinux-8:
@@ -487,7 +487,7 @@ jobs:
       distro-slug: oraclelinux-8
       display-name: Oracle Linux 8
       timeout: 20
-      instances: '["stable-3003", "stable-3004", "stable-3005", "onedir-3005", "stable-3006", "onedir-3006", "latest", "default"]'
+      instances: '["old_stable-3003", "stable-3003", "old_stable-3004", "stable-3004", "old_stable-3005", "stable-3005", "onedir-3005", "stable-3006", "onedir-3006", "latest", "default"]'
 
 
   photon-3:
@@ -529,7 +529,7 @@ jobs:
       distro-slug: rockylinux-8
       display-name: Rocky Linux 8
       timeout: 20
-      instances: '["stable-3004", "stable-3005", "onedir-3005", "stable-3006", "onedir-3006", "latest", "default"]'
+      instances: '["old_stable-3004", "stable-3004", "old_stable-3005", "stable-3005", "onedir-3005", "stable-3006", "onedir-3006", "latest", "default"]'
 
 
   rockylinux-9:
@@ -557,7 +557,7 @@ jobs:
       distro-slug: ubuntu-2004
       display-name: Ubuntu 20.04
       timeout: 20
-      instances: '["stable-3003", "stable-3004", "stable-3005", "onedir-3005", "stable-3006", "onedir-3006", "git-master", "latest", "default"]'
+      instances: '["old_stable-3003", "stable-3003", "old_stable-3004", "stable-3004", "old_stable-3005", "stable-3005", "onedir-3005", "stable-3006", "onedir-3006", "git-master", "latest", "default"]'
 
 
   ubuntu-2204:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,7 +249,7 @@ jobs:
       distro-slug: almalinux-8
       display-name: AlmaLinux 8
       timeout: 20
-      instances: '["old_stable-3003", "old_stable-3004", "old_stable-3005", "stable-3005", "onedir-3005", "stable-3006", "onedir-3006", "latest", "default"]'
+      instances: '["old-stable-3003", "old-stable-3004", "old-stable-3005", "stable-3005", "onedir-3005", "stable-3006", "onedir-3006", "latest", "default"]'
 
 
   almalinux-9:
@@ -277,7 +277,7 @@ jobs:
       distro-slug: amazon-2
       display-name: Amazon 2
       timeout: 20
-      instances: '["old_stable-3003", "old_stable-3004", "old_stable-3005", "stable-3005", "onedir-3005", "stable-3006", "onedir-3006", "git-master", "latest", "default"]'
+      instances: '["old-stable-3003", "old-stable-3004", "old-stable-3005", "stable-3005", "onedir-3005", "stable-3006", "onedir-3006", "git-master", "latest", "default"]'
 
 
   arch:
@@ -305,7 +305,7 @@ jobs:
       distro-slug: centos-7
       display-name: CentOS 7
       timeout: 20
-      instances: '["old_stable-3003", "old_stable-3004", "old_stable-3005", "stable-3005", "onedir-3005", "stable-3006", "onedir-3006", "latest", "default"]'
+      instances: '["old-stable-3003", "old-stable-3004", "old-stable-3005", "stable-3005", "onedir-3005", "stable-3006", "onedir-3006", "latest", "default"]'
 
 
   centos-stream8:
@@ -319,7 +319,7 @@ jobs:
       distro-slug: centos-stream8
       display-name: CentOS Stream 8
       timeout: 20
-      instances: '["old_stable-3003", "old_stable-3004", "old_stable-3005", "stable-3005", "onedir-3005", "stable-3006", "onedir-3006", "latest", "default"]'
+      instances: '["old-stable-3003", "old-stable-3004", "old-stable-3005", "stable-3005", "onedir-3005", "stable-3006", "onedir-3006", "latest", "default"]'
 
 
   centos-stream9:
@@ -347,7 +347,7 @@ jobs:
       distro-slug: debian-10
       display-name: Debian 10
       timeout: 20
-      instances: '["old_stable-3003", "old_stable-3004", "old_stable-3005", "stable-3005", "onedir-3005", "stable-3006", "onedir-3006", "git-master", "latest", "default"]'
+      instances: '["old-stable-3003", "old-stable-3004", "old-stable-3005", "stable-3005", "onedir-3005", "stable-3006", "onedir-3006", "git-master", "latest", "default"]'
 
 
   debian-11:
@@ -361,7 +361,7 @@ jobs:
       distro-slug: debian-11
       display-name: Debian 11
       timeout: 20
-      instances: '["old_stable-3004", "old_stable-3005", "stable-3005", "onedir-3005", "stable-3006", "onedir-3006", "git-master", "latest", "default"]'
+      instances: '["old-stable-3004", "old-stable-3005", "stable-3005", "onedir-3005", "stable-3006", "onedir-3006", "git-master", "latest", "default"]'
 
 
   fedora-36:
@@ -473,7 +473,7 @@ jobs:
       distro-slug: oraclelinux-7
       display-name: Oracle Linux 7
       timeout: 20
-      instances: '["old_stable-3003", "old_stable-3004", "old_stable-3005", "stable-3005", "onedir-3005", "stable-3006", "onedir-3006", "latest", "default"]'
+      instances: '["old-stable-3003", "old-stable-3004", "old-stable-3005", "stable-3005", "onedir-3005", "stable-3006", "onedir-3006", "latest", "default"]'
 
 
   oraclelinux-8:
@@ -487,7 +487,7 @@ jobs:
       distro-slug: oraclelinux-8
       display-name: Oracle Linux 8
       timeout: 20
-      instances: '["old_stable-3003", "old_stable-3004", "old_stable-3005", "stable-3005", "onedir-3005", "stable-3006", "onedir-3006", "latest", "default"]'
+      instances: '["old-stable-3003", "old-stable-3004", "old-stable-3005", "stable-3005", "onedir-3005", "stable-3006", "onedir-3006", "latest", "default"]'
 
 
   photon-3:
@@ -529,7 +529,7 @@ jobs:
       distro-slug: rockylinux-8
       display-name: Rocky Linux 8
       timeout: 20
-      instances: '["old_stable-3004", "old_stable-3005", "stable-3005", "onedir-3005", "stable-3006", "onedir-3006", "latest", "default"]'
+      instances: '["old-stable-3004", "old-stable-3005", "stable-3005", "onedir-3005", "stable-3006", "onedir-3006", "latest", "default"]'
 
 
   rockylinux-9:
@@ -557,7 +557,7 @@ jobs:
       distro-slug: ubuntu-2004
       display-name: Ubuntu 20.04
       timeout: 20
-      instances: '["old_stable-3003", "old_stable-3004", "old_stable-3005", "stable-3005", "onedir-3005", "stable-3006", "onedir-3006", "git-master", "latest", "default"]'
+      instances: '["old-stable-3003", "old-stable-3004", "old-stable-3005", "stable-3005", "onedir-3005", "stable-3006", "onedir-3006", "git-master", "latest", "default"]'
 
 
   ubuntu-2204:

--- a/.github/workflows/templates/generate.py
+++ b/.github/workflows/templates/generate.py
@@ -279,7 +279,7 @@ BLACKLIST_GIT_3006 = [
     "ubuntu-2204",
 ]
 
-BLACKLIST_GIT_MASTER = []
+BLACKLIST_GIT_MASTER = ["amazon-2", "debian-10"]
 
 SALT_VERSIONS = [
     "3003",

--- a/.github/workflows/templates/generate.py
+++ b/.github/workflows/templates/generate.py
@@ -316,6 +316,8 @@ OLD_STABLE_VERSION_BLACKLIST = [
 ]
 
 STABLE_VERSION_BLACKLIST = [
+    "3003",
+    "3004",
     "master",
     "nightly",
 ]

--- a/.github/workflows/templates/generate.py
+++ b/.github/workflows/templates/generate.py
@@ -276,7 +276,7 @@ BLACKLIST_GIT_3006 = [
     "ubuntu-2204",
 ]
 
-BLACKLIST_GIT_MASTER = ["amazon-2", "debian-10"]
+BLACKLIST_GIT_MASTER = ["amazon-2", "debian-10", "freebsd-131", "freebsd-123"]
 
 SALT_VERSIONS = [
     "3003",
@@ -467,6 +467,7 @@ def generate_test_jobs():
                     BLACKLIST = {
                         "3003": BLACKLIST_GIT_3003,
                         "3004": BLACKLIST_GIT_3004,
+                        "master": BLACKLIST_GIT_MASTER,
                     }
 
                     # .0 versions are a virtual version for pinning to the first
@@ -476,7 +477,7 @@ def generate_test_jobs():
                         continue
 
                 if (
-                    salt_version in ("3003", "3004")
+                    salt_version in ("3003", "3004", "master")
                     and distro in BLACKLIST[salt_version]
                 ):
                     continue

--- a/.github/workflows/templates/generate.py
+++ b/.github/workflows/templates/generate.py
@@ -48,6 +48,24 @@ BSD = [
     "openbsd-7",
 ]
 
+OLD_STABLE_DISTROS = [
+    "almalinux-8",
+    "amazon-2",
+    "arch",
+    "centos-7",
+    "centos-stream8",
+    "debian-10",
+    "debian-11",
+    "gentoo",
+    "gentoo-systemd",
+    "opensuse-15",
+    "opensuse-tumbleweed",
+    "oraclelinux-7",
+    "oraclelinux-8",
+    "rockylinux-8",
+    "ubuntu-2004",
+]
+
 STABLE_DISTROS = [
     "almalinux-8",
     "almalinux-9",
@@ -290,6 +308,12 @@ VERSION_DISPLAY_NAMES = {
     "latest": "Latest",
     "nightly": "Nightly",
 }
+
+OLD_STABLE_VERSION_BLACKLIST = [
+    "3006",
+    "master",
+    "nightly",
+]
 
 STABLE_VERSION_BLACKLIST = [
     "master",
@@ -574,7 +598,13 @@ def generate_test_jobs():
                 instances.append(salt_version)
                 continue
 
-            for bootstrap_type in ("stable", "git", "onedir", "onedir-rc"):
+            for bootstrap_type in (
+                "old_stable",
+                "stable",
+                "git",
+                "onedir",
+                "onedir-rc",
+            ):
                 if bootstrap_type == "onedir":
                     if salt_version not in ONEDIR_SALT_VERSIONS:
                         continue
@@ -585,6 +615,12 @@ def generate_test_jobs():
                     if salt_version not in ONEDIR_RC_SALT_VERSIONS:
                         continue
                     if distro not in ONEDIR_RC_DISTROS:
+                        continue
+
+                if bootstrap_type == "old_stable":
+                    if salt_version in OLD_STABLE_VERSION_BLACKLIST:
+                        continue
+                    if distro not in OLD_STABLE_DISTROS:
                         continue
 
                 if bootstrap_type == "stable":

--- a/.github/workflows/templates/generate.py
+++ b/.github/workflows/templates/generate.py
@@ -319,6 +319,20 @@ STABLE_VERSION_BLACKLIST = [
     "nightly",
 ]
 
+MAC_OLD_STABLE_VERSION_BLACKLIST = [
+    "3006",
+    "master",
+    "nightly",
+]
+
+MAC_STABLE_VERSION_BLACKLIST = [
+    "3003",
+    "3004",
+    "3005",
+    "master",
+    "nightly",
+]
+
 GIT_VERSION_BLACKLIST = [
     "nightly",
 ]
@@ -506,9 +520,13 @@ def generate_test_jobs():
                 instances.append(salt_version)
                 continue
 
-            for bootstrap_type in ("stable",):
+            for bootstrap_type in ("stable", "old-stable"):
                 if bootstrap_type == "stable":
-                    if salt_version in STABLE_VERSION_BLACKLIST:
+                    if salt_version in MAC_STABLE_VERSION_BLACKLIST:
+                        continue
+
+                if bootstrap_type == "old-stable":
+                    if salt_version in MAC_OLD_STABLE_VERSION_BLACKLIST:
                         continue
 
                 kitchen_target = f"{bootstrap_type}-{salt_version}"

--- a/.github/workflows/templates/generate.py
+++ b/.github/workflows/templates/generate.py
@@ -601,7 +601,7 @@ def generate_test_jobs():
                 continue
 
             for bootstrap_type in (
-                "old_stable",
+                "old-stable",
                 "stable",
                 "git",
                 "onedir",
@@ -619,7 +619,7 @@ def generate_test_jobs():
                     if distro not in ONEDIR_RC_DISTROS:
                         continue
 
-                if bootstrap_type == "old_stable":
+                if bootstrap_type == "old-stable":
                     if salt_version in OLD_STABLE_VERSION_BLACKLIST:
                         continue
                     if distro not in OLD_STABLE_DISTROS:

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -311,8 +311,7 @@ __usage() {
     - onedir_rc            Install latest onedir RC release.
     - onedir_rc [version]  Install a specific version. Only supported for
                            onedir RC packages available at repo.saltproject.io
-    - old_stable           Install latest old_stable release. This is the default
-                           install type
+    - old_stable           Install latest old_stable release.
     - old_stable [branch]  Install latest version on a branch. Only supported
                            for packages available at repo.saltproject.io
     - old_stable [version] Install a specific version. Only supported for

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -4856,7 +4856,6 @@ install_centos_git_deps() {
     # Set ONEDIR_REV to STABLE_REV in case we
     # end up calling install_centos_onedir_deps
     ONEDIR_REV=${STABLE_REV}
-    install_centos_stable_deps || \
     install_centos_onedir_deps || \
     return 1
 

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -311,21 +311,32 @@ __usage() {
     - onedir_rc            Install latest onedir RC release.
     - onedir_rc [version]  Install a specific version. Only supported for
                            onedir RC packages available at repo.saltproject.io
+    - old_stable           Install latest old_stable release. This is the default
+                           install type
+    - old_stable [branch]  Install latest version on a branch. Only supported
+                           for packages available at repo.saltproject.io
+    - old_stable [version] Install a specific version. Only supported for
+                           packages available at repo.saltproject.io
+                           To pin a 3xxx minor version, specify it as 3xxx.0
 
   Examples:
     - ${__ScriptName}
     - ${__ScriptName} stable
-    - ${__ScriptName} stable 2017.7
-    - ${__ScriptName} stable 2017.7.2
+    - ${__ScriptName} stable 3006
+    - ${__ScriptName} stable 3006.1
     - ${__ScriptName} testing
     - ${__ScriptName} git
     - ${__ScriptName} git 2017.7
     - ${__ScriptName} git v2017.7.2
     - ${__ScriptName} git 06f249901a2e2f1ed310d58ea3921a129f214358
     - ${__ScriptName} onedir
-    - ${__ScriptName} onedir 3005
+    - ${__ScriptName} onedir 3006
     - ${__ScriptName} onedir_rc
-    - ${__ScriptName} onedir_rc 3005
+    - ${__ScriptName} onedir_rc 3006
+    - ${__ScriptName} old_stable
+    - ${__ScriptName} old_stable 3005
+    - ${__ScriptName} old_stable 3005.1
+
 
   Options:
     -a  Pip install all Python pkg dependencies for Salt. Requires -V to install
@@ -625,13 +636,25 @@ elif [ "$ITYPE" = "stable" ]; then
             _ONEDIR_REV="$1"
             ITYPE="onedir"
             shift
-        elif [ "$(echo "$1" | grep -E '^(3003|3004|3005)$')" != "" ]; then
-            STABLE_REV="$1"
-            shift
-        elif [ "$(echo "$1" | grep -E '^([3-9][0-5]{2}[6-9](\.[0-9]*)?)')" != "" ]; then
+        elif [ "$(echo "$1" | grep -E '^([3-9][0-5]{2}[5-9](\.[0-9]*)?)')" != "" ]; then
             ONEDIR_REV="minor/$1"
             _ONEDIR_REV="$1"
             ITYPE="onedir"
+            shift
+        else
+            echo "Unknown stable version: $1 (valid: 3005, 3006, latest)"
+            exit 1
+        fi
+    fi
+
+# If doing old_stable install, check if version specified
+elif [ "$ITYPE" = "old_stable" ]; then
+    if [ "$#" -eq 0 ];then
+        ITYPE="stable"
+    else
+        if [ "$(echo "$1" | grep -E '^(3003|3004|3005)$')" != "" ]; then
+            STABLE_REV="$1"
+            ITYPE="stable"
             shift
         elif [ "$(echo "$1" | grep -E '^([3-9][0-5]{3}(\.[0-9]*)?)$')" != "" ]; then
             # Handle the 3xxx.0 version as 3xxx archive (pin to minor) and strip the fake ".0" suffix
@@ -641,7 +664,7 @@ elif [ "$ITYPE" = "stable" ]; then
             fi
             shift
         else
-            echo "Unknown stable version: $1 (valid: 3003, 3004, 3005, 3006, latest)"
+            echo "Unknown stable version: $1 (valid: 3003, 3004, 3005)"
             exit 1
         fi
     fi
@@ -4574,6 +4597,12 @@ install_fedora_onedir_post() {
 #   CentOS Install Functions
 #
 __install_saltstack_rhel_repository() {
+  if [ "${DISTRO_MAJOR_VERSION}" -ge 9 ]; then
+    echoerror "Old stable repository unavailable on RH variants greater than or equal to 9"
+    echoerror "Use the stable install type."
+    exit 1
+  fi
+
     if [ "$ITYPE" = "stable" ]; then
         repo_rev="$STABLE_REV"
     else

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -630,7 +630,7 @@ elif [ "$ITYPE" = "stable" ]; then
         _ONEDIR_REV="latest"
         ITYPE="onedir"
     else
-        if [ "$(echo "$1" | grep -E '^(nightly|latest|3006)$')" != "" ]; then
+        if [ "$(echo "$1" | grep -E '^(nightly|latest|3005|3006)$')" != "" ]; then
             ONEDIR_REV="$1"
             _ONEDIR_REV="$1"
             ITYPE="onedir"

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -311,10 +311,10 @@ __usage() {
     - onedir_rc            Install latest onedir RC release.
     - onedir_rc [version]  Install a specific version. Only supported for
                            onedir RC packages available at repo.saltproject.io
-    - old_stable           Install latest old_stable release.
-    - old_stable [branch]  Install latest version on a branch. Only supported
+    - old-stable           Install latest old stable release.
+    - old-stable [branch]  Install latest version on a branch. Only supported
                            for packages available at repo.saltproject.io
-    - old_stable [version] Install a specific version. Only supported for
+    - old-stable [version] Install a specific version. Only supported for
                            packages available at repo.saltproject.io
                            To pin a 3xxx minor version, specify it as 3xxx.0
 
@@ -332,9 +332,9 @@ __usage() {
     - ${__ScriptName} onedir 3006
     - ${__ScriptName} onedir_rc
     - ${__ScriptName} onedir_rc 3006
-    - ${__ScriptName} old_stable
-    - ${__ScriptName} old_stable 3005
-    - ${__ScriptName} old_stable 3005.1
+    - ${__ScriptName} old-stable
+    - ${__ScriptName} old-stable 3005
+    - ${__ScriptName} old-stable 3005.1
 
 
   Options:
@@ -606,7 +606,7 @@ if [ "$#" -gt 0 ];then
 fi
 
 # Check installation type
-if [ "$(echo "$ITYPE" | grep -E '(stable|testing|git|onedir|onedir_rc|old_stable)')" = "" ]; then
+if [ "$(echo "$ITYPE" | grep -E '(stable|testing|git|onedir|onedir_rc|old-stable)')" = "" ]; then
     echoerror "Installation type \"$ITYPE\" is not known..."
     exit 1
 fi
@@ -646,8 +646,8 @@ elif [ "$ITYPE" = "stable" ]; then
         fi
     fi
 
-# If doing old_stable install, check if version specified
-elif [ "$ITYPE" = "old_stable" ]; then
+# If doing old-stable install, check if version specified
+elif [ "$ITYPE" = "old-stable" ]; then
     if [ "$#" -eq 0 ];then
         ITYPE="stable"
     else
@@ -663,7 +663,7 @@ elif [ "$ITYPE" = "old_stable" ]; then
             fi
             shift
         else
-            echo "Unknown old_stable version: $1 (valid: 3003, 3004, 3005)"
+            echo "Unknown old stable version: $1 (valid: 3003, 3004, 3005)"
             exit 1
         fi
     fi

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -652,6 +652,7 @@ elif [ "$ITYPE" = "old-stable" ]; then
             shift
         elif [ "$(echo "$1" | grep -E '^([3-9][0-5]{3}(\.[0-9]*)?)$')" != "" ]; then
             # Handle the 3xxx.0 version as 3xxx archive (pin to minor) and strip the fake ".0" suffix
+            ITYPE="stable"
             STABLE_REV=$(echo "$1" | sed -E 's/^([3-9][0-9]{3})\.0$/\1/')
             if [ "$(uname)" != "Darwin" ]; then
                 STABLE_REV="archive/$STABLE_REV"

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -606,7 +606,7 @@ if [ "$#" -gt 0 ];then
 fi
 
 # Check installation type
-if [ "$(echo "$ITYPE" | grep -E '(stable|testing|git|onedir|onedir_rc)')" = "" ]; then
+if [ "$(echo "$ITYPE" | grep -E '(stable|testing|git|onedir|onedir_rc|old_stable)')" = "" ]; then
     echoerror "Installation type \"$ITYPE\" is not known..."
     exit 1
 fi
@@ -663,7 +663,7 @@ elif [ "$ITYPE" = "old_stable" ]; then
             fi
             shift
         else
-            echo "Unknown stable version: $1 (valid: 3003, 3004, 3005)"
+            echo "Unknown old_stable version: $1 (valid: 3003, 3004, 3005)"
             exit 1
         fi
     fi

--- a/kitchen.macos.yml
+++ b/kitchen.macos.yml
@@ -18,15 +18,15 @@ platforms:
   - name: macos-1015
 
 suites:
-  - name: stable-3003
+  - name: old-stable-3003
     provisioner:
       salt_version: 3003.4
       salt_call_command: /opt/salt/bin/salt-call
-  - name: stable-3004
+  - name: old-stable-3004
     provisioner:
       salt_version: 3004.1
       salt_call_command: /opt/salt/bin/salt-call
-  - name: stable-3005
+  - name: old-stable-3005
     provisioner:
       salt_version: 3005.1
       salt_call_command: /opt/salt/bin/salt-call

--- a/kitchen.macos.yml
+++ b/kitchen.macos.yml
@@ -20,14 +20,17 @@ platforms:
 suites:
   - name: old-stable-3003
     provisioner:
+      salt_bootstrap_options: -MP old-stable %s
       salt_version: 3003.4
       salt_call_command: /opt/salt/bin/salt-call
   - name: old-stable-3004
     provisioner:
+      salt_bootstrap_options: -MP old-stable %s
       salt_version: 3004.1
       salt_call_command: /opt/salt/bin/salt-call
   - name: old-stable-3005
     provisioner:
+      salt_bootstrap_options: -MP old-stable %s
       salt_version: 3005.1
       salt_call_command: /opt/salt/bin/salt-call
   - name: stable-3006

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -224,10 +224,10 @@ suites:
       - freebsd-131
       - freebsd-123
       - openbsd-6
-  - name: stable-3003-0
+  - name: old-stable-3003-0
     provisioner:
       salt_version: 3003
-      salt_bootstrap_options: -x python3 -MP stable 3003.0
+      salt_bootstrap_options: -x python3 -MP old_stable 3003.0
     excludes:
       - opensuse-15
       - opensuse-tumbleweed
@@ -244,10 +244,10 @@ suites:
       - freebsd-131
       - freebsd-123
       - openbsd-6
-  - name: stable-3003
+  - name: old-stable-3003
     provisioner:
       salt_version: 3003
-      salt_bootstrap_options: -x python3 -MP stable %s
+      salt_bootstrap_options: -x python3 -MP old-stable %s
     excludes:
       - opensuse-15
       - opensuse-tumbleweed
@@ -255,10 +255,10 @@ suites:
       - freebsd-131
       - freebsd-123
       - openbsd-6
-  - name: stable-3004-0
+  - name: old-stable-3004-0
     provisioner:
       salt_version: 3004
-      salt_bootstrap_options: -x python3 -MP stable 3004.0
+      salt_bootstrap_options: -x python3 -MP old-stable 3004.0
     excludes:
       - opensuse-15
       - opensuse-tumbleweed
@@ -268,10 +268,21 @@ suites:
       - freebsd-131
       - freebsd-123
       - openbsd-6
-  - name: stable-3004
+  - name: old-stable-3004
     provisioner:
       salt_version: 3004
-      salt_bootstrap_options: -x python3 -MP stable %s
+      salt_bootstrap_options: -x python3 -MP old-stable %s
+    excludes:
+      - opensuse-15
+      - opensuse-tumbleweed
+      - arch
+      - freebsd-131
+      - freebsd-123
+      - openbsd-6
+  - name: old-stable-3005
+    provisioner:
+      salt_version: 3005
+      salt_bootstrap_options: -x python3 -MP old-stable %s
     excludes:
       - opensuse-15
       - opensuse-tumbleweed

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -227,7 +227,7 @@ suites:
   - name: old-stable-3003-0
     provisioner:
       salt_version: 3003
-      salt_bootstrap_options: -x python3 -MP old_stable 3003.0
+      salt_bootstrap_options: -x python3 -MP old-stable 3003.0
     excludes:
       - opensuse-15
       - opensuse-tumbleweed


### PR DESCRIPTION
### What does this PR do?
Add an old_stable install type to avoid cluttering up stable with older non-onedir installs

### What issues does this PR fix or reference?
N/A
