### PR TITLE
Remove support for macos-12, as deprecated by github

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,22 +114,6 @@ jobs:
 
 
 
-  macos-12:
-    name: macOS 12
-    if: github.event_name == 'push' || needs.collect-changed-files.outputs.run-tests == 'true'
-    uses: ./.github/workflows/test-macos.yml
-    needs:
-      - lint
-      - generate-actions-workflow
-    with:
-      distro-slug: macos-12
-      display-name: macOS 12
-      container-slug: macos-12
-      timeout: 20
-      runs-on: macos-12
-      instances: '["stable-3006", "stable-3006-8", "stable-3007", "stable-3007-1", "latest"]'
-
-
   macos-13:
     name: macOS 13
     if: github.event_name == 'push' || needs.collect-changed-files.outputs.run-tests == 'true'
@@ -293,7 +277,6 @@ jobs:
     needs:
       - lint
       - generate-actions-workflow
-      - macos-12
       - macos-13
       - macos-14
       - windows-2022

--- a/.github/workflows/templates/generate.py
+++ b/.github/workflows/templates/generate.py
@@ -27,7 +27,6 @@ WINDOWS = [
 ]
 
 OSX = [
-    "macos-12",
     "macos-13",
     "macos-14",
 ]
@@ -203,7 +202,6 @@ DISTRO_DISPLAY_NAMES = {
     "ubuntu-2004": "Ubuntu 20.04",
     "ubuntu-2204": "Ubuntu 22.04",
     "ubuntu-2404": "Ubuntu 24.04",
-    "macos-12": "macOS 12",
     "macos-13": "macOS 13",
     "macos-14": "macOS 14",
     "windows-2022": "Windows 2022",
@@ -223,7 +221,6 @@ CONTAINER_SLUG_NAMES = {
     "ubuntu-2004": "ubuntu-20.04",
     "ubuntu-2204": "ubuntu-22.04",
     "ubuntu-2404": "ubuntu-24.04",
-    "macos-12": "macos-12",
     "macos-13": "macos-13",
     "macos-14": "macOS 14",
     "windows-2022": "windows-2022",

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -48,12 +48,12 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Python Dependencies with pip breakage
-        if: ${{ ( inputs.distro-slug != 'macos-12' ) && ( inputs.distro-slug != 'macos-13' ) }}
+        if: ${{ inputs.distro-slug != 'macos-13' }}
         run: |
           python3 -m pip install --break-system-packages -r tests/requirements.txt
 
       - name: Install Python Dependencies without pip breakage
-        if: ${{ ( inputs.distro-slug == 'macos-12' ) || ( inputs.distro-slug == 'macos-13' ) }}
+        if: ${{ inputs.distro-slug == 'macos-13' }}
         run: |
           python3 -m pip install -r tests/requirements.txt
 


### PR DESCRIPTION
### What does this PR do?
Remove support for macos-12, as deprecated by github

### What issues does this PR fix or reference?
Fixes https://github.com/saltstack/salt-bootstrap/issues/2075

