### PR TITLE
Added support with -W for installing salt-api

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -119,6 +119,7 @@ To view the latest options and descriptions for ``salt-bootstrap``, use ``-h`` a
     -L  Also install salt-cloud and required python-libcloud package
     -M  Also install salt-master
     -S  Also install salt-syndic
+    -W  Also install salt-api
     -N  Do not install salt-minion
     -X  Do not start daemons after installation
     -d  Disables checking if Salt services are enabled to start on system boot.

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -398,7 +398,6 @@ __usage() {
     -s  Sleep time used when waiting for daemons to start, restart and when
         checking for the services running. Default: ${__DEFAULT_SLEEP}
     -S  Also install salt-syndic
-    -W  Also install salt-api
     -r  Disable all repository configuration performed by this script. This
         option assumes all necessary repository configuration is already present
         on the system.
@@ -406,6 +405,7 @@ __usage() {
     -v  Display script version
     -V  Install Salt into virtualenv
         (only available for Ubuntu based distributions)
+    -W  Also install salt-api
     -x  Changes the Python version used to install Salt (default: Python 3).
         Python 2.7 is no longer supported.
     -X  Do not start daemons after installation


### PR DESCRIPTION
### What does this PR do?
Add support for installing salt-api with the -W option

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt-bootstrap/issues/2012

### Previous Behavior
No way to install salt-api with bootstrap script

### New Behavior
Able to install salt-api with bootstrap script using the '-W' option
