### PR TITLE
Fix installing salt 3007 as stable or onedir

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -630,7 +630,7 @@ elif [ "$ITYPE" = "stable" ]; then
         _ONEDIR_REV="latest"
         ITYPE="onedir"
     else
-        if [ "$(echo "$1" | grep -E '^(nightly|latest|3005|3006)$')" != "" ]; then
+        if [ "$(echo "$1" | grep -E '^(nightly|latest|3005|3006|3007)$')" != "" ]; then
             ONEDIR_REV="$1"
             _ONEDIR_REV="$1"
             ITYPE="onedir"
@@ -641,7 +641,7 @@ elif [ "$ITYPE" = "stable" ]; then
             ITYPE="onedir"
             shift
         else
-            echo "Unknown stable version: $1 (valid: 3005, 3006, latest)"
+            echo "Unknown stable version: $1 (valid: 3005, 3006, 3007, latest)"
             exit 1
         fi
     fi
@@ -673,7 +673,7 @@ elif [ "$ITYPE" = "onedir" ]; then
     if [ "$#" -eq 0 ];then
         ONEDIR_REV="latest"
     else
-        if [ "$(echo "$1" | grep -E '^(nightly|latest|3005|3006)$')" != "" ]; then
+        if [ "$(echo "$1" | grep -E '^(nightly|latest|3005|3006|3007)$')" != "" ]; then
             ONEDIR_REV="$1"
             shift
         elif [ "$(echo "$1" | grep -E '^(3005(\.[0-9]*)?)')" != "" ]; then
@@ -685,7 +685,7 @@ elif [ "$ITYPE" = "onedir" ]; then
             ONEDIR_REV="minor/$1"
             shift
         else
-            echo "Unknown onedir version: $1 (valid: 3005, 3006, latest, nightly.)"
+            echo "Unknown onedir version: $1 (valid: 3005, 3006, 3007, latest, nightly.)"
             exit 1
         fi
     fi


### PR DESCRIPTION
### What does this PR do?

When trying to install salt 3007 as onedir or stable specifying only the major (which means the latest minor in this major serie for salt 3005 and 3006), under debian ot ubuntu, salt-bootstrap fails because it looks for the repo signing key iin `minor/3007` instead of just `3007`

This PR fixes that behaviour and let you install salt 3007 major as onedir or stable

### Previous Behavior

salt-bootstrap onedir 3007 fails on debian or ubuntu

### New Behavior

salt-bootstrap onedir 3007 works on debian or ubuntu
