### PR TITLE
Cleanup use of the term 'Post Neon' given only support 3006 and up

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -272,7 +272,7 @@ _ONEDIR_NIGHTLY_DIR="salt-dev/${_ONEDIR_DIR}"
 _PY_EXE="python3"
 _MINIMUM_PIP_VERSION="9.0.1"
 _MINIMUM_SETUPTOOLS_VERSION="9.1"
-_POST_NEON_PIP_INSTALL_ARGS="--prefix=/usr"
+_PIP_INSTALL_ARGS="--prefix=/usr"
 _PIP_DOWNLOAD_ARGS=""
 _QUICK_START="$BS_FALSE"
 _AUTO_ACCEPT_MINION_KEYS="$BS_FALSE"
@@ -1819,7 +1819,7 @@ if [ "$ITYPE" = "git" ]; then
                 __NEW_VS_TAG_REGEX_MATCH=$(echo "${GIT_REV}" | sed -E 's/^(v?3[0-9]{3}(\.[0-9]{1,2})?).*$/MATCH/')
                 if [ "$__NEW_VS_TAG_REGEX_MATCH" = "MATCH" ]; then
                     __TAG_REGEX_MATCH="${__NEW_VS_TAG_REGEX_MATCH}"
-                    echodebug "Post Neon Tag Regex Match On: ${GIT_REV}"
+                    echodebug "Tag Regex Match On: ${GIT_REV}"
                 else
                     __TAG_REGEX_MATCH=$(echo "${GIT_REV}" | sed -E 's/^(v?[0-9]{1,4}\.[0-9]{1,2})(\.[0-9]{1,2})?.*$/MATCH/')
                     echodebug "Pre Neon Tag Regex Match On: ${GIT_REV}"
@@ -1829,7 +1829,7 @@ if [ "$ITYPE" = "git" ]; then
                 __NEW_VS_TAG_REGEX_MATCH=$(echo "${GIT_REV}" | sed 's/^.*\(v\?3[[:digit:]]\{3\}\(\.[[:digit:]]\{1,2\}\)\?\).*$/MATCH/')
                 if [ "$__NEW_VS_TAG_REGEX_MATCH" = "MATCH" ]; then
                     __TAG_REGEX_MATCH="${__NEW_VS_TAG_REGEX_MATCH}"
-                    echodebug "Post Neon Tag Regex Match On: ${GIT_REV}"
+                    echodebug "Tag Regex Match On: ${GIT_REV}"
                 else
                     __TAG_REGEX_MATCH=$(echo "${GIT_REV}" | sed 's/^.*\(v\?[[:digit:]]\{1,4\}\.[[:digit:]]\{1,2\}\)\(\.[[:digit:]]\{1,2\}\)\?.*$/MATCH/')
                     echodebug "Pre Neon Tag Regex Match On: ${GIT_REV}"
@@ -1839,7 +1839,7 @@ if [ "$ITYPE" = "git" ]; then
     fi
 
     echo
-    echowarn "Post Neon git based installations will always install salt"
+    echowarn "git based installations will always install salt"
     echowarn "and its dependencies using pip which will be upgraded to"
     echowarn "at least v${_MINIMUM_PIP_VERSION}, and, in case the setuptools version is also"
     echowarn "too old, it will be upgraded to at least v${_MINIMUM_SETUPTOOLS_VERSION}"
@@ -2596,19 +2596,19 @@ __install_pip_deps() {
 }   # ----------  end of function __install_pip_deps  ----------
 
 #---  FUNCTION  -------------------------------------------------------------------------------------------------------
-#          NAME:  __install_salt_from_repo_post_neon
+#          NAME:  __install_salt_from_repo
 #   DESCRIPTION:  Return 0 or 1 if successfully able to install. Can provide a different python version to
 #                 install pip packages with. If $py_exe is not specified it will use the default python version.
 #    PARAMETERS:  py_exe
 #----------------------------------------------------------------------------------------------------------------------
-__install_salt_from_repo_post_neon() {
+__install_salt_from_repo() {
     _py_exe="$1"
 
     if [ "${_py_exe}" = "" ]; then
         _py_exe="python3"
     fi
 
-    echodebug "__install_salt_from_repo_post_neon py_exe=$_py_exe"
+    echodebug "__install_salt_from_repo py_exe=$_py_exe"
 
     _py_version=$(${_py_exe} -c "import sys; print('{0}.{1}'.format(*sys.version_info))")
     _pip_cmd="pip${_py_version}"
@@ -2647,8 +2647,8 @@ EOM
 )
     if ! ${_py_exe} -c "$CHECK_PIP_VERSION_SCRIPT"; then
         # Upgrade pip to at least 1.2 which is when we can start using "python3 -m pip"
-        echodebug "Running '${_pip_cmd} install ${_POST_NEON_PIP_INSTALL_ARGS} pip>=${_MINIMUM_PIP_VERSION}'"
-        ${_pip_cmd} install ${_POST_NEON_PIP_INSTALL_ARGS} -v "pip>=${_MINIMUM_PIP_VERSION}"
+        echodebug "Running '${_pip_cmd} install ${_PIP_INSTALL_ARGS} pip>=${_MINIMUM_PIP_VERSION}'"
+        ${_pip_cmd} install ${_PIP_INSTALL_ARGS} -v "pip>=${_MINIMUM_PIP_VERSION}"
         sleep 1
         echodebug "PATH: ${PATH}"
         _pip_cmd="pip${_py_version}"
@@ -2681,8 +2681,8 @@ EOM
         echodebug "OS is greater than / equal Debian 12 or Ubuntu 24.04, using ${_USE_BREAK_SYSTEM_PACKAGES}"
     fi
 
-    echodebug "Running '${_pip_cmd} install ${_USE_BREAK_SYSTEM_PACKAGES} --upgrade ${_POST_NEON_PIP_INSTALL_ARGS}  wheel ${_setuptools_dep}"
-    ${_pip_cmd} install ${_USE_BREAK_SYSTEM_PACKAGES} --upgrade ${_POST_NEON_PIP_INSTALL_ARGS}  wheel "${_setuptools_dep}"
+    echodebug "Running '${_pip_cmd} install ${_USE_BREAK_SYSTEM_PACKAGES} --upgrade ${_PIP_INSTALL_ARGS}  wheel ${_setuptools_dep}"
+    ${_pip_cmd} install ${_USE_BREAK_SYSTEM_PACKAGES} --upgrade ${_PIP_INSTALL_ARGS}  wheel "${_setuptools_dep}"
 
     echoinfo "Installing salt using ${_py_exe}"
     cd "${_SALT_GIT_CHECKOUT_DIR}" || return 1
@@ -2700,8 +2700,8 @@ EOM
     ${_pip_cmd} download -d /tmp/git/deps ${_PIP_DOWNLOAD_ARGS} . || (echo "Failed to download salt dependencies" && return 1)
 
     echoinfo "Installing Downloaded Salt Dependencies"
-    echodebug "Running '${_pip_cmd} install ${_USE_BREAK_SYSTEM_PACKAGES} --ignore-installed ${_POST_NEON_PIP_INSTALL_ARGS} /tmp/git/deps/*'"
-    ${_pip_cmd} install ${_USE_BREAK_SYSTEM_PACKAGES} --ignore-installed ${_POST_NEON_PIP_INSTALL_ARGS} /tmp/git/deps/* || return 1
+    echodebug "Running '${_pip_cmd} install ${_USE_BREAK_SYSTEM_PACKAGES} --ignore-installed ${_PIP_INSTALL_ARGS} /tmp/git/deps/*'"
+    ${_pip_cmd} install ${_USE_BREAK_SYSTEM_PACKAGES} --ignore-installed ${_PIP_INSTALL_ARGS} /tmp/git/deps/* || return 1
     rm -f /tmp/git/deps/*
 
     echoinfo "Building Salt Python Wheel"
@@ -2718,10 +2718,10 @@ EOM
 
     echoinfo "Installing Built Salt Wheel"
     ${_pip_cmd} uninstall --yes ${_USE_BREAK_SYSTEM_PACKAGES} salt 2>/dev/null || true
-    echodebug "Running '${_pip_cmd} install ${_USE_BREAK_SYSTEM_PACKAGES} --no-deps --force-reinstall ${_POST_NEON_PIP_INSTALL_ARGS} /tmp/git/deps/salt*.whl'"
+    echodebug "Running '${_pip_cmd} install ${_USE_BREAK_SYSTEM_PACKAGES} --no-deps --force-reinstall ${_PIP_INSTALL_ARGS} /tmp/git/deps/salt*.whl'"
 
     ${_pip_cmd} install ${_USE_BREAK_SYSTEM_PACKAGES} --no-deps --force-reinstall \
-        ${_POST_NEON_PIP_INSTALL_ARGS} \
+        ${_PIP_INSTALL_ARGS} \
         --global-option="--salt-config-dir=$_SALT_ETC_DIR --salt-cache-dir=${_SALT_CACHE_DIR} ${SETUP_PY_INSTALL_ARGS}" \
         /tmp/git/deps/salt*.whl || return 1
 
@@ -2744,12 +2744,12 @@ EOM
         return 1
     fi
     return 0
-}   # ----------  end of function __install_salt_from_repo_post_neon  ----------
+}   # ----------  end of function __install_salt_from_repo  ----------
 
 
 # shellcheck disable=SC2268
 if [ "x${_PY_MAJOR_VERSION}" = "x" ]; then
-    # Default to python 3 for post Neon install
+    # Default to python 3 for install
     _PY_MAJOR_VERSION=3
 fi
 
@@ -3142,8 +3142,8 @@ install_ubuntu_git() {
         return 1
     fi
 
-    _POST_NEON_PIP_INSTALL_ARGS=""
-    __install_salt_from_repo_post_neon "${_PY_EXE}" || return 1
+    _PIP_INSTALL_ARGS=""
+    __install_salt_from_repo "${_PY_EXE}" || return 1
     cd "${_SALT_GIT_CHECKOUT_DIR}" || return 1
 
     # Account for new path for services files in later releases
@@ -3556,9 +3556,9 @@ install_debian_git() {
 
     # We can use --prefix on debian based ditributions
 
-    _POST_NEON_PIP_INSTALL_ARGS=""
+    _PIP_INSTALL_ARGS=""
 
-    __install_salt_from_repo_post_neon "${_PY_EXE}" || return 1
+    __install_salt_from_repo "${_PY_EXE}" || return 1
     cd "${_SALT_GIT_CHECKOUT_DIR}" || return 1
 
     # Account for new path for services files in later releases
@@ -3817,7 +3817,7 @@ install_fedora_git() {
         return 1
     fi
 
-     __install_salt_from_repo_post_neon "${_PY_EXE}" || return 1
+     __install_salt_from_repo "${_PY_EXE}" || return 1
     return 0
 
 }
@@ -4192,7 +4192,7 @@ install_centos_git() {
     fi
 
     echodebug "_PY_EXE: $_PY_EXE"
-     __install_salt_from_repo_post_neon "${_PY_EXE}" || return 1
+     __install_salt_from_repo "${_PY_EXE}" || return 1
 
     return 0
 }
@@ -5150,7 +5150,7 @@ install_alpine_linux_stable() {
 }
 
 install_alpine_linux_git() {
-     __install_salt_from_repo_post_neon "${_PY_EXE}" || return 1
+     __install_salt_from_repo "${_PY_EXE}" || return 1
     return 0
 }
 
@@ -5703,10 +5703,10 @@ install_arch_linux_git() {
         return 1
     fi
 
-    _POST_NEON_PIP_INSTALL_ARGS="${_POST_NEON_PIP_INSTALL_ARGS} --use-pep517"
+    _PIP_INSTALL_ARGS="${_PIP_INSTALL_ARGS} --use-pep517"
     _PIP_DOWNLOAD_ARGS="${_PIP_DOWNLOAD_ARGS} --use-pep517"
 
-    __install_salt_from_repo_post_neon "${_PY_EXE}" || return 1
+    __install_salt_from_repo "${_PY_EXE}" || return 1
 
     return 0
 }
@@ -6353,7 +6353,7 @@ install_opensuse_stable() {
 }
 
 install_opensuse_git() {
-    __install_salt_from_repo_post_neon "${_PY_EXE}" || return 1
+    __install_salt_from_repo "${_PY_EXE}" || return 1
     return 0
 }
 
@@ -6556,7 +6556,7 @@ install_opensuse_15_git() {
         _PYEXE=python3
     fi
 
-    __install_salt_from_repo_post_neon "${_PY_EXE}" || return 1
+    __install_salt_from_repo "${_PY_EXE}" || return 1
     return 0
 }
 
@@ -6698,9 +6698,15 @@ __gentoo_pre_dep() {
         mkdir /etc/portage
     fi
 
-    # Enable Python 3.7 target for Salt Neon using GIT
-    if [ "${ITYPE}" = "git" ] && [ "${GIT_REV}" = "v3000" ]; then
-        EXTRA_PYTHON_TARGET=python3_7
+    # Enable Python 3.10 target for Salt 3006 or later, otherwise 3.7 as previously, using GIT
+    if [ "${ITYPE}" = "git" ]; then
+        GIT_REV_MAJOR=$(echo "${GIT_REV}" | awk -F "." '{print $1}')
+        if [ "${GIT_REV_MAJOR}" = "v3006" ] || [ "${GIT_REV_MAJOR}" = "v3007" ]; then
+            EXTRA_PYTHON_TARGET=python3_10
+        else
+            # assume pre-3006, so leave it as Python 3.7
+            EXTRA_PYTHON_TARGET=python3_7
+        fi
     fi
 
     if [ -n "${EXTRA_PYTHON_TARGET:-}" ]; then
@@ -6798,7 +6804,7 @@ install_gentoo_git() {
         _PYEXE=$(emerge --info | grep -oE 'PYTHON_SINGLE_TARGET="[^"]*"' | sed -e 's/"//g' -e 's/_/./g' | cut -d= -f2)
     fi
 
-    __install_salt_from_repo_post_neon "${_PYEXE}" || return 1
+    __install_salt_from_repo "${_PYEXE}" || return 1
     return 0
 }
 
@@ -7147,7 +7153,7 @@ install_macosx_git() {
         return 1
     fi
 
-    __install_salt_from_repo_post_neon "${_PY_EXE}" || return 1
+    __install_salt_from_repo "${_PY_EXE}" || return 1
     return 0
 }
 


### PR DESCRIPTION
### What does this PR do?
Cleanup use of the term 'Post Neon' given only support 3006 and up, time to remove old term.
Also allowed for use of Python 3.10 with Salt 3006 and later, when using gentoo

