### PR TITLE
Updated URLs in README, and fix deps download issue on RedHat family

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,51 +180,6 @@ jobs:
 
 
 
-  amazonlinux-2:
-    name: Amazon 2
-    if: github.event_name == 'push' || needs.collect-changed-files.outputs.run-tests == 'true'
-    uses: ./.github/workflows/test-linux.yml
-    needs:
-      - lint
-      - generate-actions-workflow
-    with:
-      distro-slug: amazonlinux-2
-      display-name: Amazon 2
-      container-slug: systemd-amazonlinux-2
-      timeout: 20
-      instances: '["stable-3006", "onedir-3006", "stable-3006-8", "stable-3007", "onedir-3007", "stable-3007-1", "latest", "default"]'
-
-
-  amazonlinux-2023:
-    name: Amazon 2023
-    if: github.event_name == 'push' || needs.collect-changed-files.outputs.run-tests == 'true'
-    uses: ./.github/workflows/test-linux.yml
-    needs:
-      - lint
-      - generate-actions-workflow
-    with:
-      distro-slug: amazonlinux-2023
-      display-name: Amazon 2023
-      container-slug: systemd-amazonlinux-2023
-      timeout: 20
-      instances: '["stable-3006", "onedir-3006", "stable-3006-8", "stable-3007", "onedir-3007", "stable-3007-1", "latest", "default"]'
-
-
-  debian-11:
-    name: Debian 11
-    if: github.event_name == 'push' || needs.collect-changed-files.outputs.run-tests == 'true'
-    uses: ./.github/workflows/test-linux.yml
-    needs:
-      - lint
-      - generate-actions-workflow
-    with:
-      distro-slug: debian-11
-      display-name: Debian 11
-      container-slug: systemd-debian-11
-      timeout: 20
-      instances: '["stable-3006", "onedir-3006", "stable-3006-8", "stable-3007", "onedir-3007", "stable-3007-1", "latest", "default"]'
-
-
   debian-12:
     name: Debian 12
     if: github.event_name == 'push' || needs.collect-changed-files.outputs.run-tests == 'true'
@@ -237,7 +192,7 @@ jobs:
       display-name: Debian 12
       container-slug: systemd-debian-12
       timeout: 20
-      instances: '["stable-3007", "onedir-3007", "stable-3007-1", "git-master", "latest", "default"]'
+      instances: '["stable-3007", "onedir-3007", "stable-3007-1", "latest", "default"]'
 
 
   photon-5:
@@ -282,7 +237,7 @@ jobs:
       display-name: Rocky Linux 9
       container-slug: systemd-rockylinux-9
       timeout: 20
-      instances: '["stable-3006", "onedir-3006", "stable-3006-8", "stable-3007", "onedir-3007", "stable-3007-1", "git-master", "latest", "default"]'
+      instances: '["stable-3006", "onedir-3006", "stable-3006-8", "stable-3007", "onedir-3007", "stable-3007-1", "latest", "default"]'
 
 
   ubuntu-2204:
@@ -312,9 +267,6 @@ jobs:
       - macos-13
       - macos-14
       - windows-2022
-      - amazonlinux-2
-      - amazonlinux-2023
-      - debian-11
       - debian-12
       - photon-5
       - rockylinux-8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,6 +180,66 @@ jobs:
 
 
 
+  amazonlinux-2:
+    name: Amazon 2
+    if: github.event_name == 'push' || needs.collect-changed-files.outputs.run-tests == 'true'
+    uses: ./.github/workflows/test-linux.yml
+    needs:
+      - lint
+      - generate-actions-workflow
+    with:
+      distro-slug: amazonlinux-2
+      display-name: Amazon 2
+      container-slug: systemd-amazonlinux-2
+      timeout: 20
+      instances: '["stable-3006", "onedir-3006", "stable-3006-8", "stable-3007", "onedir-3007", "stable-3007-1", "latest", "default"]'
+
+
+  amazonlinux-2023:
+    name: Amazon 2023
+    if: github.event_name == 'push' || needs.collect-changed-files.outputs.run-tests == 'true'
+    uses: ./.github/workflows/test-linux.yml
+    needs:
+      - lint
+      - generate-actions-workflow
+    with:
+      distro-slug: amazonlinux-2023
+      display-name: Amazon 2023
+      container-slug: systemd-amazonlinux-2023
+      timeout: 20
+      instances: '["stable-3006", "onedir-3006", "stable-3006-8", "stable-3007", "onedir-3007", "stable-3007-1", "latest", "default"]'
+
+
+  debian-11:
+    name: Debian 11
+    if: github.event_name == 'push' || needs.collect-changed-files.outputs.run-tests == 'true'
+    uses: ./.github/workflows/test-linux.yml
+    needs:
+      - lint
+      - generate-actions-workflow
+    with:
+      distro-slug: debian-11
+      display-name: Debian 11
+      container-slug: systemd-debian-11
+      timeout: 20
+      instances: '["stable-3006", "onedir-3006", "stable-3006-8", "stable-3007", "onedir-3007", "stable-3007-1", "git-master", "latest", "default"]'
+
+
+  debian-12:
+    name: Debian 12
+    if: github.event_name == 'push' || needs.collect-changed-files.outputs.run-tests == 'true'
+    uses: ./.github/workflows/test-linux.yml
+    needs:
+      - lint
+      - generate-actions-workflow
+    with:
+      distro-slug: debian-12
+      display-name: Debian 12
+      container-slug: systemd-debian-12
+      timeout: 20
+      instances: '["git-3006", "stable-3007", "git-3007", "onedir-3007", "stable-3007-1", "git-master", "latest", "default"]'
+
+
   photon-5:
     name: Photon OS 5
     if: github.event_name == 'push' || needs.collect-changed-files.outputs.run-tests == 'true'
@@ -222,7 +282,7 @@ jobs:
       display-name: Rocky Linux 9
       container-slug: systemd-rockylinux-9
       timeout: 20
-      instances: '["stable-3006", "onedir-3006", "stable-3006-8", "stable-3007", "onedir-3007", "stable-3007-1", "latest", "default"]'
+      instances: '["stable-3006", "git-3006", "onedir-3006", "stable-3006-8", "stable-3007", "git-3007", "onedir-3007", "stable-3007-1", "git-master", "latest", "default"]'
 
 
   ubuntu-2204:
@@ -237,7 +297,7 @@ jobs:
       display-name: Ubuntu 22.04
       container-slug: systemd-ubuntu-22.04
       timeout: 20
-      instances: '["stable-3006", "onedir-3006", "stable-3006-8", "stable-3007", "onedir-3007", "stable-3007-1", "git-master", "latest", "default"]'
+      instances: '["stable-3006", "git-3006", "onedir-3006", "stable-3006-8", "stable-3007", "git-3007", "onedir-3007", "stable-3007-1", "git-master", "latest", "default"]'
 
 
   set-pipeline-exit-status:
@@ -252,6 +312,10 @@ jobs:
       - macos-13
       - macos-14
       - windows-2022
+      - amazonlinux-2
+      - amazonlinux-2023
+      - debian-11
+      - debian-12
       - photon-5
       - rockylinux-8
       - rockylinux-9

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,6 +180,51 @@ jobs:
 
 
 
+  amazonlinux-2:
+    name: Amazon 2
+    if: github.event_name == 'push' || needs.collect-changed-files.outputs.run-tests == 'true'
+    uses: ./.github/workflows/test-linux.yml
+    needs:
+      - lint
+      - generate-actions-workflow
+    with:
+      distro-slug: amazonlinux-2
+      display-name: Amazon 2
+      container-slug: systemd-amazonlinux-2
+      timeout: 20
+      instances: '["stable-3006", "onedir-3006", "stable-3006-8", "stable-3007", "onedir-3007", "stable-3007-1", "latest", "default"]'
+
+
+  amazonlinux-2023:
+    name: Amazon 2023
+    if: github.event_name == 'push' || needs.collect-changed-files.outputs.run-tests == 'true'
+    uses: ./.github/workflows/test-linux.yml
+    needs:
+      - lint
+      - generate-actions-workflow
+    with:
+      distro-slug: amazonlinux-2023
+      display-name: Amazon 2023
+      container-slug: systemd-amazonlinux-2023
+      timeout: 20
+      instances: '["stable-3006", "onedir-3006", "stable-3006-8", "stable-3007", "onedir-3007", "stable-3007-1", "latest", "default"]'
+
+
+  debian-11:
+    name: Debian 11
+    if: github.event_name == 'push' || needs.collect-changed-files.outputs.run-tests == 'true'
+    uses: ./.github/workflows/test-linux.yml
+    needs:
+      - lint
+      - generate-actions-workflow
+    with:
+      distro-slug: debian-11
+      display-name: Debian 11
+      container-slug: systemd-debian-11
+      timeout: 20
+      instances: '["stable-3006", "onedir-3006", "stable-3006-8", "stable-3007", "onedir-3007", "stable-3007-1", "latest", "default"]'
+
+
   debian-12:
     name: Debian 12
     if: github.event_name == 'push' || needs.collect-changed-files.outputs.run-tests == 'true'
@@ -192,7 +237,7 @@ jobs:
       display-name: Debian 12
       container-slug: systemd-debian-12
       timeout: 20
-      instances: '["git-3006", "stable-3007", "git-3007", "onedir-3007", "stable-3007-1", "git-master", "latest", "default"]'
+      instances: '["stable-3007", "onedir-3007", "stable-3007-1", "git-master", "latest", "default"]'
 
 
   photon-5:
@@ -237,7 +282,7 @@ jobs:
       display-name: Rocky Linux 9
       container-slug: systemd-rockylinux-9
       timeout: 20
-      instances: '["stable-3006", "git-3006", "onedir-3006", "stable-3006-8", "stable-3007", "git-3007", "onedir-3007", "stable-3007-1", "git-master", "latest", "default"]'
+      instances: '["stable-3006", "onedir-3006", "stable-3006-8", "stable-3007", "onedir-3007", "stable-3007-1", "git-master", "latest", "default"]'
 
 
   ubuntu-2204:
@@ -267,6 +312,9 @@ jobs:
       - macos-13
       - macos-14
       - windows-2022
+      - amazonlinux-2
+      - amazonlinux-2023
+      - debian-11
       - debian-12
       - photon-5
       - rockylinux-8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,51 +180,6 @@ jobs:
 
 
 
-  amazonlinux-2:
-    name: Amazon 2
-    if: github.event_name == 'push' || needs.collect-changed-files.outputs.run-tests == 'true'
-    uses: ./.github/workflows/test-linux.yml
-    needs:
-      - lint
-      - generate-actions-workflow
-    with:
-      distro-slug: amazonlinux-2
-      display-name: Amazon 2
-      container-slug: systemd-amazonlinux-2
-      timeout: 20
-      instances: '["stable-3006", "onedir-3006", "stable-3006-8", "stable-3007", "onedir-3007", "stable-3007-1", "latest", "default"]'
-
-
-  amazonlinux-2023:
-    name: Amazon 2023
-    if: github.event_name == 'push' || needs.collect-changed-files.outputs.run-tests == 'true'
-    uses: ./.github/workflows/test-linux.yml
-    needs:
-      - lint
-      - generate-actions-workflow
-    with:
-      distro-slug: amazonlinux-2023
-      display-name: Amazon 2023
-      container-slug: systemd-amazonlinux-2023
-      timeout: 20
-      instances: '["stable-3006", "onedir-3006", "stable-3006-8", "stable-3007", "onedir-3007", "stable-3007-1", "latest", "default"]'
-
-
-  debian-11:
-    name: Debian 11
-    if: github.event_name == 'push' || needs.collect-changed-files.outputs.run-tests == 'true'
-    uses: ./.github/workflows/test-linux.yml
-    needs:
-      - lint
-      - generate-actions-workflow
-    with:
-      distro-slug: debian-11
-      display-name: Debian 11
-      container-slug: systemd-debian-11
-      timeout: 20
-      instances: '["stable-3006", "onedir-3006", "stable-3006-8", "stable-3007", "onedir-3007", "stable-3007-1", "git-master", "latest", "default"]'
-
-
   debian-12:
     name: Debian 12
     if: github.event_name == 'push' || needs.collect-changed-files.outputs.run-tests == 'true'
@@ -312,9 +267,6 @@ jobs:
       - macos-13
       - macos-14
       - windows-2022
-      - amazonlinux-2
-      - amazonlinux-2023
-      - debian-11
       - debian-12
       - photon-5
       - rockylinux-8

--- a/.github/workflows/templates/generate.py
+++ b/.github/workflows/templates/generate.py
@@ -18,9 +18,6 @@ os.chdir(os.path.abspath(os.path.dirname(__file__)))
 #    "ubuntu-2004",
 #    "ubuntu-2404",
 LINUX_DISTROS = [
-    "amazonlinux-2",
-    "amazonlinux-2023",
-    "debian-11",
     "debian-12",
     "photon-5",
     "rockylinux-8",
@@ -40,15 +37,15 @@ OSX = [
 
 # only test against current containers with systemd
 # will add these when they become available with systemd
+#    "amazonlinux-2",
+#    "amazonlinux-2023",
+#    "debian-11",
 #    "debian-13",
 #    "fedora-40",
 #    "photon-4",
 #    "ubuntu-2004",
 #    "ubuntu-2404",
 STABLE_DISTROS = [
-    "amazonlinux-2",
-    "amazonlinux-2023",
-    "debian-11",
     "debian-12",
     "photon-5",
     "rockylinux-8",
@@ -58,15 +55,15 @@ STABLE_DISTROS = [
 
 # only test against current containers with systemd
 # will add these when they become available with systemd
+#    "amazonlinux-2",
+#    "amazonlinux-2023",
+#    "debian-11",
 #    "debian-13",
 #    "fedora-40",
 #    "photon-4",
 #    "ubuntu-2004",
 #    "ubuntu-2404",
 ONEDIR_DISTROS = [
-    "amazonlinux-2",
-    "amazonlinux-2023",
-    "debian-11",
     "debian-12",
     "photon-5",
     "rockylinux-8",
@@ -133,6 +130,9 @@ BLACKLIST_GIT_3007 = [
 BLACKLIST_GIT_MASTER = [
     "amazonlinux-2",
     "amazonlinux-2023",
+    "debian-11",
+    "debian-13",
+    "fedora-40",
     "photon-4",
     "photon-5",
 ]

--- a/.github/workflows/templates/generate.py
+++ b/.github/workflows/templates/generate.py
@@ -8,6 +8,9 @@ os.chdir(os.path.abspath(os.path.dirname(__file__)))
 
 # only test against current containers with systemd
 # will add these when they become available with systemd
+#    "amazonlinux-2",
+#    "amazonlinux-2023",
+#    "debian-11",
 #    "debian-12",
 #    "debian-13",
 #    "fedora-40",
@@ -15,9 +18,6 @@ os.chdir(os.path.abspath(os.path.dirname(__file__)))
 #    "ubuntu-2004",
 #    "ubuntu-2404",
 LINUX_DISTROS = [
-    "amazonlinux-2",
-    "amazonlinux-2023",
-    "debian-11",
     "debian-12",
     "photon-5",
     "rockylinux-8",
@@ -37,15 +37,15 @@ OSX = [
 
 # only test against current containers with systemd
 # will add these when they become available with systemd
+#    "amazonlinux-2",
+#    "amazonlinux-2023",
+#    "debian-11",
 #    "debian-13",
 #    "fedora-40",
 #    "photon-4",
 #    "ubuntu-2004",
 #    "ubuntu-2404",
 STABLE_DISTROS = [
-    "amazonlinux-2",
-    "amazonlinux-2023",
-    "debian-11",
     "debian-12",
     "photon-5",
     "rockylinux-8",
@@ -55,15 +55,15 @@ STABLE_DISTROS = [
 
 # only test against current containers with systemd
 # will add these when they become available with systemd
+#    "amazonlinux-2",
+#    "amazonlinux-2023",
+#    "debian-11",
 #    "debian-13",
 #    "fedora-40",
 #    "photon-4",
 #    "ubuntu-2004",
 #    "ubuntu-2404",
 ONEDIR_DISTROS = [
-    "amazonlinux-2",
-    "amazonlinux-2023",
-    "debian-11",
     "debian-12",
     "photon-5",
     "rockylinux-8",
@@ -126,15 +126,16 @@ BLACKLIST_GIT_3007 = [
     "ubuntu-2404",
 ]
 
-##    "rockylinux-9",
 BLACKLIST_GIT_MASTER = [
     "amazonlinux-2",
     "amazonlinux-2023",
     "debian-11",
+    "debian-12",
     "debian-13",
     "fedora-40",
     "photon-4",
     "photon-5",
+    "rockylinux-9",
 ]
 
 SALT_VERSIONS = [

--- a/.github/workflows/templates/generate.py
+++ b/.github/workflows/templates/generate.py
@@ -18,6 +18,10 @@ os.chdir(os.path.abspath(os.path.dirname(__file__)))
 #    "ubuntu-2004",
 #    "ubuntu-2404",
 LINUX_DISTROS = [
+    "amazonlinux-2",
+    "amazonlinux-2023",
+    "debian-11",
+    "debian-12",
     "photon-5",
     "rockylinux-8",
     "rockylinux-9",
@@ -36,17 +40,16 @@ OSX = [
 
 # only test against current containers with systemd
 # will add these when they become available with systemd
-#    "amazonlinux-2",
-#    "amazonlinux-2023",
-#    "centos-stream9",
-#    "debian-11",
-#    "debian-12",
 #    "debian-13",
 #    "fedora-40",
 #    "photon-4",
 #    "ubuntu-2004",
 #    "ubuntu-2404",
 STABLE_DISTROS = [
+    "amazonlinux-2",
+    "amazonlinux-2023",
+    "debian-11",
+    "debian-12",
     "photon-5",
     "rockylinux-8",
     "rockylinux-9",
@@ -55,16 +58,16 @@ STABLE_DISTROS = [
 
 # only test against current containers with systemd
 # will add these when they become available with systemd
-#    "amazonlinux-2",
-#    "amazonlinux-2023",
-#    "debian-11",
-#    "debian-12",
 #    "debian-13",
 #    "fedora-40",
 #    "photon-4",
 #    "ubuntu-2004",
 #    "ubuntu-2404",
 ONEDIR_DISTROS = [
+    "amazonlinux-2",
+    "amazonlinux-2023",
+    "debian-11",
+    "debian-12",
     "photon-5",
     "rockylinux-8",
     "rockylinux-9",
@@ -75,12 +78,12 @@ ONEDIR_DISTROS = [
 # will add these when they become available with systemd
 #    "amazonlinux-2",
 #    "amazonlinux-2023",
-#    "debian-12",
 #    "photon-4",
 #    "photon-5",
-#    "rockylinux-9",
+#    "rockylinux-8",
 #    "ubuntu-2404",
 ONEDIR_RC_DISTROS = [
+    "debian-12",
     "photon-5",
     "rockylinux-9",
     "ubuntu-2204",
@@ -97,41 +100,41 @@ BLACKLIST_3007 = [
     "photon-5",
 ]
 
+#    "debian-12",
+#    "rockylinux-9",
+#    "ubuntu-2204",
 BLACKLIST_GIT_3006 = [
     "amazonlinux-2",
     "amazonlinux-2023",
     "debian-11",
-    "debian-12",
     "fedora-40",
     "photon-4",
     "photon-5",
-    "rockylinux-9",
     "ubuntu-2004",
-    "ubuntu-2204",
     "ubuntu-2404",
 ]
 
+#    "debian-12",
+#    "rockylinux-9",
+#    "ubuntu-2204",
 BLACKLIST_GIT_3007 = [
     "amazonlinux-2",
     "amazonlinux-2023",
     "debian-11",
-    "debian-12",
     "debian-13",
     "fedora-40",
     "photon-4",
     "photon-5",
-    "rockylinux-9",
     "ubuntu-2004",
-    "ubuntu-2204",
     "ubuntu-2404",
 ]
 
+##    "rockylinux-9",
 BLACKLIST_GIT_MASTER = [
     "amazonlinux-2",
     "amazonlinux-2023",
     "photon-4",
     "photon-5",
-    "rockylinux-9",
 ]
 
 SALT_VERSIONS = [

--- a/.github/workflows/templates/generate.py
+++ b/.github/workflows/templates/generate.py
@@ -8,9 +8,6 @@ os.chdir(os.path.abspath(os.path.dirname(__file__)))
 
 # only test against current containers with systemd
 # will add these when they become available with systemd
-#    "amazonlinux-2",
-#    "amazonlinux-2023",
-#    "debian-11",
 #    "debian-12",
 #    "debian-13",
 #    "fedora-40",
@@ -18,6 +15,9 @@ os.chdir(os.path.abspath(os.path.dirname(__file__)))
 #    "ubuntu-2004",
 #    "ubuntu-2404",
 LINUX_DISTROS = [
+    "amazonlinux-2",
+    "amazonlinux-2023",
+    "debian-11",
     "debian-12",
     "photon-5",
     "rockylinux-8",
@@ -37,15 +37,15 @@ OSX = [
 
 # only test against current containers with systemd
 # will add these when they become available with systemd
-#    "amazonlinux-2",
-#    "amazonlinux-2023",
-#    "debian-11",
 #    "debian-13",
 #    "fedora-40",
 #    "photon-4",
 #    "ubuntu-2004",
 #    "ubuntu-2404",
 STABLE_DISTROS = [
+    "amazonlinux-2",
+    "amazonlinux-2023",
+    "debian-11",
     "debian-12",
     "photon-5",
     "rockylinux-8",
@@ -55,15 +55,15 @@ STABLE_DISTROS = [
 
 # only test against current containers with systemd
 # will add these when they become available with systemd
-#    "amazonlinux-2",
-#    "amazonlinux-2023",
-#    "debian-11",
 #    "debian-13",
 #    "fedora-40",
 #    "photon-4",
 #    "ubuntu-2004",
 #    "ubuntu-2404",
 ONEDIR_DISTROS = [
+    "amazonlinux-2",
+    "amazonlinux-2023",
+    "debian-11",
     "debian-12",
     "photon-5",
     "rockylinux-8",
@@ -97,31 +97,31 @@ BLACKLIST_3007 = [
     "photon-5",
 ]
 
-#    "debian-12",
-#    "rockylinux-9",
 #    "ubuntu-2204",
 BLACKLIST_GIT_3006 = [
     "amazonlinux-2",
     "amazonlinux-2023",
     "debian-11",
+    "debian-12",
     "fedora-40",
     "photon-4",
     "photon-5",
+    "rockylinux-9",
     "ubuntu-2004",
     "ubuntu-2404",
 ]
 
-#    "debian-12",
-#    "rockylinux-9",
 #    "ubuntu-2204",
 BLACKLIST_GIT_3007 = [
     "amazonlinux-2",
     "amazonlinux-2023",
     "debian-11",
+    "debian-12",
     "debian-13",
     "fedora-40",
     "photon-4",
     "photon-5",
+    "rockylinux-9",
     "ubuntu-2004",
     "ubuntu-2404",
 ]

--- a/README.rst
+++ b/README.rst
@@ -343,8 +343,7 @@ Installing the latest master branch of Salt from git:
 
 .. code:: console
 
-  curl -L https://github.com/saltstack/salt-bootstrap/releases/latest/download/bootstrap-salt.sh |
-  sudo sh -s -- git master
+  curl -L https://github.com/saltstack/salt-bootstrap/releases/latest/download/bootstrap-salt.sh | sudo sh -s -- git master
 
 Note: use of git is recommended for development environments, for example: testing new features of
 Salt which have not yet been released.

--- a/README.rst
+++ b/README.rst
@@ -59,8 +59,9 @@ If you're looking for a *one-liner* to install Salt, please scroll to the bottom
 instructions for `Installing via an Insecure One-Liner`_.
 
 There are also .sha256 files for verifying against in the repo for the stable branch.  You can also
-get the correct sha256 sum for the stable release from https://bootstrap.saltproject.io/sha256 and
-https://winbootstrap.saltproject.io/sha256
+get the correct sha256 sum for the stable release from
+https://github.com/saltstack/salt-bootstrap/releases/latest/download/bootstrap-salt.sh.sha256 and
+https://github.com/saltstack/salt-bootstrap/releases/latest/download/bootstrap-salt.ps1.sha256
 
 Contributing
 ------------
@@ -86,9 +87,9 @@ To view the latest options and descriptions for ``salt-bootstrap``, use ``-h`` a
     - stable              Install latest stable release. This is the default
                           install type
     - stable [branch]     Install latest version on a branch. Only supported
-                          for packages available at repo.saltproject.io
+                          for packages available at packages.broadcom.com
     - stable [version]    Install a specific version. Only supported for
-                          packages available at repo.saltproject.io
+                          packages available at packages.broadcom.com
                           To pin a 3xxx minor version, specify it as 3xxx.0
     - testing             RHEL-family specific: configure EPEL testing repo
     - git                 Install from the head of the master branch
@@ -171,8 +172,8 @@ To view the latest options and descriptions for ``salt-bootstrap``, use ``-h`` a
         on the system.
     -R  Specify a custom repository URL. Assumes the custom repository URL
         points to a repository that mirrors Salt packages located at
-        repo.saltproject.io. The option passed with -R replaces the
-        "repo.saltproject.io". If -R is passed, -r is also set. Currently only
+        packages.broadcom.com. The option passed with -R replaces the
+        "packages.broadcom.com". If -R is passed, -r is also set. Currently only
         works on CentOS/RHEL and Debian based distributions.
     -J  Replace the Master config file with data passed in as a JSON string. If
         a Master config file is found, a reasonable effort will be made to save
@@ -208,35 +209,35 @@ If you want to install a package of a specific release version, from the Salt Pr
 
 .. code:: console
 
-  curl -o bootstrap-salt.sh -L https://bootstrap.saltproject.io
+  curl -o bootstrap-salt.sh -L https://github.com/saltstack/salt-bootstrap/releases/latest/download/bootstrap-salt.sh
   sudo sh bootstrap-salt.sh -P stable 3006.1
 
 If you want to install a specific release version, based on the Git tags:
 
 .. code:: console
 
-  curl -o bootstrap-salt.sh -L https://bootstrap.saltproject.io
+  curl -o bootstrap-salt.sh -L https://github.com/saltstack/salt-bootstrap/releases/latest/download/bootstrap-salt.sh
   sudo sh bootstrap-salt.sh git v3006.1
 
 Using ``curl`` to install latest development version from GitHub:
 
 .. code:: console
 
-  curl -o bootstrap-salt.sh -L https://bootstrap.saltproject.io
-  sudo sh bootstrap-salt.sh git master
+  curl -o bootstrap-salt.sh -L https://github.com/saltstack/salt-bootstrap/releases/latest/download/bootstrap-salt.sh sudo sh
+  bootstrap-salt.sh git master
 
 To install a specific branch from a Git fork:
 
 .. code:: console
 
-  curl -o bootstrap-salt.sh -L https://bootstrap.saltproject.io
+  curl -o bootstrap-salt.sh -L https://github.com/saltstack/salt-bootstrap/releases/latest/download/bootstrap-salt.sh
   sudo sh bootstrap-salt.sh -g https://github.com/myuser/salt.git git mybranch
 
 If all you want is to install a ``salt-master`` using latest Git:
 
 .. code:: console
 
-  curl -o bootstrap-salt.sh -L https://bootstrap.saltproject.io
+  curl -o bootstrap-salt.sh -L https://github.com/saltstack/salt-bootstrap/releases/latest/download/bootstrap-salt.sh
   sudo sh bootstrap-salt.sh -M -N git master
 
 If your host has Internet access only via HTTP proxy, from the Salt Project repo:
@@ -244,7 +245,7 @@ If your host has Internet access only via HTTP proxy, from the Salt Project repo
 .. code:: console
 
   PROXY='http://user:password@myproxy.example.com:3128'
-  curl -o bootstrap-salt.sh -L -x "$PROXY" https://bootstrap.saltproject.io
+  curl -o bootstrap-salt.sh -L -x "$PROXY" https://github.com/saltstack/salt-bootstrap/releases/latest/download/bootstrap-salt.sh
   sudo sh bootstrap-salt.sh -P -H "$PROXY" stable
 
 If your host has Internet access only via HTTP proxy, installing via Git:
@@ -252,7 +253,8 @@ If your host has Internet access only via HTTP proxy, installing via Git:
 .. code:: console
 
   PROXY='http://user:password@myproxy.example.com:3128'
-  curl -o bootstrap-salt.sh -L -x "$PROXY" https://bootstrap.saltproject.io
+  curl -o bootstrap-salt.sh -L -x "$PROXY"
+  https://github.com/saltstack/salt-bootstrap/releases/latest/download/bootstrap-salt.sh
   sudo sh bootstrap-salt.sh -H "$PROXY" git
 
 
@@ -263,22 +265,23 @@ Using ``wget`` to install your distribution's stable packages:
 
 .. code:: console
 
-  wget -O bootstrap-salt.sh https://bootstrap.saltproject.io
+  wget -O bootstrap-salt.sh
+  https://github.com/saltstack/salt-bootstrap/releases/latest/download/bootstrap-salt.sh
   sudo sh bootstrap-salt.sh
 
 Installing a specific version from git using ``wget``:
 
 .. code:: console
 
-  wget -O bootstrap-salt.sh https://bootstrap.saltproject.io
-  sudo sh bootstrap-salt.sh git v3004.1
+  wget -O bootstrap-salt.sh https://github.com/saltstack/salt-bootstrap/releases/latest/download/bootstrap-salt.sh
+  sudo sh bootstrap-salt.sh git v3006.8
 
 Installing a specific version package from the Salt Project repo using ``wget``:
 
 .. code:: console
 
-  wget -O bootstrap-salt.sh https://bootstrap.saltproject.io
-  sudo sh bootstrap-salt.sh -P stable 3006.1
+  wget -O bootstrap-salt.sh https://github.com/saltstack/salt-bootstrap/releases/latest/download/bootstrap-salt.sh
+  sudo sh bootstrap-salt.sh -P stable 3006.8
 
 **NOTE**
 
@@ -293,14 +296,14 @@ If you already have Python installed, ``python 3.10``, then it's as easy as:
 
 .. code:: console
 
-  python -m urllib "https://bootstrap.saltproject.io" > bootstrap-salt.sh
+  python -m urllib "https://github.com/saltstack/salt-bootstrap/releases/latest/download/bootstrap-salt.sh" > bootstrap-salt.sh
   sudo sh bootstrap-salt.sh -P stable 3006.1
 
 With python version 3:
 
 .. code:: console
 
-  python3 -c 'import urllib.request; print(urllib.request.urlopen("https://bootstrap.saltproject.io").read().decode("ascii"))' > bootstrap-salt.sh
+  python3 -c 'import urllib.request; print(urllib.request.urlopen("https://github.com/saltstack/salt-bootstrap/releases/latest/download/bootstrap-salt.sh").read().decode("ascii"))' > bootstrap-salt.sh
   sudo sh bootstrap-salt.sh git v3006.1
 
 Note: Python 2.x is no longer supported given it reached it's End-Of-Life Jan. 1st, 2020
@@ -323,25 +326,26 @@ Installing the latest stable release of Salt (default):
 
 .. code:: console
 
-  curl -L https://bootstrap.saltproject.io | sudo sh
+  curl -L  https://github.com/saltstack/salt-bootstrap/releases/latest/download/bootstrap-salt.sh | sudo sh
 
 Using ``wget`` to install your distribution's stable packages:
 
 .. code:: console
 
-  wget -O - https://bootstrap.saltproject.io | sudo sh
+  wget -O - https://github.com/saltstack/salt-bootstrap/releases/latest/download/bootstrap-salt.sh | sudo sh
 
 Installing a target version package of Salt from the Salt Project repo:
 
 .. code:: console
 
-  curl -L https://bootstrap.saltproject.io | sudo sh -s -- stable 3006.8
+  curl -L https://github.com/saltstack/salt-bootstrap/releases/latest/download/bootstrap-salt.sh | sudo sh -s -- stable 3006.8
 
 Installing the latest master branch of Salt from git:
 
 .. code:: console
 
-  curl -L https://bootstrap.saltproject.io | sudo sh -s -- git master
+  curl -L https://github.com/saltstack/salt-bootstrap/releases/latest/download/bootstrap-salt.sh |
+  sudo sh -s -- git master
 
 Note: use of git is recommended for development environments, for example: testing new features of
 Salt which have not yet been released.
@@ -356,9 +360,7 @@ Using ``PowerShell`` to install latest stable version:
 .. code:: powershell
 
   [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]'Tls12'
-  Invoke-WebRequest -Uri https://winbootstrap.saltproject.io -OutFile "$env:TEMP\bootstrap-salt.ps1"
-  Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
-  & "$env:TEMP\bootstrap-salt.ps1"
+  Invoke-WebRequest -Uri https://github.com/saltstack/salt-bootstrap/releases/latest/download/bootstrap-salt.ps1 -OutFile "$env:TEMP\bootstrap-salt.ps1" Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser & "$env:TEMP\bootstrap-salt.ps1"
 
 Display information about the install script parameters:
 
@@ -370,7 +372,7 @@ Using ``cygwin`` to install latest stable version:
 
 .. code:: console
 
-  curl -o bootstrap-salt.ps1 -L https://winbootstrap.saltproject.io
+  curl -o bootstrap-salt.ps1 -L https://github.com/saltstack/salt-bootstrap/releases/latest/download/bootstrap-salt.ps1
   "/cygdrive/c/WINDOWS/System32/WindowsPowerShell/v1.0/powershell.exe" -NoProfile -InputFormat None -ExecutionPolicy Bypass -Command "[System.Net.ServicePointManager]::SecurityProtocol = 3072; iex ./bootstrap-salt.ps1"
 
 
@@ -380,13 +382,13 @@ Supported Operating Systems
 The salt-bootstrap script officially supports the distributions outlined in
 `Salt's Supported Operating Systems
 <https://docs.saltproject.io/salt/install-guide/en/latest/topics/salt-supported-operating-systems.html>`_
-document, (BSD-based OSs, Solaris and AIX are no longer
-supported).  The operating systems listed below should reflect this document but may become out of
-date. If an operating system is listed below, but is not listed on the official supported operating
+document, (BSD-based OSs, Solaris and AIX are no longer supported).
+The operating systems listed below should reflect this document but may become out of date.
+If an operating system is listed below, but is not listed on the official supported operating
 systems document, the level of support is "best-effort".
 
 Since Salt is written in Python, the packages available from the `Salt Project's repository
-<https://repo.saltproject.io/salt/py3>`_ are
+<packages.broardcom.com>`_ are
 CPU architecture independent and could be installed on any hardware supported by Linux kernel.
 However, the Salt Project does package Salt's binary dependencies only for ``x86_64`` (``amd64``)
 and ``AArch64`` (``arm64``).

--- a/README.rst
+++ b/README.rst
@@ -325,7 +325,7 @@ Installing the latest stable release of Salt (default):
 
 .. code:: console
 
-  curl -L  https://github.com/saltstack/salt-bootstrap/releases/latest/download/bootstrap-salt.sh | sudo sh
+  curl -L https://github.com/saltstack/salt-bootstrap/releases/latest/download/bootstrap-salt.sh | sudo sh
 
 Using ``wget`` to install your distribution's stable packages:
 

--- a/README.rst
+++ b/README.rst
@@ -253,8 +253,7 @@ If your host has Internet access only via HTTP proxy, installing via Git:
 .. code:: console
 
   PROXY='http://user:password@myproxy.example.com:3128'
-  curl -o bootstrap-salt.sh -L -x "$PROXY"
-  https://github.com/saltstack/salt-bootstrap/releases/latest/download/bootstrap-salt.sh
+  curl -o bootstrap-salt.sh -L -x "$PROXY" https://github.com/saltstack/salt-bootstrap/releases/latest/download/bootstrap-salt.sh
   sudo sh bootstrap-salt.sh -H "$PROXY" git
 
 

--- a/README.rst
+++ b/README.rst
@@ -223,8 +223,8 @@ Using ``curl`` to install latest development version from GitHub:
 
 .. code:: console
 
-  curl -o bootstrap-salt.sh -L https://github.com/saltstack/salt-bootstrap/releases/latest/download/bootstrap-salt.sh sudo sh
-  bootstrap-salt.sh git master
+  curl -o bootstrap-salt.sh -L https://github.com/saltstack/salt-bootstrap/releases/latest/download/bootstrap-salt.sh
+  sudo sh bootstrap-salt.sh git master
 
 To install a specific branch from a Git fork:
 

--- a/README.rst
+++ b/README.rst
@@ -358,7 +358,9 @@ Using ``PowerShell`` to install latest stable version:
 .. code:: powershell
 
   [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]'Tls12'
-  Invoke-WebRequest -Uri https://github.com/saltstack/salt-bootstrap/releases/latest/download/bootstrap-salt.ps1 -OutFile "$env:TEMP\bootstrap-salt.ps1" Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser & "$env:TEMP\bootstrap-salt.ps1"
+  Invoke-WebRequest -Uri https://github.com/saltstack/salt-bootstrap/releases/latest/download/bootstrap-salt.ps1 -OutFile "$env:TEMP\bootstrap-salt.ps1"
+  Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
+  & "$env:TEMP\bootstrap-salt.ps1"
 
 Display information about the install script parameters:
 

--- a/README.rst
+++ b/README.rst
@@ -388,7 +388,7 @@ If an operating system is listed below, but is not listed on the official suppor
 systems document, the level of support is "best-effort".
 
 Since Salt is written in Python, the packages available from the `Salt Project's repository
-<packages.broardcom.com>`_ are
+<packages.broadcom.com>`_ are
 CPU architecture independent and could be installed on any hardware supported by Linux kernel.
 However, the Salt Project does package Salt's binary dependencies only for ``x86_64`` (``amd64``)
 and ``AArch64`` (``arm64``).

--- a/README.rst
+++ b/README.rst
@@ -264,8 +264,7 @@ Using ``wget`` to install your distribution's stable packages:
 
 .. code:: console
 
-  wget -O bootstrap-salt.sh
-  https://github.com/saltstack/salt-bootstrap/releases/latest/download/bootstrap-salt.sh
+  wget -O bootstrap-salt.sh https://github.com/saltstack/salt-bootstrap/releases/latest/download/bootstrap-salt.sh
   sudo sh bootstrap-salt.sh
 
 Installing a specific version from git using ``wget``:
@@ -359,8 +358,7 @@ Using ``PowerShell`` to install latest stable version:
 
   [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]'Tls12'
   Invoke-WebRequest -Uri https://github.com/saltstack/salt-bootstrap/releases/latest/download/bootstrap-salt.ps1 -OutFile "$env:TEMP\bootstrap-salt.ps1"
-  Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
-  & "$env:TEMP\bootstrap-salt.ps1"
+  Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser & "$env:TEMP\bootstrap-salt.ps1"
 
 Display information about the install script parameters:
 

--- a/bootstrap-salt.ps1
+++ b/bootstrap-salt.ps1
@@ -39,7 +39,8 @@
     Salt Bootstrap GitHub Project (script home) - https://github.com/saltstack/salt-bootstrap
     Original Vagrant Provisioner Project - https://github.com/saltstack/salty-vagrant
     Vagrant Project (utilizes this script) - https://github.com/mitchellh/vagrant
-    Salt Download Location - https://repo.saltproject.io/salt/py3/windows
+    Salt Download Location - https://packages.broadcom.com/artifactory/saltproject-generic/windows/
+    Salt Manual Install Directions (Windows) - https://docs.saltproject.io/salt/install-guide/en/latest/topics/install-by-operating-system/windows.html
 #>
 
 #===============================================================================

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2103,7 +2103,7 @@ __git_clone_and_checkout() {
     fi
 
     if [ "$(echo "$GIT_REV" | grep -E '^(3006|3007)$')" != "" ]; then
-        GIT_REV_ADJ="$1.x"  # branches are 3006.x or 3007.x
+        GIT_REV_ADJ="$GIT_REV.x"  # branches are 3006.x or 3007.x
     else
         GIT_REV_ADJ="$GIT_REV"
     fi

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -26,7 +26,7 @@
 #======================================================================================================================
 set -o nounset                              # Treat unset variables as an error
 
-__ScriptVersion="2024.11.21"
+__ScriptVersion="2024.11.25"
 __ScriptName="bootstrap-salt.sh"
 
 __ScriptFullName="$0"
@@ -640,7 +640,11 @@ elif [ "$ITYPE" = "git" ]; then
     if [ "$#" -eq 0 ];then
         GIT_REV="master"
     else
-        GIT_REV="$1"
+        if [ "$(echo "$1" | grep -E '^(3006|3007)$')" != "" ]; then
+            GIT_REV="$1.x"  # branches are 3006.x or 3007.x
+        else
+            GIT_REV="$1"
+        fi
         shift
     fi
 
@@ -3085,7 +3089,7 @@ install_ubuntu_deps() {
     # Additionally install procps and pciutils which allows for Docker bootstraps. See 366#issuecomment-39666813
     __PACKAGES="${__PACKAGES} procps pciutils"
 
-    # ensure sudo installed
+    # ensure sudo, ps installed
     __PACKAGES="${__PACKAGES} sudo"
 
     ## include hwclock if not part of base OS (23.10 and up)
@@ -3170,6 +3174,9 @@ install_ubuntu_git_deps() {
     if [ ! -f /usr/sbin/hwclock ]; then
         __PACKAGES="${__PACKAGES} util-linux-extra"
     fi
+
+    # Additionally install procps and pciutils which allows for Docker bootstraps. See 366#issuecomment-39666813
+    __PACKAGES="${__PACKAGES} procps pciutils"
 
     # ensure sudo installed
     __PACKAGES="${__PACKAGES} sudo"
@@ -3617,6 +3624,9 @@ install_debian_git_deps() {
 
     __PACKAGES="python${PY_PKG_VER}-dev python${PY_PKG_VER}-pip python${PY_PKG_VER}-setuptools gcc"
     echodebug "install_debian_git_deps() Installing ${__PACKAGES}"
+
+    # Additionally install procps and pciutils which allows for Docker bootstraps. See 366#issuecomment-39666813
+    __PACKAGES="${__PACKAGES} procps pciutils"
 
     # ensure sudo installed
     __PACKAGES="${__PACKAGES} sudo"

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -26,7 +26,7 @@
 #======================================================================================================================
 set -o nounset                              # Treat unset variables as an error
 
-__ScriptVersion="2024.11.21"
+__ScriptVersion="2024.11.22"
 __ScriptName="bootstrap-salt.sh"
 
 __ScriptFullName="$0"
@@ -314,6 +314,9 @@ __usage() {
 
   Usage :  ${__ScriptName} [options] <install-type> [install-type-args]
 
+
+  Usage :  bootstrap-salt.sh [options] <install-type> [install-type-args]
+
   Installation types:
     - stable               Install latest stable release. This is the default
                            install type
@@ -351,7 +354,6 @@ __usage() {
     - ${__ScriptName} onedir_rc
     - ${__ScriptName} onedir_rc 3008
 
-
   Options:
     -a  Pip install all Python pkg dependencies for Salt. Requires -V to install
         all pip pkgs into the virtualenv.
@@ -373,7 +375,7 @@ __usage() {
     -f  Force shallow cloning for git installations.
         This may result in an "n/a" in the version number.
     -F  Allow copied files to overwrite existing (config, init.d, etc)
-    -g  Salt Git repository URL. Default: ${_SALTSTACK_REPO_URL}
+    -g  Salt Git repository URL. Default: https://github.com/saltstack/salt.git
     -h  Display this message
     -H  Use the specified HTTP proxy for all download URLs (including https://).
         For example: http://myproxy.example.com:3128
@@ -419,7 +421,7 @@ __usage() {
         "packages.broadcom.com". If -R is passed, -r is also set. Currently only
         works on CentOS/RHEL and Debian based distributions and macOS.
     -s  Sleep time used when waiting for daemons to start, restart and when
-        checking for the services running. Default: ${__DEFAULT_SLEEP}
+        checking for the services running. Default: 3
     -S  Also install salt-syndic
     -r  Disable all repository configuration performed by this script. This
         option assumes all necessary repository configuration is already present

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2741,11 +2741,6 @@ __install_salt_from_repo() {
     __check_pip_allowed
 
     echodebug "Installed pip version: $(${_pip_cmd} --version)"
-    echodebug "Upgrading pip to latest, running '${_pip_cmd} install ${_PIP_INSTALL_ARGS} -U pip>=${_MINIMUM_PIP_VERSION}'"
-    ## DGM ${_pip_cmd} install ${_PIP_INSTALL_ARGS} -v -U "pip>=${_MINIMUM_PIP_VERSION}"
-    ${_py_exe} -m pip install ${_PIP_INSTALL_ARGS} -v -U "pip>=${_MINIMUM_PIP_VERSION}"
-
-    echodebug "Upgraded pip version: $(${_pip_cmd} --version)"
 
     _setuptools_dep="setuptools>=${_MINIMUM_SETUPTOOLS_VERSION},<${_MAXIMUM_SETUPTOOLS_VERSION}"
     if [ "$_PY_MAJOR_VERSION" -ne 3 ]; then

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2817,11 +2817,7 @@ EOM
 
     echoinfo "Downloading Salt Dependencies from PyPi"
     echodebug "Running '${_pip_cmd} download -d /tmp/git/deps ${_PIP_DOWNLOAD_ARGS} .'"
-    if [ "${OS_NAME}" = "Linux" ]; then
-        ${_pip_cmd} download -d /tmp/git/deps ${_PIP_DOWNLOAD_ARGS} -r "requirements/static/pkg/py${_py_version}/linux.txt"
-    else
-        ${_pip_cmd} download -d /tmp/git/deps ${_PIP_DOWNLOAD_ARGS} .
-    fi
+    ${_pip_cmd} download -d /tmp/git/deps ${_PIP_DOWNLOAD_ARGS} .
     # shellcheck disable=SC2181
     if [ $? -ne 0 ]; then
         echo "Failed to download salt dependencies"

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2742,7 +2742,8 @@ __install_salt_from_repo() {
 
     echodebug "Installed pip version: $(${_pip_cmd} --version)"
     echodebug "Upgrading pip to latest, running '${_pip_cmd} install ${_PIP_INSTALL_ARGS} -U pip>=${_MINIMUM_PIP_VERSION}'"
-    ${_pip_cmd} install ${_PIP_INSTALL_ARGS} -v -U "pip>=${_MINIMUM_PIP_VERSION}"
+    ## DGM ${_pip_cmd} install ${_PIP_INSTALL_ARGS} -v -U "pip>=${_MINIMUM_PIP_VERSION}"
+    ${_py_exe} -m pip install ${_PIP_INSTALL_ARGS} -v -U "pip>=${_MINIMUM_PIP_VERSION}"
 
     echodebug "Upgraded pip version: $(${_pip_cmd} --version)"
 

--- a/tests/integration/test_installation.py
+++ b/tests/integration/test_installation.py
@@ -67,4 +67,5 @@ def test_target_salt_version(path, target_salt_version):
     cmd = ["salt-call", "--local", "grains.item", "saltversion", "--timeout=120"]
     result = run_salt_call(cmd)
     # Returns: {'saltversion': '3006.9+217.g53cfa53040'}
-    assert result["saltversion"] == target_salt_version
+    adj_saltversion = result["saltversion"].split("+")[0]
+    assert adj_saltversion == target_salt_version

--- a/tests/integration/test_installation.py
+++ b/tests/integration/test_installation.py
@@ -29,10 +29,6 @@ def run_salt_call(cmd):
     if platform.system() == "Windows":
         cmd.append("--out=json")
         result = subprocess.run(cmd, capture_output=True, text=True)
-        print(
-            f"DGM run_salt_call, cmd '{cmd}', result '{result}', stdout '{result.stdout}'",
-            flush=True,
-        )
         if 0 == result.returncode:
             json_data = json.loads(result.stdout)
         else:
@@ -43,10 +39,6 @@ def run_salt_call(cmd):
         cmdl.extend(cmd)
         cmdl.append("--out=json")
         result = subprocess.run(cmdl, capture_output=True, text=True)
-        print(
-            f"DGM run_salt_call, cmdl '{cmdl}', result '{result}', stdout '{result.stdout}'",
-            flush=True,
-        )
         if 0 == result.returncode:
             json_data = json.loads(result.stdout)
         else:
@@ -74,10 +66,5 @@ def test_target_salt_version(path, target_salt_version):
         pytest.skip(f"No target version specified")
     cmd = ["salt-call", "--local", "grains.item", "saltversion", "--timeout=120"]
     result = run_salt_call(cmd)
-    dgm_saltversion = result["saltversion"]
-    print(
-        f"DGM test_target_salt_version, target_salt_version '{target_salt_version}', result saltversion '{dgm_saltversion }', result '{result}'",
-        flush=True,
-    )
     # Returns: {'saltversion': '3006.9+217.g53cfa53040'}
     assert result["saltversion"] == target_salt_version


### PR DESCRIPTION
### What does this PR do?
Updated URLs for downloading the bootstrap script etc to GitHub repository

Also fixed issue with downloading dependencies on Redhat family by upgrading to latest version of pip. default pip (21.3.1) failed to utilize '.' arguments, would only work if specific requirements file was fed to it, upgrading to 24.3.1 resolved the issue.

Also added more systemd containers to test against.

### What issues does this PR fix or reference?
fixes #2051


