### PR TITLE
fixes for Photon4/5

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -6610,7 +6610,7 @@ install_vmware_photon_os_onedir_deps() {
         __install_saltstack_vmware_photon_os_onedir_repository || return 1
     fi
 
-    __PACKAGES="procps-ng sudo shadow"
+    __PACKAGES="procps-ng sudo shadow wget"
 
     # shellcheck disable=SC2086
     __tdnf_install_noinput ${__PACKAGES} || return 1

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -6295,8 +6295,8 @@ __get_packagesite_onedir_latest() {
 }
 
 
-__install_saltstack_photon_onedir_repository() {
-    echodebug "__install_saltstack_photon_onedir_repository() entry"
+__install_saltstack_vmware_photon_os_onedir_repository() {
+    echodebug "__install_saltstack_vmware_photon_os_onedir_repository() entry"
 
     if [ -n "$_PY_EXE" ] && [ "$_PY_MAJOR_VERSION" -ne 3 ]; then
         echoerror "Python version is no longer supported, only Python 3"
@@ -6376,8 +6376,8 @@ __install_saltstack_photon_onedir_repository() {
     return 0
 }
 
-install_photon_deps() {
-    echodebug "install_photon_deps() entry"
+install_vmware_photon_os_deps() {
+    echodebug "install_vmware_photon_os_deps() entry"
 
     if [ -n "$_PY_EXE" ] && [ "$_PY_MAJOR_VERSION" -ne 3 ]; then
         echoerror "Python version is no longer supported, only Python 3"
@@ -6406,8 +6406,8 @@ install_photon_deps() {
     return 0
 }
 
-install_photon_stable_post() {
-    echodebug "install_photon_stable_post() entry"
+install_vmware_photon_os_stable_post() {
+    echodebug "install_vmware_photon_os_stable_post() entry"
 
     for fname in api master minion syndic; do
         # Skip salt-api since the service should be opt-in and not necessarily started on boot
@@ -6424,8 +6424,8 @@ install_photon_stable_post() {
     done
 }
 
-install_photon_git_deps() {
-    echodebug "install_photon_git_deps() entry"
+install_vmware_photon_os_git_deps() {
+    echodebug "install_vmware_photon_os_git_deps() entry"
 
     if [ -n "$_PY_EXE" ] && [ "$_PY_MAJOR_VERSION" -ne 3 ]; then
         echoerror "Python version is no longer supported, only Python 3"
@@ -6463,7 +6463,7 @@ install_photon_git_deps() {
 
     __PACKAGES="python${PY_PKG_VER}-devel python${PY_PKG_VER}-pip python${PY_PKG_VER}-setuptools gcc glibc-devel linux-devel.x86_64 cython${PY_PKG_VER}"
 
-    echodebug "install_photon_git_deps() distro major version, ${DISTRO_MAJOR_VERSION}"
+    echodebug "install_vmware_photon_os_git_deps() distro major version, ${DISTRO_MAJOR_VERSION}"
 
     ## Photon 5 container is missing systemd on default installation
     if [ "${DISTRO_MAJOR_VERSION}" -lt 5  ]; then
@@ -6489,8 +6489,8 @@ install_photon_git_deps() {
     return 0
 }
 
-install_photon_git() {
-    echodebug "install_photon_git() entry"
+install_vmware_photon_os_git() {
+    echodebug "install_vmware_photon_os_git() entry"
 
     if [ "${_PY_EXE}" != "" ]; then
         _PYEXE=${_PY_EXE}
@@ -6500,7 +6500,7 @@ install_photon_git() {
         return 1
     fi
 
-    install_photon_git_deps
+    install_vmware_photon_os_git_deps
 
     if [ -f "${_SALT_GIT_CHECKOUT_DIR}/salt/syspaths.py" ]; then
         ${_PYEXE} setup.py --salt-config-dir="$_SALT_ETC_DIR" --salt-cache-dir="${_SALT_CACHE_DIR}" ${SETUP_PY_INSTALL_ARGS} install --prefix=/usr || return 1
@@ -6510,8 +6510,8 @@ install_photon_git() {
     return 0
 }
 
-install_photon_git_post() {
-    echodebug "install_photon_git_post() entry"
+install_vmware_photon_os_git_post() {
+    echodebug "install_vmware_photon_os_git_post() entry"
 
     for fname in api master minion syndic; do
         # Skip if not meant to be installed
@@ -6543,9 +6543,9 @@ install_photon_git_post() {
     done
 }
 
-install_photon_restart_daemons() {
+install_vmware_photon_os_restart_daemons() {
     [ "$_START_DAEMONS" -eq $BS_FALSE ] && return
-    echodebug "install_photon_restart_daemons() entry"
+    echodebug "install_vmware_photon_os_restart_daemons() entry"
 
 
     for fname in api master minion syndic; do
@@ -6567,8 +6567,8 @@ install_photon_restart_daemons() {
     done
 }
 
-install_photon_check_services() {
-    echodebug "install_photon_check_services() entry"
+install_vmware_photon_os_check_services() {
+    echodebug "install_vmware_photon_os_check_services() entry"
 
     for fname in api master minion syndic; do
         # Skip salt-api since the service should be opt-in and not necessarily started on boot
@@ -6585,8 +6585,8 @@ install_photon_check_services() {
     return 0
 }
 
-install_photon_onedir_deps() {
-    echodebug "install_photon_onedir_deps() entry"
+install_vmware_photon_os_onedir_deps() {
+    echodebug "install_vmware_photon_os_onedir_deps() entry"
 
 
     if [ "$_UPGRADE_SYS" -eq $BS_TRUE ]; then
@@ -6600,14 +6600,14 @@ install_photon_onedir_deps() {
     fi
 
     if [ "$_DISABLE_REPOS" -eq "$BS_FALSE" ]; then
-        __install_saltstack_photon_onedir_repository || return 1
+        __install_saltstack_vmware_photon_os_onedir_repository || return 1
     fi
 
     # If -R was passed, we need to configure custom repo url with rsync-ed packages
     # Which was handled in __install_saltstack_rhel_repository buu that hanlded old-stable which is for
     # releases which are End-Of-Life. This call has its own check in case -r was passed without -R.
     if [ "$_CUSTOM_REPO_URL" != "null" ]; then
-        __install_saltstack_photon_onedir_repository || return 1
+        __install_saltstack_vmware_photon_os_onedir_repository || return 1
     fi
 
     __PACKAGES="procps-ng sudo shadow"
@@ -6626,9 +6626,9 @@ install_photon_onedir_deps() {
 }
 
 
-install_photon_onedir() {
+install_vmware_photon_os_onedir() {
 
-    echodebug "install_photon_onedir() entry"
+    echodebug "install_vmware_photon_os_onedir() entry"
 
     STABLE_REV=$ONEDIR_REV
     _GENERIC_PKG_VERSION=""
@@ -6672,9 +6672,9 @@ install_photon_onedir() {
     return 0
 }
 
-install_photon_onedir_post() {
+install_vmware_photon_os_onedir_post() {
     STABLE_REV=$ONEDIR_REV
-    install_photon_stable_post || return 1
+    install_vmware_photon_os_stable_post || return 1
 
     return 0
 }


### PR DESCRIPTION
### What does this PR do?
Fixed installation on Photon 4 and Photon 5.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt-bootstrap/issues/2078
https://github.com/saltstack/salt-bootstrap/issues/2079

1) Photon identifies itself as "vmware_photon_os". But the installer was assuming that it was just "photon". Fixed by renaming.
2) Photon (at least in minimal-install) does not yet have `wget`. But the installer tries to use it. Fixed by adding dependency on `wget`.

Note that I'm not actually a user of Photon. I have VirtualBox VMs for all operating systems that are supported by SaltStack, so that I can test my project [SaltGUI](https://github.com/erwindon/SaltGUI).