### PR TITLE
Updated deprecated versions for actions for upload, download, checkout for release

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -54,7 +54,7 @@ jobs:
     environment: release
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Get Salt Project GitHub Actions Bot Environment
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
     outputs:
       release-version: ${{ steps.update-repo.outputs.release-version }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: develop
           repository: ${{ github.repository }}
@@ -139,7 +139,7 @@ jobs:
           repository: ${{ github.repository }}
 
       - name: Upload Release Details
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: release-details
           path: |
@@ -158,7 +158,7 @@ jobs:
     permissions:
       contents: write  # To be able to publish the release
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: stable
           repository: ${{ github.repository }}
@@ -205,7 +205,7 @@ jobs:
           git config --global commit.gpgsign true
 
       - name: Download Release Details
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: release-details
 
@@ -254,13 +254,13 @@ jobs:
     permissions:
       contents: write  # To be able to publish the release
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: stable
           repository: ${{ github.repository }}
           ssh-key: ${{ secrets.SALT_BOOTSTRAP_RELEASE_KEY }}
       - name: Download Release Details
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: release-details
 
@@ -287,7 +287,7 @@ jobs:
             LICENSE
 
       - name: Delete Release Details Artifact
-        uses: geekyeggo/delete-artifact@v2
+        uses: geekyeggo/delete-artifact@v5
         with:
           name: release-details
           failOnError: false
@@ -303,7 +303,7 @@ jobs:
     environment: release
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: stable
           repository: ${{ github.repository }}
@@ -367,7 +367,7 @@ jobs:
       pull-requests: write  # For action peter-evans/create-pull-request
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: stable
           repository: ${{ github.repository }}
@@ -378,7 +378,7 @@ jobs:
           echo "SH=$(sha256sum bootstrap-salt.sh | awk '{ print $1 }')" >> "$GITHUB_ENV"
           echo "BS_VERSION=$(sh bootstrap-salt.sh -v | awk '{ print $4 }')" >> "$GITHUB_ENV"
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: develop
           repository: ${{ github.repository }}


### PR DESCRIPTION
### What does this PR do?
Updates the GitHub actions in the release.yml file to supported versions of actions and not the old deprecated versions

### What issues does this PR fix or reference?
Release failures due to use of deprecated actions when merging ```develop``` into ``` stable``` branch.

