### PR TITLE
Write alpine service scripts directly

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -5535,15 +5535,22 @@ install_alpine_linux_post() {
         [ $fname = "syndic" ] && [ "$_INSTALL_SYNDIC" -eq $BS_FALSE ] && continue
 
         if [ -f /sbin/rc-update ]; then
-            script_url="${_SALTSTACK_REPO_URL%.git}/raw/master/pkg/alpine/salt-$fname"
-            [ -f "/etc/init.d/salt-$fname" ] || __fetch_url "/etc/init.d/salt-$fname" "$script_url"
+            local script_path="/etc/init.d/salt-$fname"
+            if ! [ -f "$script_path" ]; then
+                cat <<_eof > "$script_path"
+#!/sbin/openrc-run
+command="/usr/bin/salt-${fname}"
+command_args="--daemon"
+pidfile="/var/run/salt-${fname}.pid"
+name="Salt ${fname} daemon"
 
-            # shellcheck disable=SC2181
-            if [ $? -eq 0 ]; then
-                chmod +x "/etc/init.d/salt-$fname"
-            else
-                echoerror "Failed to get OpenRC init script for $OS_NAME from $script_url."
-                return 1
+depend() {
+        need localmount
+        use net
+        after bootmisc
+}
+_eof
+                chmod +x "$script_path"
             fi
 
             # Skip salt-api since the service should be opt-in and not necessarily started on boot

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -5535,7 +5535,7 @@ install_alpine_linux_post() {
         [ $fname = "syndic" ] && [ "$_INSTALL_SYNDIC" -eq $BS_FALSE ] && continue
 
         if [ -f /sbin/rc-update ]; then
-            local script_path="/etc/init.d/salt-$fname"
+            script_path="/etc/init.d/salt-$fname"
             if ! [ -f "$script_path" ]; then
                 cat <<_eof > "$script_path"
 #!/sbin/openrc-run


### PR DESCRIPTION
### What does this PR do?

Writes alpine service files for salt daemons directly, rather than trying to download them from the salt repo (which deprecated them a while ago). This mirrors [how it's done for gentoo](https://github.com/saltstack/salt-bootstrap/blob/develop/bootstrap-salt.sh#L7682-L7698).

### What issues does this PR fix or reference?

Alpine install is broken. In the `install_alpine_linux_post()` phase, it [tries to install](https://github.com/saltstack/salt-bootstrap/blob/develop/bootstrap-salt.sh#L5495) OpenRC scripts from `<salt-repo>/pkg/alpine/...`, but they're not there anymore. They were moved to [`old/`](https://github.com/saltstack/salt/tree/master/pkg/old) when they got deprecated [3.5 years ago](https://github.com/saltstack/salt/commit/701633d181).