### PR TITLE
Updated README, and removed experimental  to ability install different Python version which was limited to RHEL 7, which is EOL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,6 +22,11 @@ that, please read the generated help by passing ``-h`` to the script or even bet
 
 Also, to secure your Salt installation, check out these instructions for `hardening salt`_.
 
+Older versions of Salt prior to 3006 are no longer supported by this bootstrap script as they have
+reached their End-Of-Life. Only onedir-based architecture versions of Salt are supported by this
+bootstrap script.
+
+
 Bootstrap
 =========
 
@@ -88,12 +93,12 @@ To view the latest options and descriptions for ``salt-bootstrap``, use ``-h`` a
   Examples:
     - bootstrap-salt.sh
     - bootstrap-salt.sh stable
-    - bootstrap-salt.sh stable 3004.1
-    - bootstrap-salt.sh stable v3003.4
+    - bootstrap-salt.sh stable 3006.7
+    - bootstrap-salt.sh stable v3006.8
     - bootstrap-salt.sh testing
     - bootstrap-salt.sh git
-    - bootstrap-salt.sh git 3004.1
-    - bootstrap-salt.sh git v3003.4
+    - bootstrap-salt.sh git 3007.1
+    - bootstrap-salt.sh git v3007.1
     - bootstrap-salt.sh git 06f249901a2e2f1ed310d58ea3921a129f214358
 
   Options:
@@ -174,16 +179,8 @@ To view the latest options and descriptions for ``salt-bootstrap``, use ``-h`` a
         no ".bak" file will be created as either of those options will force
         a complete overwrite of the file.
     -q  Quiet salt installation from git (setup.py install -q)
-    -x  Changes the Python version used to install Salt.
-        For CentOS 6 git installations python2.7 is supported.
-        Fedora git installation, CentOS 7, Ubuntu 18.04 support python3.
-    -y  Installs a different python version on host. Currently this has only been
-        tested with CentOS 6 and is considered experimental. This will install the
-        ius repo on the box if disable repo is false. This must be used in conjunction
-        with -x <pythonversion>.  For example:
-            sh bootstrap.sh -P -y -x python2.7 git v2017.7.2
-        The above will install python27 and install the git version of salt using the
-        python2.7 executable. This only works for git and pip installations.
+    -x  Changes the Python version used to install Salt (default: Python 3)
+        Python 2.7 is not longer supported.
     -Q  Quickstart, install the Salt master and the Salt minion.
         And automatically accept the minion key.
 
@@ -286,19 +283,12 @@ However, the ``-P`` flag is not necessary for Git-based bootstraps.
 Install using Python
 ~~~~~~~~~~~~~~~~~~~~
 
-If you already have Python installed, ``python 2.7``, then it's as easy as:
+If you already have Python installed, ``python 3.10``, then it's as easy as:
 
 .. code:: console
 
   python -m urllib "https://bootstrap.saltproject.io" > bootstrap-salt.sh
   sudo sh bootstrap-salt.sh -P stable 3006.1
-
-With python version 2, the following in-line code should always work:
-
-.. code:: console
-
-  python -c 'import urllib; print urllib.urlopen("https://bootstrap.saltproject.io").read()' > bootstrap-salt.sh
-  sudo sh bootstrap-salt.sh git master
 
 With python version 3:
 
@@ -307,34 +297,7 @@ With python version 3:
   python3 -c 'import urllib.request; print(urllib.request.urlopen("https://bootstrap.saltproject.io").read().decode("ascii"))' > bootstrap-salt.sh
   sudo sh bootstrap-salt.sh git v3006.1
 
-Install using fetch
-~~~~~~~~~~~~~~~~~~~
-
-On a FreeBSD-based system you usually don't have either of the above binaries available. You **do**
-have ``fetch`` available though:
-
-.. code:: console
-
-  fetch -o bootstrap-salt.sh https://bootstrap.saltproject.io
-  sudo sh bootstrap-salt.sh
-
-If you have any SSL issues install ``ca_root_nss``:
-
-.. code:: console
-
-  pkg install ca_root_nss
-
-And either copy the certificates to the place where fetch can find them:
-
-.. code:: console
-
-  cp /usr/local/share/certs/ca-root-nss.crt /etc/ssl/cert.pem
-
-Or link them to the right place:
-
-.. code:: console
-
-  ln -s /usr/local/share/certs/ca-root-nss.crt /etc/ssl/cert.pem
+Note: Python 2.x is no longer supported given it reached it's End-Of-Life Jan. 1st, 2020
 
 
 Installing via an Insecure One-Liner
@@ -366,13 +329,17 @@ Installing a target version package of Salt from the Salt Project repo:
 
 .. code:: console
 
-  curl -L https://bootstrap.saltproject.io | sudo sh -s -- stable 3006.1
+  curl -L https://bootstrap.saltproject.io | sudo sh -s -- stable 3006.8
 
 Installing the latest master branch of Salt from git:
 
 .. code:: console
 
   curl -L https://bootstrap.saltproject.io | sudo sh -s -- git master
+
+Note: use of git is recommended for development environments, for example: testing new features of
+Salt which have not yet been released.
+It is recommended that production environments should use ``stable``.
 
 
 Install on Windows
@@ -405,10 +372,10 @@ Supported Operating Systems
 ---------------------------
 
 The salt-bootstrap script officially supports the distributions outlined in
-`Salt's Supported Operating Systems`_ document, except for Solaris and AIX. The operating systems
-listed below should reflect this document but may become out of date. If an operating system is
-listed below, but is not listed on the official supported operating systems document, the level of
-support is "best-effort".
+`Salt's Supported Operating Systems`_ document, (BSD-based OSs, Solaris and AIX are no longer
+supported).  The operating systems listed below should reflect this document but may become out of
+date. If an operating system is listed below, but is not listed on the official supported operating
+systems document, the level of support is "best-effort".
 
 Since Salt is written in Python, the packages available from the `Salt Project's repository`_ are
 CPU architecture independent and could be installed on any hardware supported by Linux kernel.
@@ -416,7 +383,7 @@ However, the Salt Project does package Salt's binary dependencies only for ``x86
 and ``AArch64`` (``arm64``).
 
 It is recommended to use ``git`` bootstrap mode as described above to install Salt on other
-architectures, such as ``x86`` (``i386``), ``AArch64`` (``arm64``) or ``ARM EABI`` (``armel``).
+architectures, such as ``x86`` (``i386``) or ``ARM EABI`` (``armel``).
 You also may need to disable repository configuration and allow ``pip`` installations by providing
 ``-r`` and ``-P`` options to the bootstrap script, i.e.:
 
@@ -435,8 +402,8 @@ Debian and derivatives
 ~~~~~~~~~~~~~~~~~~~~~~
 
 - Cumulus Linux 2/3
-- Debian GNU/Linux 9/10/11
-- Devuan GNU/Linux 1/2
+- Debian GNU/Linux 9/10/11/12
+- Devuan GNU/Linux 1/2/3/4/5
 - Kali Linux 1.0 (based on Debian 7)
 - Linux Mint Debian Edition 1 (based on Debian 8)
 - Raspbian 8 (``armhf`` packages) and 9 (using ``git`` installation mode only)
@@ -447,10 +414,11 @@ Red Hat family
 
 - Amazon Linux 2012.3 and later
 - Amazon Linux 2
+- Amazon Linux 2023
 - CentOS 7/8/9
 - Cloud Linux 6/7
-- Fedora 36/37/38 (install latest stable from standard repositories)
-- Oracle Linux 7/8
+- Fedora 38/39/40 (install latest stable from standard repositories)
+- Oracle Linux 7/8/9
 - Red Hat Enterprise Linux 7/8/9
 - Scientific Linux 7/8/9
 
@@ -464,8 +432,7 @@ SUSE family
 - SUSE Linux Enterprise Server 11 SP4, 12 SP2
 
 **NOTE:** Leap 15 installs Python 3 Salt packages by default. Salt is packaged by SUSE, and
-Leap 15 ships with Python 3. Salt with Python 2 can be installed using the the ``-x`` option
-in combination with the ``git`` installation method.
+Leap 15 ships with Python 3.
 
 .. code:: console
 
@@ -475,7 +442,7 @@ in combination with the ``git`` installation method.
 Ubuntu and derivatives
 ~~~~~~~~~~~~~~~~~~~~~~
 
-- KDE neon (based on Ubuntu 18.04/20.04/22.04)
+- KDE neon (based on Ubuntu 20.04/22.04/24.04)
 - Linux Mint 17/18
 
 Ubuntu Best Effort Support: Non-LTS Releases
@@ -506,12 +473,11 @@ UNIX systems
 
 **BSD**:
 
-- OpenBSD (``pip`` installation)
-- FreeBSD 11/12/13/14-CURRENT
+- No longer supported
 
 **SunOS**:
 
-- SmartOS (2015Q4 and later)
+- No longer supported
 
 
 Using a custom salt bootstrap
@@ -589,8 +555,8 @@ Salt is ready and working in the Docker container with the Minion authenticated 
 
 **NOTE**
 
-The ``Dockerfile`` here inherits the Ubuntu 14.04 public image with Upstart configured as the init
-system. Use it as an example or starting point of how to make your own Docker images with suitable
-Salt components, custom configurations, and even `pre-accepted Minion keys`_ already installed.
+The ``Dockerfile`` here inherits the Ubuntu 20.04 public image. Use it as an example or starting
+point of how to make your own Docker images with suitable Salt components, custom configurations,
+and even `pre-accepted Minion keys`_ already installed.
 
 .. vim: fenc=utf-8 spell spl=en cc=100 tw=99 fo=want sts=2 sw=2 et

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -26,7 +26,7 @@
 #======================================================================================================================
 set -o nounset                              # Treat unset variables as an error
 
-__ScriptVersion="2024.07.16"
+__ScriptVersion="2024.07.17"
 __ScriptName="bootstrap-salt.sh"
 
 __ScriptFullName="$0"
@@ -404,9 +404,8 @@ __usage() {
     -v  Display script version
     -V  Install Salt into virtualenv
         (only available for Ubuntu based distributions)
-    -x  Changes the Python version used to install Salt.
+    -x  Changes the Python version used to install Salt (default: Python 3).
         Python 2.7 is no longer supported.
-        Fedora git installation, CentOS 8, Ubuntu 20.04 support python3.
     -X  Do not start daemons after installation
 
 EOT
@@ -1237,43 +1236,6 @@ __gather_linux_system_info() {
         break
     done
 }
-
-
-#---  FUNCTION  -------------------------------------------------------------------------------------------------------
-#          NAME:  __install_python()
-#   DESCRIPTION:  Install a different version of python on a host. Currently this has only been tested on CentOS 6 and
-#                 is considered experimental.
-#----------------------------------------------------------------------------------------------------------------------
-__install_python() {
-    if [ "$_PY_EXE" = "" ]; then
-        echoerror "Must specify -x <pythonversion> with -y to install a specific python version"
-        exit 1
-    fi
-
-    __PACKAGES="$_PY_PKG_VER"
-
-    if [ ${_DISABLE_REPOS} -eq ${BS_FALSE} ]; then
-        echoinfo "Attempting to install a repo to help provide a separate python package"
-        echoinfo "$DISTRO_NAME_L"
-        case "$DISTRO_NAME_L" in
-            "red_hat"|"centos")
-                __PYTHON_REPO_URL="https://repo.ius.io/ius-release-el${DISTRO_MAJOR_VERSION}.rpm"
-                ;;
-            *)
-                echoerror "Installing a repo to provide a python package is only supported on Redhat/CentOS.
-                If a repo is already available, please try running script with -r."
-                exit 1
-                ;;
-        esac
-
-        echoinfo "Installing IUS repo"
-        __yum_install_noinput "${__PYTHON_REPO_URL}" || return 1
-    fi
-
-    echoinfo "Installing ${__PACKAGES}"
-    __yum_install_noinput "${__PACKAGES}" || return 1
-}
-
 
 
 #---  FUNCTION  -------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
### What does this PR do?
Updated README, and removed experimental ability to install different Python version which was limited to RHEL 7, which is EOL

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-bootstrap/issues/1524


