### PR TITLE
Get versions correctly

### DIFF
--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -59,7 +59,8 @@ jobs:
         run: |
           # We need to get the version here and make it an environment variable
           # It is used to install via bootstrap and in the test
-          # The version is in the instance name
+          # The version is in the instance name:
+          # ["stable-3006", "stable-3006-8", "stable-3007", "stable-3007-1", "latest"]
           $instance = "${{ matrix.instance }}"
           $version = $instance -split "-",2
           if ( $version.Count -gt 1 ) {

--- a/bootstrap-salt.ps1
+++ b/bootstrap-salt.ps1
@@ -207,25 +207,36 @@ function Get-AvailableVersions {
         Write-Verbose "- $_"
     }
 
-    # Get the latest version, should be the last in the list
-    Write-Verbose "Getting latest available version"
-    $latest = $available_versions | Select-Object -Last 1
-    Write-Verbose "Latest available version: $latest"
-
     # Create a versions table
     # This will have the latest version available, the latest version available
     # for each major version, and every version available. This makes the
     # version lookup logic easier. The contents of the versions table can be
     # found by running -Verbose
     Write-Verbose "Populating the versions table"
-    $versions_table = [ordered]@{"latest"=$latest}
+    $versions_table = [ordered]@{}
     $available_versions | ForEach-Object {
-        $versions_table[$(Get-MajorVersion $_)] = $_
+        $major_version = $(Get-MajorVersion $_)
+        if ( $versions_table.Keys -contains $major_version ) {
+            if ( [System.Version]$_ -gt [System.Version]$versions_table[$major_version] ) {
+                $versions_table[$major_version] = $_
+            }
+        } else {
+            $versions_table[$major_version] = $_
+        }
+
+        if ( $versions_table -contains "latest" ) {
+            if ( [System.Version]$_ -gt [System.Version]$versions_table["latest"] ) {
+                $versions_table["latest"] = $_
+            }
+        } else {
+            $versions_table["latest"] = $_
+        }
+
         $versions_table[$_.ToLower()] = $_.ToLower()
     }
 
     Write-Verbose "Versions Table:"
-    $versions_table | Sort-Object Name | Out-String | ForEach-Object {
+    $versions_table.GetEnumerator() | Sort-Object Name | Out-String | ForEach-Object {
         Write-Verbose "$_"
     }
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,9 @@
 import json
 import os
+import requests
+from packaging.version import Version
 
 import pytest
-import requests
 
 API_URL = (
     "https://packages.broadcom.com/artifactory/api/storage/saltproject-generic/windows"
@@ -27,9 +28,18 @@ def target_salt_version():
             version = folder["uri"].strip("/")
             versions[version] = version
             # We're trying to get the latest major version and latest overall
-            maj_version = version.split(".")[0]
-            versions[maj_version] = version
-            versions["latest"] = version
+            maj_ver, _ = version.split(".")
+            if maj_ver in versions:
+                if Version(version) > Version(versions[maj_ver]):
+                    versions[maj_ver] = version
+            else:
+                versions[maj_ver] = version
+
+            if "latest" in versions:
+                if Version(version) > Version(versions["latest"]):
+                    versions["latest"] = version
+            else:
+                versions["latest"] = version
 
     if target_salt.startswith("v"):
         target_salt = target_salt[1:]

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,2 +1,3 @@
 pytest
 requests
+packaging


### PR DESCRIPTION
### What does this PR do?
Get versions correctly from packages.broadcom.com.

### Previous Behavior
There was a problem when populating the major version entry in the dictionary. It would populate based on sorting which isn't always right as far as what is the latest version. It would always end at 3006.9 for example, even after 3006.15 was released.

### New Behavior
Now it does some version comparison to actually update "latest" and "major_version" entries so they actually are the latest versions available.
