### PR TITLE
Revert "Merge pull request #1983 from Dudek-AMS/develop"

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -3660,10 +3660,10 @@ __install_saltstack_debian_repository() {
     __apt_get_install_noinput ${__PACKAGES} || return 1
 
     # amd64 is just a part of repository URI, 32-bit pkgs are hosted under the same location
-    SALTSTACK_DEBIAN_URL="${HTTP_VAL}://${_REPO_URL}/${__PY_VERSION_REPO}/debian/${DEBIAN_RELEASE}/${__REPO_ARCH}"
+    SALTSTACK_DEBIAN_URL="${HTTP_VAL}://${_REPO_URL}/${__PY_VERSION_REPO}/debian/${DEBIAN_RELEASE}/${__REPO_ARCH}/${STABLE_REV}"
     echo "$__REPO_ARCH_DEB $SALTSTACK_DEBIAN_URL $DEBIAN_CODENAME main" > "/etc/apt/sources.list.d/salt.list"
 
-    __apt_key_fetch "$SALTSTACK_DEBIAN_URL/SALT-PROJECT-GPG-PUBKEY-2023.gpg" || return 1
+    __apt_key_fetch "$SALTSTACK_DEBIAN_URL/salt-archive-keyring.gpg" || return 1
 
     __wait_for_apt apt-get update || return 1
 }


### PR DESCRIPTION
This reverts commit e05d70558f7aa1bc4b3ecce530e1ad60f4bab7ac, reversing changes made to 59af6ad185ec7334b4eedb4fa6fa287e06956427.

### What does this PR do?

I spoke a bit about what I think happened [here](https://github.com/saltstack/salt-bootstrap/issues/1986#issuecomment-2038485346), but in short:

The two lines of link changes in #1983 caused a regression by updating the [legacy repository](https://repo.saltproject.io/py3/debian/11/amd64/latest/) installation codepath with links to the new, incompatible [onedir file hierarchy](https://repo.saltproject.io/salt/py3/debian/11/amd64/).

- Works:
    - `http://repo.saltproject.io/py3/debian/11/amd64/latest/salt-archive-keyring.gpg`
    - `http://repo.saltproject.io/salt/py3/debian/11/amd64/SALT-PROJECT-GPG-PUBKEY-2023.gpg`
- Doesn't Work:
    - `http://repo.saltproject.io/py3/debian11/amd64/latest/SALT-PROJECT-GPG-PUBKEY-2023.gpg`

Subsequently, the release of [v2024.04.03](https://github.com/saltstack/salt-bootstrap/releases/tag/v2024.04.03) has broken all the Debian 10/11 VM provisioning at my workplace (currently pinned to salt version 3004.2).

I've chosen to do a simple revert since the original PR changed code that was unrelated to the quoted issue. `__install_saltstack_debian_repository` was updated instead of `__install_saltstack_debian_onedir_repository`, but the former has no ability to generate the problematic `https://repo.saltproject.io/salt/py3/debian/12/amd64/latest/salt-archive-keyring.gpg` link they were referencing without a custom repo URL being passed in with `-R`.

What was more likely is that the latter function [attempts to download from legacy before trying the onedir repository](https://github.com/Dudek-AMS/salt-bootstrap/blob/cecea60a06312057d55d6348d80552b3108a2ea5/bootstrap-salt.sh) before continuing to the `SALT-PROJECT-GPG-PUBKEY-2023.gpg` case, and the author was just seeing that uncaptured output go to STDERR and assumed it was a failure. 

This is supported since we never actually replicated their reported issue and they never provided evidence on the bootstrap process failing. In fact, right after the error line in their terminal we see "Hit: ...", indicating that execution continued. And looking at #1988  we can see exactly that, resulting in a successful bootstrapping. The issue there really being that the script should more clearly explain that it's a soft failure and that it's moving on to a different method OR send that initial command's STDERR to the void.

### What issues does this PR fix or reference?

Resolves #1986 (closed, but not yet addressed).

### Previous Behavior

All legacy repository (non-onedir) repository installations on Debian fail due to an invalid URL used to download the GPG key.

### New Behavior

It works.

This does NOT address the issue described by the original PR or #1988. The STDERR line is still generated.