### PR TITLE
Add KDE neon to list of Ubuntu derivates (again)

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1280,7 +1280,7 @@ __gather_system_info() {
 #----------------------------------------------------------------------------------------------------------------------
 # shellcheck disable=SC2034
 __ubuntu_derivatives_translation() {
-    UBUNTU_DERIVATIVES="(trisquel|linuxmint|elementary_os|pop)"
+    UBUNTU_DERIVATIVES="(trisquel|linuxmint|elementary_os|pop|neon)"
     # Mappings
     trisquel_10_ubuntu_base="20.04"
     trisquel_11_ubuntu_base="22.04"


### PR DESCRIPTION
### What does this PR do?
Added KDE neon to list of Ubuntu derivates (again)

### What issues does this PR fix or reference?

### Previous Behavior
When run on KDE neon ``bootstrap-salt.sh`` terminated with ``ERROR: No dependencies installation function found. Exiting...``.

### New Behavior
When run on KDE neon ``bootstrap-salt.sh`` now doesn't terminate with the above error but works as intended.
