### PR TITLE
Add support to install on Ubuntu 24.04 Noble Numbat

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1612,6 +1612,9 @@ __ubuntu_codename_translation() {
         "22")
             DISTRO_CODENAME="jammy"
             ;;
+        "24")
+            DISTRO_CODENAME="noble"
+            ;;
         *)
             DISTRO_CODENAME="trusty"
             ;;


### PR DESCRIPTION
### What does this PR do?

This PR add support for salt 3007 installation as onedir or stable package on Ubuntu 24.04 Noble Numbat using salt's Ubuntu 24.04 repositories.

It currently only support salt 3007 as other versions are not available in saltstack's Ubuntu 24.04 repos

### Previous Behavior

Installation failure on Ubuntu 24.04

### New Behavior

Installation works on Ubuntu 24.04