### PR TITLE
Add script version to powershell script

### DIFF
--- a/.github/workflows/scripts/cut-release.py
+++ b/.github/workflows/scripts/cut-release.py
@@ -188,6 +188,7 @@ def main():
         + changelog_file.read_text()
     )
 
+    # Update Script Version for the bash script
     bootstrap_script_path = REPO_ROOT / "bootstrap-salt.sh"
     print(
         f"* Updating {bootstrap_script_path.relative_to(REPO_ROOT)} ...",
@@ -201,6 +202,22 @@ def main():
             bootstrap_script_path.read_text(),
         )
     )
+
+    # Update the Script Version for the powershell script
+    bootstrap_script_path = REPO_ROOT / "bootstrap-salt.ps1"
+    print(
+        f"* Updating {bootstrap_script_path.relative_to(REPO_ROOT)} ...",
+        file=sys.stderr,
+        flush=True,
+    )
+    bootstrap_script_path.write_text(
+        re.sub(
+            r'\$__ScriptVersion = "(.*)"',
+            f'$__ScriptVersion = "{options.release_tag.lstrip("v")}"',
+            bootstrap_script_path.read_text(),
+        )
+    )
+
     parser.exit(status=0, message="CHANGELOG.md and bootstrap-salt.sh updated\n")
 
 

--- a/bootstrap-salt.ps1
+++ b/bootstrap-salt.ps1
@@ -94,7 +94,12 @@ param(
     [Parameter(Mandatory=$false)]
     [Alias("h")]
     # Displays help for this script.
-    [Switch] $Help
+    [Switch] $Help,
+
+    [Parameter(Mandatory=$false)]
+    [Alias("e")]
+    # Displays the Version for this script.
+    [Switch] $ScriptVersion
 )
 
 # We'll check for help first because it really has no requirements
@@ -102,6 +107,15 @@ if ($help) {
     # Get the full script name
     $this_script = & {$myInvocation.ScriptName}
     Get-Help $this_script -Detailed
+    exit 0
+}
+
+$__ScriptVersion = "2024.04.03"
+$ScriptName = $myInvocation.MyCommand.Name
+
+# We'll check for the Version next, because it also has no requirements
+if ($ScriptVersion) {
+    Write-Host $__ScriptVersion
     exit 0
 }
 
@@ -303,6 +317,8 @@ if ( [Uri]($RepoUrl).AbsoluteUri -eq $defaultUrl ) {
 #===============================================================================
 # Verify Parameters
 #===============================================================================
+Write-Verbose "Running Script: $ScriptName"
+Write-Verbose "Script Version: $__ScriptVersion"
 Write-Verbose "Parameters passed in:"
 Write-Verbose "version: $Version"
 Write-Verbose "runservice: $RunService"


### PR DESCRIPTION
### What does this PR do?
Adds a script version to the bootstrap script for Windows. Adds a new option (`ScriptVersion`) to display the version. Updates the CICD to update the version of the script on each release.