### PR TITLE
Debian 12 arm64

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1524,7 +1524,7 @@ __check_dpkg_architecture() {
             else
                 # Saltstack official repository has arm64 metadata beginning with Debian 11,
                 # use amd64 repositories on arm64 for anything older, since all pkgs are arch-independent
-                if [ "$DISTRO_NAME_L" = "debian" ] || [ "$DISTRO_MAJOR_VERSION" -lt 11 ]; then
+                if [ "$DISTRO_NAME_L" = "debian" ] && [ "$DISTRO_MAJOR_VERSION" -lt 11 ]; then
                   __REPO_ARCH="amd64"
                 else
                   __REPO_ARCH="arm64"

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1712,6 +1712,11 @@ __debian_codename_translation() {
             ;;
         "12")
             DISTRO_CODENAME="bookworm"
+            # FIXME - TEMPORARY
+            # use bullseye packages until bookworm packages are available
+            DISTRO_CODENAME="bullseye"
+            DISTRO_MAJOR_VERSION=11
+            rv=11
             ;;
         *)
             DISTRO_CODENAME="stretch"

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1710,6 +1710,9 @@ __debian_codename_translation() {
         "11")
             DISTRO_CODENAME="bullseye"
             ;;
+        "12")
+            DISTRO_CODENAME="bookworm"
+            ;;
         *)
             DISTRO_CODENAME="stretch"
             ;;


### PR DESCRIPTION
### What does this PR do?
- Fixes Debian arm64 package architecture selection logic (1fe4f5d7e046d92be40a7b59451cdd9abb7e48bf)
- Adds Debian 12 codename (c8ec3e8b2336ef76287e7ec83614a0ac34c16669)
- Temporarily uses Debian 11 packages when installed on Debian 12 (f6cce49722e9bd5c529c69e10449866ea90bd41e)

### Previous Behavior
- arm64 packages were not used when installed on Debian 11 or 12 due to logic error
- fails to install correctly on Debian 12

### New Behavior
Installs correctly on Debian 12 arm64
