### PR TITLE
fix(bootstrap): install git deps from linux.lock or linux.txt

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2785,8 +2785,18 @@ __install_salt_from_repo() {
 
     rm -f ${_TMP_DIR}/git/deps/*
 
-    echodebug "Installing Salt requirements from PyPi, ${_pip_cmd} install ${_USE_BREAK_SYSTEM_PACKAGES} --ignore-installed ${_PIP_INSTALL_ARGS} -r requirements/static/ci/py${_py_version}/linux.txt"
-    ${_pip_cmd} install ${_USE_BREAK_SYSTEM_PACKAGES} --ignore-installed ${_PIP_INSTALL_ARGS} -r "requirements/static/ci/py${_py_version}/linux.txt"
+    _salt_static_ci_linux_req=""
+    if [ -f "requirements/static/ci/py${_py_version}/linux.lock" ]; then
+        _salt_static_ci_linux_req="requirements/static/ci/py${_py_version}/linux.lock"
+    elif [ -f "requirements/static/ci/py${_py_version}/linux.txt" ]; then
+        _salt_static_ci_linux_req="requirements/static/ci/py${_py_version}/linux.txt"
+    else
+        echoerror "Salt static CI requirements not found: expected requirements/static/ci/py${_py_version}/linux.lock or requirements/static/ci/py${_py_version}/linux.txt"
+        return 1
+    fi
+
+    echodebug "Installing Salt requirements from PyPi, ${_pip_cmd} install ${_USE_BREAK_SYSTEM_PACKAGES} --ignore-installed ${_PIP_INSTALL_ARGS} -r ${_salt_static_ci_linux_req}"
+    ${_pip_cmd} install ${_USE_BREAK_SYSTEM_PACKAGES} --ignore-installed ${_PIP_INSTALL_ARGS} -r "${_salt_static_ci_linux_req}"
     # shellcheck disable=SC2181
     if [ $? -ne 0 ]; then
         echo "Failed to install salt requirements for the version of Python ${_py_version}"


### PR DESCRIPTION
### What does this PR do?
Salt 3008+ replaced the static CI linux.txt artifact with linux.lock. Pick whichever file exists in the checkout so one bootstrap script works across Salt versions.