### PR TITLE
Fixes #2094 by changing reference to script var BS_TMP_DIR  to _TMP_DIR  in help message text.

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -369,7 +369,7 @@ __usage() {
         also be specified. Salt installation will be ommitted, but some of the
         dependencies could be installed to write configuration with -j or -J.
     -d  Disables checking if Salt services are enabled to start on system boot.
-        You can also do this by touching ${BS_TMP_DIR}/disable_salt_checks on the target
+        You can also do this by touching ${_TMP_DIR}/disable_salt_checks on the target
         host. Default: \${BS_FALSE}
     -D  Show debug output
     -f  Force shallow cloning for git installations.


### PR DESCRIPTION
### What does this PR do?
Fixes bash error when invoking script with -h param when not defining BS_TMP_DIR

### What issues does this PR fix or reference?
#2094 

### Previous Behavior
Script would fail to print help text, and display error about unbound variable or unset variable

### New Behavior

Script correctly displays help text
