### PR TITLE
Set RootDir depending on Salt Version

### DIFF
--- a/bootstrap-salt.ps1
+++ b/bootstrap-salt.ps1
@@ -353,7 +353,14 @@ if ($RunService.ToLower() -eq "true") {
 
 $ConfiguredAnything = $False
 
-$RootDir = "C:\salt"
+# Detect older version of Salt to determing default RootDir
+if ($majorVersion -lt 3004) {
+    $RootDir = "$env:SystemDrive`:\salt"
+} else {
+    $RootDir = "$env:ProgramData\Salt Project\Salt"
+}
+
+# Check for existing installation where RootDir is stored in the registry
 $SaltRegKey = "HKLM:\SOFTWARE\Salt Project\Salt"
 if (Test-Path -Path $SaltRegKey) {
     if ($null -ne (Get-ItemProperty $SaltRegKey).root_dir) {


### PR DESCRIPTION
### What does this PR do?
Sets the default RootDir based on the version of Salt. Versions before 3004 used `C:\salt`. 3004 and older use `C:\ProgramData\Program Files\Salt`.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-bootstrap/issues/1950

### Previous Behavior
All installations would lay down conf in `C:\Salt`

### New Behavior
Now it detects the version being installed and sets up the appropriate RootDir
