### PR TITLE
Restrict use of dnf to Fedora only, otherwise use yum when dealing with RedHat family

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -5652,8 +5652,10 @@ install_amazon_linux_ami_2_deps() {
 
     if [ $_DISABLE_REPOS -eq $BS_FALSE ] || [ "$_CUSTOM_REPO_URL" != "null" ]; then
         if [ ! -s "${YUM_REPO_FILE}" ]; then
-            FETCH_URL="https://github.com/saltstack/salt-install-guide/releases/latest/download/salt.repo"
-            __fetch_url "${YUM_REPO_FILE}" "${FETCH_URL}"
+            ## Amazon Linux yum (v3) doesn't support config-manager
+            ## FETCH_URL="https://github.com/saltstack/salt-install-guide/releases/latest/download/salt.repo"
+            ## __fetch_url "${YUM_REPO_FILE}" "${FETCH_URL}"
+            # shellcheck disable=SC2129
             if [ "$STABLE_REV" != "latest" ]; then
                 # 3006.x is default, and latest for 3006.x branch
                 if [ "$(echo "$STABLE_REV" | grep -E '^(3006|3007)$')" != "" ]; then
@@ -5661,14 +5663,33 @@ install_amazon_linux_ami_2_deps() {
                     REPO_REV_MAJOR=$(echo "$STABLE_REV" | cut -d '.' -f 1)
                     if [ "$REPO_REV_MAJOR" -eq "3007" ]; then
                         # Enable the Salt 3007 STS repo
-                        yum config-manager --set-disable salt-repo-*
-                        yum config-manager --set-enabled salt-repo-3007-sts
+                        echo "[salt-repo-3007-sts]" > "${YUM_REPO_FILE}"
+                        echo "name=Salt Repo for Salt v3007 STS" >> "${YUM_REPO_FILE}"
+                        echo "baseurl=https://${_REPO_URL}/saltproject-rpm/" >> "${YUM_REPO_FILE}"
+                        echo "skip_if_unavailable=True" >> "${YUM_REPO_FILE}"
+                        echo "priority=10" >> "${YUM_REPO_FILE}"
+                        echo "enabled=1" >> "${YUM_REPO_FILE}"
+                        echo "enabled_metadata=1" >> "${YUM_REPO_FILE}"
+                        echo "gpgcheck=1" >> "${YUM_REPO_FILE}"
+                        echo "exclude=*3006* *3008* *3009* *3010*" >> "${YUM_REPO_FILE}"
+                        echo "gpgkey=https://${_REPO_URL}/api/security/keypair/SaltProjectKey/public" >> "${YUM_REPO_FILE}"
+                    else
+                        # Salt 3006 repo
+                        echo "[salt-repo-3006-lts]" > "${YUM_REPO_FILE}"
+                        echo "name=Salt Repo for Salt v3006 LTS" >> "${YUM_REPO_FILE}"
+                        echo "baseurl=https://${_REPO_URL}/saltproject-rpm/" >> "${YUM_REPO_FILE}"
+                        echo "skip_if_unavailable=True" >> "${YUM_REPO_FILE}"
+                        echo "priority=10" >> "${YUM_REPO_FILE}"
+                        echo "enabled=1" >> "${YUM_REPO_FILE}"
+                        echo "enabled_metadata=1" >> "${YUM_REPO_FILE}"
+                        echo "gpgcheck=1" >> "${YUM_REPO_FILE}"
+                        echo "exclude=*3007* *3008* *3009* *3010*" >> "${YUM_REPO_FILE}"
+                        echo "gpgkey=https://${_REPO_URL}/api/security/keypair/SaltProjectKey/public" >> "${YUM_REPO_FILE}"
                     fi
                 elif [ "$(echo "$STABLE_REV" | grep -E '^([3-9][0-5]{2}[6-9](\.[0-9]*)?)')" != "" ]; then
                     # using minor version
                     STABLE_REV_DOT=$(echo "$STABLE_REV" | sed 's/-/\./')
                     echo "[salt-repo-${STABLE_REV_DOT}-lts]" > "${YUM_REPO_FILE}"
-                    # shellcheck disable=SC2129
                     echo "name=Salt Repo for Salt v${STABLE_REV_DOT} LTS" >> "${YUM_REPO_FILE}"
                     echo "baseurl=https://${_REPO_URL}/saltproject-rpm/" >> "${YUM_REPO_FILE}"
                     echo "skip_if_unavailable=True" >> "${YUM_REPO_FILE}"
@@ -5680,8 +5701,15 @@ install_amazon_linux_ami_2_deps() {
                 fi
             else
                 # Enable the Salt LATEST repo
-                yum config-manager --set-disable salt-repo-*
-                yum config-manager --set-enabled salt-repo-latest
+                echo "[salt-repo-latest]" > "${YUM_REPO_FILE}"
+                echo "name=Salt Repo for Salt LATEST release" >> "${YUM_REPO_FILE}"
+                echo "baseurl=https://${_REPO_URL}/saltproject-rpm/" >> "${YUM_REPO_FILE}"
+                echo "skip_if_unavailable=True" >> "${YUM_REPO_FILE}"
+                echo "priority=10" >> "${YUM_REPO_FILE}"
+                echo "enabled=1" >> "${YUM_REPO_FILE}"
+                echo "enabled_metadata=1" >> "${YUM_REPO_FILE}"
+                echo "gpgcheck=1" >> "${YUM_REPO_FILE}"
+                echo "gpgkey=https://${_REPO_URL}/api/security/keypair/SaltProjectKey/public" >> "${YUM_REPO_FILE}"
             fi
             yum clean expire-cache || return 1
             yum makecache || return 1
@@ -5717,8 +5745,10 @@ install_amazon_linux_ami_2_onedir_deps() {
 
     if [ $_DISABLE_REPOS -eq $BS_FALSE ] || [ "$_CUSTOM_REPO_URL" != "null" ]; then
         if [ ! -s "${YUM_REPO_FILE}" ]; then
-            FETCH_URL="https://github.com/saltstack/salt-install-guide/releases/latest/download/salt.repo"
-            __fetch_url "${YUM_REPO_FILE}" "${FETCH_URL}"
+            ## Amazon Linux yum (v3) doesn't support config-manager
+            ## FETCH_URL="https://github.com/saltstack/salt-install-guide/releases/latest/download/salt.repo"
+            ## __fetch_url "${YUM_REPO_FILE}" "${FETCH_URL}"
+            # shellcheck disable=SC2129
             if [ "$ONEDIR_REV" != "latest" ]; then
                 # 3006.x is default, and latest for 3006.x branch
                 if [ "$(echo "$ONEDIR_REV" | grep -E '^(3006|3007)$')" != "" ]; then
@@ -5726,14 +5756,33 @@ install_amazon_linux_ami_2_onedir_deps() {
                     REPO_REV_MAJOR=$(echo "$ONEDIR_REV" | cut -d '.' -f 1)
                     if [ "$REPO_REV_MAJOR" -eq "3007" ]; then
                         # Enable the Salt 3007 STS repo
-                        yum config-manager --set-disable salt-repo-*
-                        yum config-manager --set-enabled salt-repo-3007-sts
+                        echo "[salt-repo-3007-sts]" > "${YUM_REPO_FILE}"
+                        echo "name=Salt Repo for Salt v3007 STS" >> "${YUM_REPO_FILE}"
+                        echo "baseurl=https://${_REPO_URL}/saltproject-rpm/" >> "${YUM_REPO_FILE}"
+                        echo "skip_if_unavailable=True" >> "${YUM_REPO_FILE}"
+                        echo "priority=10" >> "${YUM_REPO_FILE}"
+                        echo "enabled=1" >> "${YUM_REPO_FILE}"
+                        echo "enabled_metadata=1" >> "${YUM_REPO_FILE}"
+                        echo "gpgcheck=1" >> "${YUM_REPO_FILE}"
+                        echo "exclude=*3006* *3008* *3009* *3010*" >> "${YUM_REPO_FILE}"
+                        echo "gpgkey=https://${_REPO_URL}/api/security/keypair/SaltProjectKey/public" >> "${YUM_REPO_FILE}"
+                    else
+                        # Salt 3006 repo
+                        echo "[salt-repo-3006-lts]" > "${YUM_REPO_FILE}"
+                        echo "name=Salt Repo for Salt v3006 LTS" >> "${YUM_REPO_FILE}"
+                        echo "baseurl=https://${_REPO_URL}/saltproject-rpm/" >> "${YUM_REPO_FILE}"
+                        echo "skip_if_unavailable=True" >> "${YUM_REPO_FILE}"
+                        echo "priority=10" >> "${YUM_REPO_FILE}"
+                        echo "enabled=1" >> "${YUM_REPO_FILE}"
+                        echo "enabled_metadata=1" >> "${YUM_REPO_FILE}"
+                        echo "gpgcheck=1" >> "${YUM_REPO_FILE}"
+                        echo "exclude=*3007* *3008* *3009* *3010*" >> "${YUM_REPO_FILE}"
+                        echo "gpgkey=https://${_REPO_URL}/api/security/keypair/SaltProjectKey/public" >> "${YUM_REPO_FILE}"
                     fi
                 elif [ "$(echo "$ONEDIR_REV" | grep -E '^([3-9][0-5]{2}[6-9](\.[0-9]*)?)')" != "" ]; then
                     # using minor version
                     ONEDIR_REV_DOT=$(echo "$ONEDIR_REV" | sed 's/-/\./')
                     echo "[salt-repo-${ONEDIR_REV_DOT}-lts]" > "${YUM_REPO_FILE}"
-                    # shellcheck disable=SC2129
                     echo "name=Salt Repo for Salt v${ONEDIR_REV_DOT} LTS" >> "${YUM_REPO_FILE}"
                     echo "baseurl=https://${_REPO_URL}/saltproject-rpm/" >> "${YUM_REPO_FILE}"
                     echo "skip_if_unavailable=True" >> "${YUM_REPO_FILE}"
@@ -5745,8 +5794,15 @@ install_amazon_linux_ami_2_onedir_deps() {
                 fi
             else
                 # Enable the Salt LATEST repo
-                yum config-manager --set-disable salt-repo-*
-                yum config-manager --set-enabled salt-repo-latest
+                echo "[salt-repo-latest]" > "${YUM_REPO_FILE}"
+                echo "name=Salt Repo for Salt LATEST release" >> "${YUM_REPO_FILE}"
+                echo "baseurl=https://${_REPO_URL}/saltproject-rpm/" >> "${YUM_REPO_FILE}"
+                echo "skip_if_unavailable=True" >> "${YUM_REPO_FILE}"
+                echo "priority=10" >> "${YUM_REPO_FILE}"
+                echo "enabled=1" >> "${YUM_REPO_FILE}"
+                echo "enabled_metadata=1" >> "${YUM_REPO_FILE}"
+                echo "gpgcheck=1" >> "${YUM_REPO_FILE}"
+                echo "gpgkey=https://${_REPO_URL}/api/security/keypair/SaltProjectKey/public" >> "${YUM_REPO_FILE}"
             fi
             yum clean expire-cache || return 1
             yum makecache || return 1
@@ -5852,6 +5908,13 @@ install_amazon_linux_ami_2023_git_deps() {
     return 0
 }
 
+install_amazon_linux_ami_2023_deps() {
+
+    # Set ONEDIR_REV to STABLE_REV
+    ONEDIR_REV=${STABLE_REV}
+    install_amazon_linux_ami_2023_onedir_deps || return 1
+}
+
 install_amazon_linux_ami_2023_onedir_deps() {
 
     # We need to install yum-utils before doing anything else when installing on
@@ -5870,8 +5933,10 @@ install_amazon_linux_ami_2023_onedir_deps() {
 
     if [ $_DISABLE_REPOS -eq $BS_FALSE ] || [ "$_CUSTOM_REPO_URL" != "null" ]; then
         if [ ! -s "${YUM_REPO_FILE}" ]; then
-            FETCH_URL="https://github.com/saltstack/salt-install-guide/releases/latest/download/salt.repo"
-            __fetch_url "${YUM_REPO_FILE}" "${FETCH_URL}"
+            ## Amazon Linux yum (v3) doesn't support config-manager
+            ## FETCH_URL="https://github.com/saltstack/salt-install-guide/releases/latest/download/salt.repo"
+            ## __fetch_url "${YUM_REPO_FILE}" "${FETCH_URL}"
+            # shellcheck disable=SC2129
             if [ "$ONEDIR_REV" != "latest" ]; then
                 # 3006.x is default, and latest for 3006.x branch
                 if [ "$(echo "$ONEDIR_REV" | grep -E '^(3006|3007)$')" != "" ]; then
@@ -5879,14 +5944,33 @@ install_amazon_linux_ami_2023_onedir_deps() {
                     REPO_REV_MAJOR=$(echo "$ONEDIR_REV" | cut -d '.' -f 1)
                     if [ "$REPO_REV_MAJOR" -eq "3007" ]; then
                         # Enable the Salt 3007 STS repo
-                        yum config-manager --set-disable salt-repo-*
-                        yum config-manager --set-enabled salt-repo-3007-sts
+                        echo "[salt-repo-3007-sts]" > "${YUM_REPO_FILE}"
+                        echo "name=Salt Repo for Salt v3007 STS" >> "${YUM_REPO_FILE}"
+                        echo "baseurl=https://${_REPO_URL}/saltproject-rpm/" >> "${YUM_REPO_FILE}"
+                        echo "skip_if_unavailable=True" >> "${YUM_REPO_FILE}"
+                        echo "priority=10" >> "${YUM_REPO_FILE}"
+                        echo "enabled=1" >> "${YUM_REPO_FILE}"
+                        echo "enabled_metadata=1" >> "${YUM_REPO_FILE}"
+                        echo "gpgcheck=1" >> "${YUM_REPO_FILE}"
+                        echo "exclude=*3006* *3008* *3009* *3010*" >> "${YUM_REPO_FILE}"
+                        echo "gpgkey=https://${_REPO_URL}/api/security/keypair/SaltProjectKey/public" >> "${YUM_REPO_FILE}"
+                    else
+                        # Salt 3006 repo
+                        echo "[salt-repo-3006-lts]" > "${YUM_REPO_FILE}"
+                        echo "name=Salt Repo for Salt v3006 LTS" >> "${YUM_REPO_FILE}"
+                        echo "baseurl=https://${_REPO_URL}/saltproject-rpm/" >> "${YUM_REPO_FILE}"
+                        echo "skip_if_unavailable=True" >> "${YUM_REPO_FILE}"
+                        echo "priority=10" >> "${YUM_REPO_FILE}"
+                        echo "enabled=1" >> "${YUM_REPO_FILE}"
+                        echo "enabled_metadata=1" >> "${YUM_REPO_FILE}"
+                        echo "gpgcheck=1" >> "${YUM_REPO_FILE}"
+                        echo "exclude=*3007* *3008* *3009* *3010*" >> "${YUM_REPO_FILE}"
+                        echo "gpgkey=https://${_REPO_URL}/api/security/keypair/SaltProjectKey/public" >> "${YUM_REPO_FILE}"
                     fi
                 elif [ "$(echo "$ONEDIR_REV" | grep -E '^([3-9][0-5]{2}[6-9](\.[0-9]*)?)')" != "" ]; then
                     # using minor version
                     ONEDIR_REV_DOT=$(echo "$ONEDIR_REV" | sed 's/-/\./')
                     echo "[salt-repo-${ONEDIR_REV_DOT}-lts]" > "${YUM_REPO_FILE}"
-                    # shellcheck disable=SC2129
                     echo "name=Salt Repo for Salt v${ONEDIR_REV_DOT} LTS" >> "${YUM_REPO_FILE}"
                     echo "baseurl=https://${_REPO_URL}/saltproject-rpm/" >> "${YUM_REPO_FILE}"
                     echo "skip_if_unavailable=True" >> "${YUM_REPO_FILE}"
@@ -5898,8 +5982,15 @@ install_amazon_linux_ami_2023_onedir_deps() {
                 fi
             else
                 # Enable the Salt LATEST repo
-                yum config-manager --set-disable salt-repo-*
-                yum config-manager --set-enabled salt-repo-latest
+                echo "[salt-repo-latest]" > "${YUM_REPO_FILE}"
+                echo "name=Salt Repo for Salt LATEST release" >> "${YUM_REPO_FILE}"
+                echo "baseurl=https://${_REPO_URL}/saltproject-rpm/" >> "${YUM_REPO_FILE}"
+                echo "skip_if_unavailable=True" >> "${YUM_REPO_FILE}"
+                echo "priority=10" >> "${YUM_REPO_FILE}"
+                echo "enabled=1" >> "${YUM_REPO_FILE}"
+                echo "enabled_metadata=1" >> "${YUM_REPO_FILE}"
+                echo "gpgcheck=1" >> "${YUM_REPO_FILE}"
+                echo "gpgkey=https://${_REPO_URL}/api/security/keypair/SaltProjectKey/public" >> "${YUM_REPO_FILE}"
             fi
             yum clean expire-cache || return 1
             yum makecache || return 1

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -4224,8 +4224,8 @@ __install_saltstack_rhel_onedir_repository() {
                 REPO_REV_MAJOR=$(echo "$ONEDIR_REV" | cut -d '.' -f 1)
                 if [ "$REPO_REV_MAJOR" -eq "3007" ]; then
                     # Enable the Salt 3007 STS repo
-                    dnf config-manager --set-disable salt-repo-*
-                    dnf config-manager --set-enabled salt-repo-3007-sts
+                    yum config-manager --set-disable salt-repo-*
+                    yum config-manager --set-enabled salt-repo-3007-sts
                 fi
             elif [ "$(echo "$ONEDIR_REV" | grep -E '^([3-9][0-5]{2}[6-9](\.[0-9]*)?)')" != "" ]; then
                 # using minor version
@@ -4243,11 +4243,11 @@ __install_saltstack_rhel_onedir_repository() {
             fi
         else
             # Enable the Salt LATEST repo
-            dnf config-manager --set-disable salt-repo-*
-            dnf config-manager --set-enabled salt-repo-latest
+            yum config-manager --set-disable salt-repo-*
+            yum config-manager --set-enabled salt-repo-latest
         fi
-        dnf clean expire-cache || return 1
-        dnf makecache || return 1
+        yum clean expire-cache || return 1
+        yum makecache || return 1
     elif [ "$ONEDIR_REV" != "latest" ]; then
         echowarn "salt.repo already exists, ignoring salt version argument."
         echowarn "Use -F (forced overwrite) to install $ONEDIR_REV."
@@ -4559,8 +4559,8 @@ install_centos_onedir() {
     fi
 
     # shellcheck disable=SC2086
-    dnf makecache || return 1
-    dnf list salt-minion || return 1
+    yum makecache || return 1
+    yum list salt-minion || return 1
     __yum_install_noinput ${__PACKAGES} || return 1
 
     return 0
@@ -5661,8 +5661,8 @@ install_amazon_linux_ami_2_deps() {
                     REPO_REV_MAJOR=$(echo "$STABLE_REV" | cut -d '.' -f 1)
                     if [ "$REPO_REV_MAJOR" -eq "3007" ]; then
                         # Enable the Salt 3007 STS repo
-                        dnf config-manager --set-disable salt-repo-*
-                        dnf config-manager --set-enabled salt-repo-3007-sts
+                        yum config-manager --set-disable salt-repo-*
+                        yum config-manager --set-enabled salt-repo-3007-sts
                     fi
                 elif [ "$(echo "$STABLE_REV" | grep -E '^([3-9][0-5]{2}[6-9](\.[0-9]*)?)')" != "" ]; then
                     # using minor version
@@ -5680,11 +5680,11 @@ install_amazon_linux_ami_2_deps() {
                 fi
             else
                 # Enable the Salt LATEST repo
-                dnf config-manager --set-disable salt-repo-*
-                dnf config-manager --set-enabled salt-repo-latest
+                yum config-manager --set-disable salt-repo-*
+                yum config-manager --set-enabled salt-repo-latest
             fi
-            dnf clean expire-cache || return 1
-            dnf makecache || return 1
+            yum clean expire-cache || return 1
+            yum makecache || return 1
         fi
     fi
 
@@ -5726,8 +5726,8 @@ install_amazon_linux_ami_2_onedir_deps() {
                     REPO_REV_MAJOR=$(echo "$ONEDIR_REV" | cut -d '.' -f 1)
                     if [ "$REPO_REV_MAJOR" -eq "3007" ]; then
                         # Enable the Salt 3007 STS repo
-                        dnf config-manager --set-disable salt-repo-*
-                        dnf config-manager --set-enabled salt-repo-3007-sts
+                        yum config-manager --set-disable salt-repo-*
+                        yum config-manager --set-enabled salt-repo-3007-sts
                     fi
                 elif [ "$(echo "$ONEDIR_REV" | grep -E '^([3-9][0-5]{2}[6-9](\.[0-9]*)?)')" != "" ]; then
                     # using minor version
@@ -5745,11 +5745,11 @@ install_amazon_linux_ami_2_onedir_deps() {
                 fi
             else
                 # Enable the Salt LATEST repo
-                dnf config-manager --set-disable salt-repo-*
-                dnf config-manager --set-enabled salt-repo-latest
+                yum config-manager --set-disable salt-repo-*
+                yum config-manager --set-enabled salt-repo-latest
             fi
-            dnf clean expire-cache || return 1
-            dnf makecache || return 1
+            yum clean expire-cache || return 1
+            yum makecache || return 1
         fi
     fi
 
@@ -5879,8 +5879,8 @@ install_amazon_linux_ami_2023_onedir_deps() {
                     REPO_REV_MAJOR=$(echo "$ONEDIR_REV" | cut -d '.' -f 1)
                     if [ "$REPO_REV_MAJOR" -eq "3007" ]; then
                         # Enable the Salt 3007 STS repo
-                        dnf config-manager --set-disable salt-repo-*
-                        dnf config-manager --set-enabled salt-repo-3007-sts
+                        yum config-manager --set-disable salt-repo-*
+                        yum config-manager --set-enabled salt-repo-3007-sts
                     fi
                 elif [ "$(echo "$ONEDIR_REV" | grep -E '^([3-9][0-5]{2}[6-9](\.[0-9]*)?)')" != "" ]; then
                     # using minor version
@@ -5898,11 +5898,11 @@ install_amazon_linux_ami_2023_onedir_deps() {
                 fi
             else
                 # Enable the Salt LATEST repo
-                dnf config-manager --set-disable salt-repo-*
-                dnf config-manager --set-enabled salt-repo-latest
+                yum config-manager --set-disable salt-repo-*
+                yum config-manager --set-enabled salt-repo-latest
             fi
-            dnf clean expire-cache || return 1
-            dnf makecache || return 1
+            yum clean expire-cache || return 1
+            yum makecache || return 1
         fi
     fi
 


### PR DESCRIPTION

### What does this PR do?
Restrict use of dnf to Fedora only, otherwise use yum when dealing with RedHat family, was using ```dnf``` on Amazon Linux 2, where only ```yum``` is supported.

### What issues does this PR fix or reference?
Fixes https://github.com/saltstack/salt-bootstrap/issues/2043

### Previous Behavior
dnf would fail on Amazon Linux 2 platform, since not supported.

### New Behavior
yum is now used on Amazon Linux 2 platform and packages install etc.
