### PR TITLE
Disabling signing of commits on release updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,35 +74,35 @@ jobs:
           python3 -m pip install -r requirements/release.txt
           pre-commit install --install-hooks
 
-      - name: Setup GnuPG
-        run: |
-          sudo install -d -m 0700 -o "$(id -u)" -g "$(id -g)" /run/gpg
-          GNUPGHOME="$(mktemp -d -p /run/gpg)"
-          echo "GNUPGHOME=${GNUPGHOME}" >> "$GITHUB_ENV"
-          cat <<EOF > "${GNUPGHOME}/gpg.conf"
-          batch
-          no-tty
-          pinentry-mode loopback
-          EOF
+      ## - name: Setup GnuPG
+      ##   run: |
+      ##     sudo install -d -m 0700 -o "$(id -u)" -g "$(id -g)" /run/gpg
+      ##     GNUPGHOME="$(mktemp -d -p /run/gpg)"
+      ##     echo "GNUPGHOME=${GNUPGHOME}" >> "$GITHUB_ENV"
+      ##     cat <<EOF > "${GNUPGHOME}/gpg.conf"
+      ##     batch
+      ##     no-tty
+      ##     pinentry-mode loopback
+      ##     EOF
 
-      - name: Get Secrets
-        id: get-secrets
-        env:
-          SECRETS_KEY: ${{ secrets.SECRETS_KEY }}
-        run: |
-          SECRETS_KEY_FILE=$(mktemp /tmp/output.XXXXXXXXXX)
-          echo "$SECRETS_KEY" > "$SECRETS_KEY_FILE"
-          aws --region us-west-2 secretsmanager get-secret-value --secret-id /cmbu-saltstack/signing/repo-signing-keys-sha256-2023 \
-            --query SecretString --output text | jq .default_key -r | base64 -d \
-            | gpg --passphrase-file "${SECRETS_KEY_FILE}" -d - \
-            | gpg --import -
-          sync
-          aws --region us-west-2 secretsmanager get-secret-value --secret-id /cmbu-saltstack/signing/repo-signing-keys-sha256-2023 \
-            --query SecretString --output text| jq .default_passphrase -r | base64 -d \
-            | gpg --passphrase-file "${SECRETS_KEY_FILE}" -o "${GNUPGHOME}/passphrase" -d -
-          sync
-          rm "$SECRETS_KEY_FILE"
-          echo "passphrase-file ${GNUPGHOME}/passphrase" >> "${GNUPGHOME}/gpg.conf"
+      ## - name: Get Secrets
+      ##   id: get-secrets
+      ##   env:
+      ##     SECRETS_KEY: ${{ secrets.SECRETS_KEY }}
+      ##   run: |
+      ##     SECRETS_KEY_FILE=$(mktemp /tmp/output.XXXXXXXXXX)
+      ##     echo "$SECRETS_KEY" > "$SECRETS_KEY_FILE"
+      ##     aws --region us-west-2 secretsmanager get-secret-value --secret-id /cmbu-saltstack/signing/repo-signing-keys-sha256-2023 \
+      ##       --query SecretString --output text | jq .default_key -r | base64 -d \
+      ##       | gpg --passphrase-file "${SECRETS_KEY_FILE}" -d - \
+      ##       | gpg --import -
+      ##     sync
+      ##     aws --region us-west-2 secretsmanager get-secret-value --secret-id /cmbu-saltstack/signing/repo-signing-keys-sha256-2023 \
+      ##       --query SecretString --output text| jq .default_passphrase -r | base64 -d \
+      ##       | gpg --passphrase-file "${SECRETS_KEY_FILE}" -o "${GNUPGHOME}/passphrase" -d -
+      ##     sync
+      ##     rm "$SECRETS_KEY_FILE"
+      ##     echo "passphrase-file ${GNUPGHOME}/passphrase" >> "${GNUPGHOME}/gpg.conf"
 
       - name: Configure Git
         shell: bash
@@ -110,8 +110,9 @@ jobs:
           git config --global --add safe.directory "$(pwd)"
           git config --global user.name "Salt Project Packaging"
           git config --global user.email saltproject-packaging@vmware.com
-          git config --global user.signingkey 64CBBC8173D76B3F
-          git config --global commit.gpgsign true
+          git config --global commit.gpgsign false
+          ## git config --global user.signingkey 64CBBC8173D76B3F
+          ## git config --global commit.gpgsign true
 
       - name: Update Repository
         id: update-repo
@@ -166,35 +167,35 @@ jobs:
           ssh-key: ${{ secrets.SALT_BOOTSTRAP_RELEASE_KEY }}
           fetch-depth: 0
 
-      - name: Setup GnuPG
-        run: |
-          sudo install -d -m 0700 -o "$(id -u)" -g "$(id -g)" /run/gpg
-          GNUPGHOME="$(mktemp -d -p /run/gpg)"
-          echo "GNUPGHOME=${GNUPGHOME}" >> "$GITHUB_ENV"
-          cat <<EOF > "${GNUPGHOME}/gpg.conf"
-          batch
-          no-tty
-          pinentry-mode loopback
-          EOF
+      ## - name: Setup GnuPG
+      ##   run: |
+      ##     sudo install -d -m 0700 -o "$(id -u)" -g "$(id -g)" /run/gpg
+      ##     GNUPGHOME="$(mktemp -d -p /run/gpg)"
+      ##     echo "GNUPGHOME=${GNUPGHOME}" >> "$GITHUB_ENV"
+      ##     cat <<EOF > "${GNUPGHOME}/gpg.conf"
+      ##     batch
+      ##     no-tty
+      ##     pinentry-mode loopback
+      ##     EOF
 
-      - name: Get Secrets
-        id: get-secrets
-        env:
-          SECRETS_KEY: ${{ secrets.SECRETS_KEY }}
-        run: |
-          SECRETS_KEY_FILE=$(mktemp /tmp/output.XXXXXXXXXX)
-          echo "$SECRETS_KEY" > "$SECRETS_KEY_FILE"
-          aws --region us-west-2 secretsmanager get-secret-value --secret-id /cmbu-saltstack/signing/repo-signing-keys-sha256-2023 \
-            --query SecretString --output text | jq .default_key -r | base64 -d \
-            | gpg --passphrase-file "${SECRETS_KEY_FILE}" -d - \
-            | gpg --import -
-          sync
-          aws --region us-west-2 secretsmanager get-secret-value --secret-id /cmbu-saltstack/signing/repo-signing-keys-sha256-2023 \
-            --query SecretString --output text| jq .default_passphrase -r | base64 -d \
-            | gpg --passphrase-file "${SECRETS_KEY_FILE}" -o "${GNUPGHOME}/passphrase" -d -
-          sync
-          rm "$SECRETS_KEY_FILE"
-          echo "passphrase-file ${GNUPGHOME}/passphrase" >> "${GNUPGHOME}/gpg.conf"
+      ## - name: Get Secrets
+      ##   id: get-secrets
+      ##   env:
+      ##     SECRETS_KEY: ${{ secrets.SECRETS_KEY }}
+      ##   run: |
+      ##     SECRETS_KEY_FILE=$(mktemp /tmp/output.XXXXXXXXXX)
+      ##     echo "$SECRETS_KEY" > "$SECRETS_KEY_FILE"
+      ##     aws --region us-west-2 secretsmanager get-secret-value --secret-id /cmbu-saltstack/signing/repo-signing-keys-sha256-2023 \
+      ##       --query SecretString --output text | jq .default_key -r | base64 -d \
+      ##       | gpg --passphrase-file "${SECRETS_KEY_FILE}" -d - \
+      ##       | gpg --import -
+      ##     sync
+      ##     aws --region us-west-2 secretsmanager get-secret-value --secret-id /cmbu-saltstack/signing/repo-signing-keys-sha256-2023 \
+      ##       --query SecretString --output text| jq .default_passphrase -r | base64 -d \
+      ##       | gpg --passphrase-file "${SECRETS_KEY_FILE}" -o "${GNUPGHOME}/passphrase" -d -
+      ##     sync
+      ##     rm "$SECRETS_KEY_FILE"
+      ##     echo "passphrase-file ${GNUPGHOME}/passphrase" >> "${GNUPGHOME}/gpg.conf"
 
       - name: Configure Git
         shell: bash
@@ -202,8 +203,9 @@ jobs:
           git config --global --add safe.directory "$(pwd)"
           git config --global user.name "Salt Project Packaging"
           git config --global user.email saltproject-packaging@vmware.com
-          git config --global user.signingkey 64CBBC8173D76B3F
-          git config --global commit.gpgsign true
+          git config --global commit.gpgsign false
+          ## git config --global user.signingkey 64CBBC8173D76B3F
+          ## git config --global commit.gpgsign true
 
       - name: Download Release Details
         uses: actions/download-artifact@v4
@@ -317,43 +319,43 @@ jobs:
           SPB_ENVIRONMENT=$(curl -sS -f -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/tags/instance/spb:environment)
           echo "SPB_ENVIRONMENT=$SPB_ENVIRONMENT" >> "$GITHUB_ENV"
 
-      - name: Setup GnuPG
-        run: |
-          sudo install -d -m 0700 -o "$(id -u)" -g "$(id -g)" /run/gpg
-          GNUPGHOME="$(mktemp -d -p /run/gpg)"
-          echo "GNUPGHOME=${GNUPGHOME}" >> "$GITHUB_ENV"
-          cat <<EOF > "${GNUPGHOME}/gpg.conf"
-          batch
-          no-tty
-          pinentry-mode loopback
-          EOF
+      ## - name: Setup GnuPG
+      ##   run: |
+      ##     sudo install -d -m 0700 -o "$(id -u)" -g "$(id -g)" /run/gpg
+      ##     GNUPGHOME="$(mktemp -d -p /run/gpg)"
+      ##     echo "GNUPGHOME=${GNUPGHOME}" >> "$GITHUB_ENV"
+      ##     cat <<EOF > "${GNUPGHOME}/gpg.conf"
+      ##     batch
+      ##     no-tty
+      ##     pinentry-mode loopback
+      ##     EOF
 
-      - name: Get Secrets
-        id: get-secrets
-        env:
-          SECRETS_KEY: ${{ secrets.SECRETS_KEY }}
-        run: |
-          SECRETS_KEY_FILE=$(mktemp /tmp/output.XXXXXXXXXX)
-          echo "$SECRETS_KEY" > "$SECRETS_KEY_FILE"
-          aws --region us-west-2 secretsmanager get-secret-value --secret-id /cmbu-saltstack/signing/repo-signing-keys-sha256-2023 \
-            --query SecretString --output text | jq .default_key -r | base64 -d \
-            | gpg --passphrase-file "${SECRETS_KEY_FILE}" -d - \
-            | gpg --import -
-          sync
-          aws --region us-west-2 secretsmanager get-secret-value --secret-id /cmbu-saltstack/signing/repo-signing-keys-sha256-2023 \
-            --query SecretString --output text| jq .default_passphrase -r | base64 -d \
-            | gpg --passphrase-file "${SECRETS_KEY_FILE}" -o "${GNUPGHOME}/passphrase" -d -
-          sync
-          rm "$SECRETS_KEY_FILE"
-          echo "passphrase-file ${GNUPGHOME}/passphrase" >> "${GNUPGHOME}/gpg.conf"
+      ## - name: Get Secrets
+      ##   id: get-secrets
+      ##   env:
+      ##     SECRETS_KEY: ${{ secrets.SECRETS_KEY }}
+      ##   run: |
+      ##     SECRETS_KEY_FILE=$(mktemp /tmp/output.XXXXXXXXXX)
+      ##     echo "$SECRETS_KEY" > "$SECRETS_KEY_FILE"
+      ##     aws --region us-west-2 secretsmanager get-secret-value --secret-id /cmbu-saltstack/signing/repo-signing-keys-sha256-2023 \
+      ##       --query SecretString --output text | jq .default_key -r | base64 -d \
+      ##       | gpg --passphrase-file "${SECRETS_KEY_FILE}" -d - \
+      ##       | gpg --import -
+      ##     sync
+      ##     aws --region us-west-2 secretsmanager get-secret-value --secret-id /cmbu-saltstack/signing/repo-signing-keys-sha256-2023 \
+      ##       --query SecretString --output text| jq .default_passphrase -r | base64 -d \
+      ##       | gpg --passphrase-file "${SECRETS_KEY_FILE}" -o "${GNUPGHOME}/passphrase" -d -
+      ##     sync
+      ##     rm "$SECRETS_KEY_FILE"
+      ##     echo "passphrase-file ${GNUPGHOME}/passphrase" >> "${GNUPGHOME}/gpg.conf"
 
-      - name: Install Requirements
-        run: |
-          python3 -m pip install -r requirements/release.txt
+      ## - name: Install Requirements
+      ##   run: |
+      ##     python3 -m pip install -r requirements/release.txt
 
-      - name: Upload Stable Release to S3
-        run: |
-          tools release s3-publish --key-id 64CBBC8173D76B3F stable
+      ## - name: Upload Stable Release to S3
+      ##   run: |
+      ##     tools release s3-publish --key-id 64CBBC8173D76B3F stable
 
   update-develop-checksums:
     name: Update Release Checksums on Develop
@@ -386,35 +388,35 @@ jobs:
           repository: ${{ github.repository }}
           ssh-key: ${{ secrets.SALT_BOOTSTRAP_RELEASE_KEY }}
 
-      - name: Setup GnuPG
-        run: |
-          sudo install -d -m 0700 -o "$(id -u)" -g "$(id -g)" /run/gpg
-          GNUPGHOME="$(mktemp -d -p /run/gpg)"
-          echo "GNUPGHOME=${GNUPGHOME}" >> "$GITHUB_ENV"
-          cat <<EOF > "${GNUPGHOME}/gpg.conf"
-          batch
-          no-tty
-          pinentry-mode loopback
-          EOF
+      ## - name: Setup GnuPG
+      ##   run: |
+      ##     sudo install -d -m 0700 -o "$(id -u)" -g "$(id -g)" /run/gpg
+      ##     GNUPGHOME="$(mktemp -d -p /run/gpg)"
+      ##     echo "GNUPGHOME=${GNUPGHOME}" >> "$GITHUB_ENV"
+      ##     cat <<EOF > "${GNUPGHOME}/gpg.conf"
+      ##     batch
+      ##     no-tty
+      ##     pinentry-mode loopback
+      ##     EOF
 
-      - name: Get Secrets
-        id: get-secrets
-        env:
-          SECRETS_KEY: ${{ secrets.SECRETS_KEY }}
-        run: |
-          SECRETS_KEY_FILE=$(mktemp /tmp/output.XXXXXXXXXX)
-          echo "$SECRETS_KEY" > "$SECRETS_KEY_FILE"
-          aws --region us-west-2 secretsmanager get-secret-value --secret-id /cmbu-saltstack/signing/repo-signing-keys-sha256-2023 \
-            --query SecretString --output text | jq .default_key -r | base64 -d \
-            | gpg --passphrase-file "${SECRETS_KEY_FILE}" -d - \
-            | gpg --import -
-          sync
-          aws --region us-west-2 secretsmanager get-secret-value --secret-id /cmbu-saltstack/signing/repo-signing-keys-sha256-2023 \
-            --query SecretString --output text| jq .default_passphrase -r | base64 -d \
-            | gpg --passphrase-file "${SECRETS_KEY_FILE}" -o "${GNUPGHOME}/passphrase" -d -
-          sync
-          rm "$SECRETS_KEY_FILE"
-          echo "passphrase-file ${GNUPGHOME}/passphrase" >> "${GNUPGHOME}/gpg.conf"
+      ## - name: Get Secrets
+      ##   id: get-secrets
+      ##   env:
+      ##     SECRETS_KEY: ${{ secrets.SECRETS_KEY }}
+      ##   run: |
+      ##     SECRETS_KEY_FILE=$(mktemp /tmp/output.XXXXXXXXXX)
+      ##     echo "$SECRETS_KEY" > "$SECRETS_KEY_FILE"
+      ##     aws --region us-west-2 secretsmanager get-secret-value --secret-id /cmbu-saltstack/signing/repo-signing-keys-sha256-2023 \
+      ##       --query SecretString --output text | jq .default_key -r | base64 -d \
+      ##       | gpg --passphrase-file "${SECRETS_KEY_FILE}" -d - \
+      ##       | gpg --import -
+      ##     sync
+      ##     aws --region us-west-2 secretsmanager get-secret-value --secret-id /cmbu-saltstack/signing/repo-signing-keys-sha256-2023 \
+      ##       --query SecretString --output text| jq .default_passphrase -r | base64 -d \
+      ##       | gpg --passphrase-file "${SECRETS_KEY_FILE}" -o "${GNUPGHOME}/passphrase" -d -
+      ##     sync
+      ##     rm "$SECRETS_KEY_FILE"
+      ##     echo "passphrase-file ${GNUPGHOME}/passphrase" >> "${GNUPGHOME}/gpg.conf"
 
       - name: Configure Git
         shell: bash
@@ -422,8 +424,9 @@ jobs:
           git config --global --add safe.directory "$(pwd)"
           git config --global user.name "Salt Project Packaging"
           git config --global user.email saltproject-packaging@vmware.com
-          git config --global user.signingkey 64CBBC8173D76B3F
-          git config --global commit.gpgsign true
+          git config --global commit.gpgsign false
+          ## git config --global user.signingkey 64CBBC8173D76B3F
+          ## git config --global commit.gpgsign true
 
       - name: Update Latest Release on README
         run: |

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -657,7 +657,7 @@ elif [ "$ITYPE" = "stable" ]; then
             ITYPE="onedir"
             shift
         else
-            echo "Unknown stable version: $1 (valid: 3006, 3007, latest)"
+            echo "Unknown stable version: $1 (valid: 3006, 3007, latest), versions older than 3006 are not available"
             exit 1
         fi
     fi
@@ -676,7 +676,7 @@ elif [ "$ITYPE" = "onedir" ]; then
             STABLE_REV="$1"
             shift
         else
-            echo "Unknown onedir version: $1 (valid: 3006, 3007, latest.)"
+            echo "Unknown onedir version: $1 (valid: 3006, 3007, latest), versions older than 3006 are not available"
             exit 1
         fi
     fi


### PR DESCRIPTION
### What does this PR do?
Secret signing was done using the secrets manager in AWS, it was used to provide signed commits which were required on this repo, disabling this signing infrastructure

### What issues does this PR fix or reference?
Fixes https://github.com/saltstack/salt-bootstrap/issues/2032
