### PR TITLE
Add openssl pkg to alpine to provide libcrypto

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -5487,7 +5487,7 @@ install_alpine_linux_git_deps() {
     # shellcheck disable=SC2119
     __git_clone_and_checkout || return 1
 
-    apk -U add python3 python3-dev py3-pip py3-setuptools g++ linux-headers zeromq-dev openrc || return 1
+    apk -U add python3 python3-dev py3-pip py3-setuptools g++ linux-headers zeromq-dev openrc openssl-dev || return 1
     _PY_EXE=python3
     return 0
 }


### PR DESCRIPTION
### What does this PR do?

Adds the `openssl-dev` package to alpine installs, which salt needs to run.

### What issues does this PR fix or reference?

After an install on alpine linux, salt throws errors due to missing crypto libs:

<details>

<summary>error output</summary>

```
Traceback (most recent call last):
  File "/usr/local/bin/salt-master", line 6, in <module>
    sys.exit(salt_master())
             ~~~~~~~~~~~^^
  File "/usr/local/lib/python3.13/site-packages/salt/scripts.py", line 124, in salt_master
    import salt.cli.daemons
  File "/usr/local/lib/python3.13/site-packages/salt/cli/daemons.py", line 46, in <module>
    import salt.utils.parsers
  File "/usr/local/lib/python3.13/site-packages/salt/utils/parsers.py", line 26, in <module>
    import salt.config as config
  File "/usr/local/lib/python3.13/site-packages/salt/config/__init__.py", line 16, in <module>
    import salt.crypt
  File "/usr/local/lib/python3.13/site-packages/salt/crypt.py", line 39, in <module>
    import salt.utils.rsax931
  File "/usr/local/lib/python3.13/site-packages/salt/utils/rsax931.py", line 172, in <module>
    libcrypto = _init_libcrypto()
  File "/usr/local/lib/python3.13/site-packages/salt/utils/rsax931.py", line 125, in _init_libcrypto
    libcrypto = _load_libcrypto()
  File "/usr/local/lib/python3.13/site-packages/salt/utils/rsax931.py", line 118, in _load_libcrypto
    return cdll.LoadLibrary(_find_libcrypto())
                            ~~~~~~~~~~~~~~~^^
  File "/usr/local/lib/python3.13/site-packages/salt/utils/rsax931.py", line 110, in _find_libcrypto
    raise OSError("Cannot locate OpenSSL libcrypto")
OSError: Cannot locate OpenSSL libcrypto
[ERROR   ] An un-handled exception was caught by Salt's global exception handler:
OSError: Cannot locate OpenSSL libcrypto
Traceback (most recent call last):
  File "/usr/local/bin/salt-master", line 6, in <module>
    sys.exit(salt_master())
             ~~~~~~~~~~~^^
  File "/usr/local/lib/python3.13/site-packages/salt/scripts.py", line 124, in salt_master
    import salt.cli.daemons
  File "/usr/local/lib/python3.13/site-packages/salt/cli/daemons.py", line 46, in <module>
    import salt.utils.parsers
  File "/usr/local/lib/python3.13/site-packages/salt/utils/parsers.py", line 26, in <module>
    import salt.config as config
  File "/usr/local/lib/python3.13/site-packages/salt/config/__init__.py", line 16, in <module>
    import salt.crypt
  File "/usr/local/lib/python3.13/site-packages/salt/crypt.py", line 39, in <module>
    import salt.utils.rsax931
  File "/usr/local/lib/python3.13/site-packages/salt/utils/rsax931.py", line 172, in <module>
    libcrypto = _init_libcrypto()
  File "/usr/local/lib/python3.13/site-packages/salt/utils/rsax931.py", line 125, in _init_libcrypto
    libcrypto = _load_libcrypto()
  File "/usr/local/lib/python3.13/site-packages/salt/utils/rsax931.py", line 118, in _load_libcrypto
    return cdll.LoadLibrary(_find_libcrypto())
                            ~~~~~~~~~~~~~~~^^
  File "/usr/local/lib/python3.13/site-packages/salt/utils/rsax931.py", line 110, in _find_libcrypto
    raise OSError("Cannot locate OpenSSL libcrypto")
OSError: Cannot locate OpenSSL libcrypto
```

</details>