### PR TITLE
Add support for specifying a directory other than /tmp for installation execution

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 minimum_pre_commit_version: 1.15.2
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v5.0.0
     hooks:
       - id: check-merge-conflict  # Check for files that contain merge conflict strings.
       - id: trailing-whitespace   # Trims trailing whitespace.

--- a/README.rst
+++ b/README.rst
@@ -196,6 +196,9 @@ To view the latest options and descriptions for ``salt-bootstrap``, use ``-h`` a
     -r  Disable all repository configuration performed by this script. This
         option assumes all necessary repository configuration is already present
         on the system.
+    -T  If set this overrides the use of /tmp for script execution. This is
+        to allow for systems in which noexec is applied to temp filesystem mounts
+        for security reasons
     -U  If set, fully upgrade the system prior to bootstrapping Salt
     -v  Display script version
     -V  Install Salt into virtualenv

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -441,7 +441,7 @@ __usage() {
 EOT
 }   # ----------  end of function __usage  ----------
 
-while getopts ':hvnDc:g:Gx:k:s:MSWNXCPFUKIA:i:Lp:dH:bflV:J:j:rR:aqQ' opt
+while getopts ':hvnDc:g:Gx:k:s:MSWNXCPFUKIA:i:Lp:dH:bflV:J:j:rR:T:aqQ' opt
 do
   case "${opt}" in
 

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2172,8 +2172,9 @@ __git_clone_and_checkout() {
         fi
 
         if [ "$__SHALLOW_CLONE" -eq $BS_TRUE ]; then
-            # Let's try shallow cloning to speed up.
-            # Test for "--single-branch" option introduced in git 1.7.10, the minimal version of git where the shallow
+            # Let's try 'treeless' cloning to speed up. Treeless cloning omits trees and blobs ('files')
+            # but includes metadata (commit history, tags, branches etc.
+            # Test for "--filter" option introduced in git 2.19, the minimal version of git where the treeless
             # cloning we need actually works
             if [ "$(git clone 2>&1 | grep 'single-branch')" != "" ]; then
                 # The "--single-branch" option is supported, attempt shallow cloning


### PR DESCRIPTION
### What does this PR do?

Adds an option to specify something other than `/tmp` for installation execution.

### What issues does this PR fix or reference?

Systems that have been hardened to CIS-2 benchmarks should have `/tmp` and `/var/tmp` mounted with the `noexec` option. This causes installations to fail when trying to execute anything from `/tmp`.

### New Behavior

Using the new option allows installations to proceed as expected. An example using the `ubuntu` user home directory:

```shell
bash /home/ubuntu/bootstrap-salt.sh -X -U -A localhost -T /home/ubuntu onedir "$SALT_VERSION"
```
