### PR TITLE
Ensure find command available in RHEL-based distros

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -4808,7 +4808,7 @@ install_centos_stable_deps() {
         fi
     fi
 
-    __PACKAGES="${__PACKAGES} procps"
+    __PACKAGES="${__PACKAGES} procps findutils"
 
     # shellcheck disable=SC2086
     __yum_install_noinput ${__PACKAGES} || return 1
@@ -5108,7 +5108,7 @@ install_centos_onedir_deps() {
         __PACKAGES="yum-utils chkconfig"
     fi
 
-    __PACKAGES="${__PACKAGES} procps"
+    __PACKAGES="${__PACKAGES} procps findutils"
 
     # shellcheck disable=SC2086
     __yum_install_noinput ${__PACKAGES} || return 1


### PR DESCRIPTION
### What does this PR do?

The Rocky Linux 8 container doesn't ship the package `findutils`.
Since salt 3006 there seems to be a scriptlet, in the the salt rpm and ondir package which requires the `find` command.

This PR adds the `findutils` package to the install dependencies for all RHEL-based distros.
In almost all cases, this package is pre-installed, and therefore doesn't seem to be a significant impact.

### What issues does this PR fix or reference?

#1991
