### PR TITLE
Use pip from specified python cmd

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2740,8 +2740,9 @@ __install_salt_from_repo() {
 
     _py_version=$(${_py_exe} -c "import sys; print('{0}.{1}'.format(*sys.version_info))")
     _pip_cmd="${_py_exe} -m pip"
-    _pip_version="$(${_pip_cmd} --version)"
-    if [ -z "${_pip_version}" ]; then
+    if ${_pip_cmd} --version > /dev/null 2>&1; then
+        _pip_version="$(${_pip_cmd} --version 2>/dev/null)"
+    else
         echodebug "Pip is not installed for Python '${_py_exe}' (version ${_py_version})"
         _pip_cmd="pip${_py_version}"
         if ! __check_command_exists "${_pip_cmd}"; then
@@ -2749,6 +2750,7 @@ __install_salt_from_repo() {
             echoerror "Unable to find a pip binary"
             return 1
         fi
+        _pip_version="$(${_pip_cmd} --version 2>/dev/null)"
     fi
 
     __check_pip_allowed

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -2739,23 +2739,21 @@ __install_salt_from_repo() {
     echodebug "__install_salt_from_repo py_exe=$_py_exe"
 
     _py_version=$(${_py_exe} -c "import sys; print('{0}.{1}'.format(*sys.version_info))")
-    _pip_cmd="pip${_py_version}"
-    if ! __check_command_exists "${_pip_cmd}"; then
-        echodebug "The pip binary '${_pip_cmd}' was not found in PATH"
-        _pip_cmd="pip$(echo "${_py_version}" | cut -c -1)"
+    _pip_cmd="${_py_exe} -m pip"
+    _pip_version="$(${_pip_cmd} --version)"
+    if [ -z "${_pip_version}" ]; then
+        echodebug "Pip is not installed for Python '${_py_exe}' (version ${_py_version})"
+        _pip_cmd="pip${_py_version}"
         if ! __check_command_exists "${_pip_cmd}"; then
             echodebug "The pip binary '${_pip_cmd}' was not found in PATH"
-            _pip_cmd="pip"
-            if ! __check_command_exists "${_pip_cmd}"; then
-                echoerror "Unable to find a pip binary"
-                return 1
-            fi
+            echoerror "Unable to find a pip binary"
+            return 1
         fi
     fi
 
     __check_pip_allowed
 
-    echodebug "Installed pip version: $(${_pip_cmd} --version)"
+    echodebug "Installed pip version: $_pip_version"
 
     _setuptools_dep="setuptools>=${_MINIMUM_SETUPTOOLS_VERSION},<${_MAXIMUM_SETUPTOOLS_VERSION}"
     if [ "$_PY_MAJOR_VERSION" -ne 3 ]; then


### PR DESCRIPTION
### What does this PR do?

Tries to use a `pip` that's matched to the specified `python` cmd, either:
1. `<python_cmd> -m pip` (eg `python3.14 -m pip`)
    * mirrors the behavior [elsewhere in the script](https://github.com/saltstack/salt-bootstrap/blob/develop/bootstrap-salt.sh#L2647)
2. `pip<py_version>` (eg `pip3.14`)
    * tries to retain some of the old "try to find a pip" behavior, but restricted to a version match 

### What issues does this PR fix or reference?

When a version of python is specified (eg with `-x python3.14` arg to the bootstrap script), but a corresponding `pip` command isn't available, the old behavior was to try using a pip of the major version (eg `pip3`), but this is problematic if that version of pip does exist, but doesn't match the python version used to build packages. That results in:
* packages being successfully built
* successfully installed, but into a different python version
* therefore salt doesn't run with the given python cmd