### PR TITLE
Use debian 12 repo on debian 12

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1713,11 +1713,6 @@ __debian_codename_translation() {
             ;;
         "12")
             DISTRO_CODENAME="bookworm"
-            # FIXME - TEMPORARY
-            # use bullseye packages until bookworm packages are available
-            DISTRO_CODENAME="bullseye"
-            DISTRO_MAJOR_VERSION=11
-            rv=11
             ;;
         *)
             DISTRO_CODENAME="stretch"


### PR DESCRIPTION
### What does this PR do?

When Debian 12 bookworm was released and salt project didn't have a debian 12 repo at that time, a hack was introduced in salt-bootstrap to use debian 11 repo.

Salt project Debian 12 repo is available since decembre 2023 so it's largely time to remove that hack and to use Debian 12 repo on Debian 12 instead of Debian 11 repo.

### What issues does this PR fix or reference?

This PR prevent a future issue (maybe) :P

### Previous Behavior

Debian 11 repository configured on Debian 12 machines

### New Behavior

Use Debian 12 repo on Debian 12 machines
