### PR TITLE
Fix checking out a branch on in existing repo

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2158,12 +2158,13 @@ __git_clone_and_checkout() {
         fi
 
         # Check if GIT_REV_ADJ is a remote branch or just a commit hash
+        __GIT_CHECKOUT_REV="$GIT_REV_ADJ"
         if git branch -r | grep -q -F -w "origin/$GIT_REV_ADJ"; then
-            GIT_REV_ADJ="origin/$GIT_REV_ADJ"
+            __GIT_CHECKOUT_REV="origin/$GIT_REV_ADJ"
         fi
 
-        echodebug "Hard reseting the cloned repository to ${GIT_REV_ADJ}"
-        git reset --hard "$GIT_REV_ADJ" || return 1
+        echodebug "Hard reseting the cloned repository to ${__GIT_CHECKOUT_REV}"
+        git reset --hard "$__GIT_CHECKOUT_REV" || return 1
     else
         if [ "$_FORCE_SHALLOW_CLONE" -eq "${BS_TRUE}" ]; then
             echoinfo "Forced shallow cloning of git repository."

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2157,18 +2157,13 @@ __git_clone_and_checkout() {
             git fetch --tags upstream
         fi
 
+        # Check if GIT_REV_ADJ is a remote branch or just a commit hash
+        if git branch -r | grep -q -F -w "origin/$GIT_REV_ADJ"; then
+            GIT_REV_ADJ="origin/$GIT_REV_ADJ"
+        fi
+
         echodebug "Hard reseting the cloned repository to ${GIT_REV_ADJ}"
         git reset --hard "$GIT_REV_ADJ" || return 1
-
-        # Just calling `git reset --hard $GIT_REV_ADJ` on a branch name that has
-        # already been checked out will not update that branch to the upstream
-        # HEAD; instead it will simply reset to itself.  Check the ref to see
-        # if it is a branch name, check out the branch, and pull in the
-        # changes.
-        if git branch -a | grep -q "${GIT_REV_ADJ}"; then
-            echodebug "Rebasing the cloned repository branch"
-            git pull --rebase || return 1
-        fi
     else
         if [ "$_FORCE_SHALLOW_CLONE" -eq "${BS_TRUE}" ]; then
             echoinfo "Forced shallow cloning of git repository."


### PR DESCRIPTION
### What does this PR do?

In the case where a git repo already exists:
* if a branch is intended to be checked out, reset to `origin/<branch>`
    * this mirrors the behavior of the repo not existing [on these lines, a little further down](https://github.com/saltstack/salt-bootstrap/blob/develop/bootstrap-salt.sh#L2214-L2217)
    * it avoids problems stemming from a local branch by that name already existing, which may not even be related, or could have diverged from `origin`
* remove the unnecessary code that rebases from `origin`, since we just directly check it out (which happens after a `fetch` updates it a few lines up)

### What issues does this PR fix or reference?

When a user first runs `bootstrap-salt.sh` with a branch specified (without a checked out repo) works fine, but sets up `HEAD` in a detached state to `origin/<branch>`. Subsequent runs of the bootstrap script fail when it tries to `git reset --hard <branch>` , with err:

> fatal: ambiguous argument '<branch>': unknown revision or path not in the working tree.

### Previous Behavior

Remove this section if not relevant

### New Behavior

Remove this section if not relevant
