### PR TITLE
Updated link for Supported Operating Systems and Repository supported by Salt

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -380,7 +380,8 @@ supported).  The operating systems listed below should reflect this document but
 date. If an operating system is listed below, but is not listed on the official supported operating
 systems document, the level of support is "best-effort".
 
-Since Salt is written in Python, the packages available from the `Salt Project's repository`_ are
+Since Salt is written in Python, the packages available from the `Salt Project's repository
+<https://repo.saltproject.io/salt/py3>`_ are
 CPU architecture independent and could be installed on any hardware supported by Linux kernel.
 However, the Salt Project does package Salt's binary dependencies only for ``x86_64`` (``amd64``)
 and ``AArch64`` (``arm64``).

--- a/README.rst
+++ b/README.rst
@@ -373,7 +373,9 @@ Supported Operating Systems
 ---------------------------
 
 The salt-bootstrap script officially supports the distributions outlined in
-`Salt's Supported Operating Systems`_ document, (BSD-based OSs, Solaris and AIX are no longer
+`Salt's Supported Operating Systems
+<https://docs.saltproject.io/salt/install-guide/en/latest/topics/salt-supported-operating-systems.html>`_
+document, (BSD-based OSs, Solaris and AIX are no longer
 supported).  The operating systems listed below should reflect this document but may become out of
 date. If an operating system is listed below, but is not listed on the official supported operating
 systems document, the level of support is "best-effort".


### PR DESCRIPTION
### What does this PR do?
Updated link to Supported Operating Systems supported by Salt, using the https://docs.saltproject.io/salt/install-guide/en/latest/topics/salt-supported-operating-systems.html link

### What issues does this PR fix or reference?
Fix: https://github.com/saltstack/salt-bootstrap/issues/1922

### Previous Behavior
Link didn't reference Salt's Supported Operating systems page

### New Behavior
Link now references Salt's Supported Operating systems page
