### PR TITLE
Add support for mint-21

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1456,6 +1456,7 @@ __ubuntu_derivatives_translation() {
     linuxmint_18_ubuntu_base="16.04"
     linuxmint_19_ubuntu_base="18.04"
     linuxmint_20_ubuntu_base="20.04"
+    linuxmint_21_ubuntu_base="22.04"
     linaro_12_ubuntu_base="12.04"
     elementary_os_02_ubuntu_base="12.04"
     neon_16_ubuntu_base="16.04"


### PR DESCRIPTION
Mint 21 is an Ubuntu 22.04 derivative so add it to the list.

### What does this PR do?

Adds support for Linux Mint 21

### What issues does this PR fix or reference?

Lack of Linux Mint 21 support.