### PR TITLE
Remove hardware clock sync

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1952,11 +1952,6 @@ __wait_for_apt(){
     # Timeout set at 15 minutes
     WAIT_TIMEOUT=900
 
-    ## see if sync'ing the clocks helps
-    if [ -f /usr/sbin/hwclock ]; then
-        /usr/sbin/hwclock -s
-    fi
-
     # Run our passed in apt command
     "${@}" 2>"$APT_ERR"
     APT_RETURN=$?


### PR DESCRIPTION
### What does this PR do?
Fixes the bootstrap script to not do a hardware clock sync. This is probably some cruft left over from testing. It's not safe to assume the hardware clock is the source of truth.

### What issues does this PR fix or reference?
#2084