### PR TITLE
fix: reinstate the old method of setting `pip` global options

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,7 +207,7 @@ jobs:
       display-name: Debian 11
       container-slug: debian-11
       timeout: 20
-      instances: '["stable-3006", "onedir-3006", "stable-3006-8", "stable-3007", "onedir-3007", "stable-3007-1", "latest", "default"]'
+      instances: '["stable-3006", "onedir-3006", "stable-3006-8", "stable-3007", "onedir-3007", "stable-3007-1", "git-master", "latest", "default"]'
 
 
   debian-12:

--- a/.github/workflows/templates/generate.py
+++ b/.github/workflows/templates/generate.py
@@ -125,7 +125,6 @@ BLACKLIST_GIT_3007 = [
 BLACKLIST_GIT_MASTER = [
     "amazonlinux-2",
     "amazonlinux-2023",
-    "debian-11",
     "debian-13",
     "fedora-40",
     "photon-4",

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 minimum_pre_commit_version: 1.15.2
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-merge-conflict  # Check for files that contain merge conflict strings.
       - id: trailing-whitespace   # Trims trailing whitespace.
@@ -12,12 +12,12 @@ repos:
       - id: end-of-file-fixer     # Makes sure files end in a newline and only a newline.
 
   - repo: https://github.com/executablebooks/mdformat
-    rev: 0.7.17
+    rev: 1.0.0
     hooks:
       - id: mdformat
 
   - repo: https://github.com/s0undt3ch/python-tools-scripts
-    rev: "0.18.6"
+    rev: "0.20.5"
     hooks:
       - id: tools
         alias: actionlint
@@ -38,7 +38,7 @@ repos:
           - requirements/release.in
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.15.0
+    rev: v3.21.2
     hooks:
       - id: pyupgrade
         name: Rewrite Code to be Py3.6+
@@ -47,13 +47,13 @@ repos:
         ## DGM args: [--py39-plus]
 
   - repo: https://github.com/asottile/reorder_python_imports
-    rev: v3.12.0
+    rev: v3.16.0
     hooks:
       - id: reorder-python-imports
         args: [--py310-plus]
 
   - repo: https://github.com/psf/black
-    rev: 24.10.0
+    rev: 25.12.0
     hooks:
       - id: black
         args: []

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2821,12 +2821,25 @@ __install_salt_from_repo() {
 
     echodebug "Running '${_pip_cmd} install ${_USE_BREAK_SYSTEM_PACKAGES} --no-deps --force-reinstall ${_PIP_INSTALL_ARGS} ${_TMP_DIR}/git/deps/salt*.whl'"
 
-    echodebug "Running ${_pip_cmd} install ${_USE_BREAK_SYSTEM_PACKAGES} --no-deps --force-reinstall ${_PIP_INSTALL_ARGS} --config-settings=--global-option=--salt-config-dir=$_SALT_ETC_DIR --salt-cache-dir=${_SALT_CACHE_DIR} ${SETUP_PY_INSTALL_ARGS} ${_TMP_DIR}/git/deps/salt*.whl"
+    _PIP_VERSION_STRING=$(${_pip_cmd} --version)
+    echodebug "Installed pip version: $_PIP_VERSION_STRING"
+    _PIP_MAJOR_VERSION=$(echo "$_PIP_VERSION_STRING" | sed -E 's/^pip ([0-9]+)\..*/\1/')
 
-    ${_pip_cmd} install ${_USE_BREAK_SYSTEM_PACKAGES} --no-deps --force-reinstall \
-        ${_PIP_INSTALL_ARGS} \
-        --config-settings="--global-option=--salt-config-dir=$_SALT_ETC_DIR --salt-cache-dir=${_SALT_CACHE_DIR} ${SETUP_PY_INSTALL_ARGS}" \
-        ${_TMP_DIR}/git/deps/salt*.whl || return 1
+    # The following branching can be removed once we no longer support distros that still ship with
+    # versions of `pip` earlier than v22.1 such as Debian 11
+    if [ "$_PIP_MAJOR_VERSION" -lt 23 ]; then
+        echodebug "Running ${_pip_cmd} install ${_USE_BREAK_SYSTEM_PACKAGES} --no-deps --force-reinstall ${_PIP_INSTALL_ARGS} --global-option=--salt-config-dir=$_SALT_ETC_DIR --salt-cache-dir=${_SALT_CACHE_DIR} ${SETUP_PY_INSTALL_ARGS} ${_TMP_DIR}/git/deps/salt*.whl"
+        ${_pip_cmd} install ${_USE_BREAK_SYSTEM_PACKAGES} --no-deps --force-reinstall \
+            ${_PIP_INSTALL_ARGS} \
+            --global-option="--salt-config-dir=$_SALT_ETC_DIR --salt-cache-dir=${_SALT_CACHE_DIR} ${SETUP_PY_INSTALL_ARGS}" \
+            ${_TMP_DIR}/git/deps/salt*.whl || return 1
+    else
+        echodebug "Running ${_pip_cmd} install ${_USE_BREAK_SYSTEM_PACKAGES} --no-deps --force-reinstall ${_PIP_INSTALL_ARGS} --config-settings=--global-option=--salt-config-dir=$_SALT_ETC_DIR --salt-cache-dir=${_SALT_CACHE_DIR} ${SETUP_PY_INSTALL_ARGS} ${_TMP_DIR}/git/deps/salt*.whl"
+        ${_pip_cmd} install ${_USE_BREAK_SYSTEM_PACKAGES} --no-deps --force-reinstall \
+            ${_PIP_INSTALL_ARGS} \
+            --config-settings="--global-option=--salt-config-dir=$_SALT_ETC_DIR --salt-cache-dir=${_SALT_CACHE_DIR} ${SETUP_PY_INSTALL_ARGS}" \
+            ${_TMP_DIR}/git/deps/salt*.whl || return 1
+    fi
 
     echoinfo "Checking if Salt can be imported using ${_py_exe}"
     CHECK_SALT_SCRIPT=$(cat << EOM

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2819,8 +2819,6 @@ __install_salt_from_repo() {
         ${_pip_cmd} install --force-reinstall --break-system-packages "${_arch_dep}"
     fi
 
-    echodebug "Running '${_pip_cmd} install ${_USE_BREAK_SYSTEM_PACKAGES} --no-deps --force-reinstall ${_PIP_INSTALL_ARGS} ${_TMP_DIR}/git/deps/salt*.whl'"
-
     _PIP_VERSION_STRING=$(${_pip_cmd} --version)
     echodebug "Installed pip version: $_PIP_VERSION_STRING"
     _PIP_MAJOR_VERSION=$(echo "$_PIP_VERSION_STRING" | sed -E 's/^pip ([0-9]+)\..*/\1/')


### PR DESCRIPTION
#2088 introduced a change that breaks Git `master` installs on old distros that
coms with `pip` versions older than v22.1.
These include Debian 11.

This affects the building of test containers used by the Saltstack Formulas Working Group.