### PR TITLE
Fix SALT_REPO_URL and mktemp command in salt-quick-start.sh

### DIFF
--- a/salt-quick-start.sh
+++ b/salt-quick-start.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 __ScriptName="salt-quick-start.sh"
-SALT_REPO_URL="https://packages.broadcom.com/artifactory/salt-project-generic/onedir"
+SALT_REPO_URL="https://packages.broadcom.com/artifactory/saltproject-generic/onedir"
 _COLORS=${QS_COLORS:-$(tput colors 2>/dev/null || echo 0)}
 
 _LOCAL=0
@@ -94,7 +94,7 @@ __parse_repo_json_jq() {
     # $2 is ARCH
 
     # get dir listing from url, sort and pick highest
-    onedir_versions_tmpf=$(mktemp)
+    onedir_versions_tmpf=$(mktemp -d)
     curr_pwd=$(pwd)
     cd  ${onedir_versions_tmpf} || return 1
     wget -r -np -nH --exclude-directories=onedir,relenv,windows -x -l 1 "$SALT_REPO_URL/"


### PR DESCRIPTION
### What does this PR do?

This PR changes two things in the `salt-quick-start.sh` file:
  - `SALT_REPO_URL` had one dash too many
  - `cd  ${onedir_versions_tmpf}` was throwing an error, because `${onedir_versions_tmpf}` was a regular file instead of a directory

### What issues does this PR fix or reference?

I did not create issues, because the PR is so minimal. Please let me know if you would prefer that I open them.

