### PR TITLE
Update bootstrap-salt.sh

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1389,6 +1389,7 @@ __check_dpkg_architecture() {
             ;;
         "arm64")
             # Saltstack official repository has full arm64 support since 3006
+            error_msg=""
             __REPO_ARCH="arm64"
             __REPO_ARCH_DEB="deb [signed-by=/usr/share/keyrings/salt-archive-keyring.gpg arch=$__REPO_ARCH]"
             ;;


### PR DESCRIPTION
On arm64 platforms, bootstrap fails to finish installation due to missing variable 'error_msg=""' in case statement. This change adds a single line to fix the bug.

### What does this PR do?
Add a single line with 'error_msg=""' to arm64 check statment

### What issues does this PR fix or reference?
Fix installation on arm64 architecture.

### Previous Behavior
Before, the script failed to deploy salt on the arm64 platform due to error on 1409 LoC

### New Behavior
Successfully, now I can install salt on arm64
