### PR TITLE
fix(bootstrap): support Salt 3008+ major versions and fix repo/key issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
       container-slug: macos-14
       timeout: 20
       runs-on: macos-14
-      instances: '["stable-3006", "stable-3006-8", "stable-3007", "stable-3007-1", "latest"]'
+      instances: '["stable-3006", "stable-3006-8", "stable-3007", "stable-3007-1", "stable-3008", "latest"]'
 
 
   macos-15-intel:
@@ -143,7 +143,7 @@ jobs:
       container-slug: macos-15-intel
       timeout: 20
       runs-on: macos-15-intel
-      instances: '["stable-3006", "stable-3006-8", "stable-3007", "stable-3007-1", "latest"]'
+      instances: '["stable-3006", "stable-3006-8", "stable-3007", "stable-3007-1", "stable-3008", "latest"]'
 
 
 
@@ -160,7 +160,7 @@ jobs:
       container-slug: windows-2022
       timeout: 20
       runs-on: windows-2022
-      instances: '["stable-3006", "stable-3006-8", "stable-3007", "stable-3007-1", "latest"]'
+      instances: '["stable-3006", "stable-3006-8", "stable-3007", "stable-3007-1", "stable-3008", "latest"]'
 
 
   windows-2025:
@@ -176,7 +176,7 @@ jobs:
       container-slug: windows-2025
       timeout: 20
       runs-on: windows-2025
-      instances: '["stable-3006", "stable-3006-8", "stable-3007", "stable-3007-1", "latest"]'
+      instances: '["stable-3006", "stable-3006-8", "stable-3007", "stable-3007-1", "stable-3008", "latest"]'
 
 
 
@@ -192,7 +192,7 @@ jobs:
       display-name: Amazon 2023
       container-slug: amazonlinux-2023
       timeout: 20
-      instances: '["stable-3006", "onedir-3006", "stable-3006-8", "stable-3007", "onedir-3007", "stable-3007-1", "latest", "default"]'
+      instances: '["stable-3006", "onedir-3006", "stable-3006-8", "stable-3007", "onedir-3007", "stable-3007-1", "stable-3008", "git-3008", "onedir-3008", "latest", "default"]'
 
 
   debian-11:
@@ -207,7 +207,7 @@ jobs:
       display-name: Debian 11
       container-slug: debian-11
       timeout: 20
-      instances: '["stable-3006", "onedir-3006", "stable-3006-8", "stable-3007", "onedir-3007", "stable-3007-1", "git-master", "latest", "default"]'
+      instances: '["stable-3006", "onedir-3006", "stable-3006-8", "stable-3007", "onedir-3007", "stable-3007-1", "stable-3008", "git-3008", "onedir-3008", "git-master", "latest", "default"]'
 
 
   debian-12:
@@ -222,7 +222,7 @@ jobs:
       display-name: Debian 12
       container-slug: debian-12
       timeout: 20
-      instances: '["stable-3007", "git-3007", "onedir-3007", "stable-3007-1", "git-master", "latest", "default"]'
+      instances: '["stable-3007", "git-3007", "onedir-3007", "stable-3007-1", "stable-3008", "git-3008", "onedir-3008", "git-master", "latest", "default"]'
 
 
   photon-5:
@@ -237,7 +237,7 @@ jobs:
       display-name: Photon OS 5
       container-slug: photon-5
       timeout: 20
-      instances: '["stable-3006", "onedir-3006", "stable-3006-8", "stable-3007", "onedir-3007", "stable-3007-1", "latest", "default"]'
+      instances: '["stable-3006", "onedir-3006", "stable-3006-8", "stable-3007", "onedir-3007", "stable-3007-1", "stable-3008", "git-3008", "onedir-3008", "latest", "default"]'
 
 
   rockylinux-8:
@@ -252,7 +252,7 @@ jobs:
       display-name: Rocky Linux 8
       container-slug: rockylinux-8
       timeout: 20
-      instances: '["stable-3006", "onedir-3006", "stable-3006-8", "stable-3007", "onedir-3007", "stable-3007-1", "latest", "default"]'
+      instances: '["stable-3006", "onedir-3006", "stable-3006-8", "stable-3007", "onedir-3007", "stable-3007-1", "stable-3008", "onedir-3008", "latest", "default"]'
 
 
   rockylinux-9:
@@ -267,7 +267,7 @@ jobs:
       display-name: Rocky Linux 9
       container-slug: rockylinux-9
       timeout: 20
-      instances: '["stable-3006", "onedir-3006", "stable-3006-8", "stable-3007", "onedir-3007", "stable-3007-1", "latest", "default"]'
+      instances: '["stable-3006", "onedir-3006", "stable-3006-8", "stable-3007", "onedir-3007", "stable-3007-1", "stable-3008", "git-3008", "onedir-3008", "latest", "default"]'
 
 
   ubuntu-2204:
@@ -282,7 +282,22 @@ jobs:
       display-name: Ubuntu 22.04
       container-slug: ubuntu-22.04
       timeout: 20
-      instances: '["stable-3006", "git-3006", "onedir-3006", "stable-3006-8", "stable-3007", "git-3007", "onedir-3007", "stable-3007-1", "git-master", "latest", "default"]'
+      instances: '["stable-3006", "git-3006", "onedir-3006", "stable-3006-8", "stable-3007", "git-3007", "onedir-3007", "stable-3007-1", "stable-3008", "git-3008", "onedir-3008", "git-master", "latest", "default"]'
+
+
+  ubuntu-2604:
+    name: Ubuntu 26.04
+    if: github.event_name == 'push' || needs.collect-changed-files.outputs.run-tests == 'true'
+    uses: ./.github/workflows/test-linux.yml
+    needs:
+      - lint
+      - generate-actions-workflow
+    with:
+      distro-slug: ubuntu-2604
+      display-name: Ubuntu 26.04
+      container-slug: ubuntu-26.04
+      timeout: 20
+      instances: '["stable-3006", "git-3006", "onedir-3006", "stable-3006-8", "stable-3007", "git-3007", "onedir-3007", "stable-3007-1", "stable-3008", "git-3008", "onedir-3008", "git-master", "latest", "default"]'
 
 
   set-pipeline-exit-status:
@@ -304,6 +319,7 @@ jobs:
       - rockylinux-8
       - rockylinux-9
       - ubuntu-2204
+      - ubuntu-2604
     if: always()
     steps:
 

--- a/.github/workflows/templates/generate.py
+++ b/.github/workflows/templates/generate.py
@@ -23,6 +23,7 @@ LINUX_DISTROS = [
     "rockylinux-8",
     "rockylinux-9",
     "ubuntu-2204",
+    "ubuntu-2604",
 ]
 
 WINDOWS = [
@@ -49,6 +50,7 @@ STABLE_DISTROS = [
     "rockylinux-8",
     "rockylinux-9",
     "ubuntu-2204",
+    "ubuntu-2604",
 ]
 
 #    "amazonlinux-2",
@@ -65,6 +67,7 @@ ONEDIR_DISTROS = [
     "rockylinux-8",
     "rockylinux-9",
     "ubuntu-2204",
+    "ubuntu-2604",
 ]
 
 #    "amazonlinux-2",
@@ -78,6 +81,7 @@ ONEDIR_RC_DISTROS = [
     "photon-5",
     "rockylinux-9",
     "ubuntu-2204",
+    "ubuntu-2604",
 ]
 
 BLACKLIST_3006 = [
@@ -90,6 +94,8 @@ BLACKLIST_3006 = [
 BLACKLIST_3007 = [
     "photon-4",
 ]
+
+BLACKLIST_3008 = []
 
 #    "ubuntu-2204",
 BLACKLIST_GIT_3006 = [
@@ -137,6 +143,7 @@ SALT_VERSIONS = [
     "3006-8",
     "3007",
     "3007-1",
+    "3008",
     "master",
     "latest",
     "nightly",
@@ -145,6 +152,7 @@ SALT_VERSIONS = [
 ONEDIR_SALT_VERSIONS = [
     "3006",
     "3007",
+    "3008",
     "latest",
 ]
 
@@ -155,6 +163,7 @@ VERSION_DISPLAY_NAMES = {
     "3006-8": "v3006.8",
     "3007": "v3007",
     "3007-1": "v3007.1",
+    "3008": "v3008",
     "master": "Master",
     "latest": "Latest",
     "nightly": "Nightly",
@@ -205,6 +214,7 @@ DISTRO_DISPLAY_NAMES = {
     "ubuntu-2004": "Ubuntu 20.04",
     "ubuntu-2204": "Ubuntu 22.04",
     "ubuntu-2404": "Ubuntu 24.04",
+    "ubuntu-2604": "Ubuntu 26.04",
     "macos-14": "macOS 14",
     "macos-15-intel": "macOS 15 (intel)",
     "windows-2022": "Windows 2022",
@@ -225,6 +235,7 @@ CONTAINER_SLUG_NAMES = {
     "ubuntu-2004": "ubuntu-20.04",
     "ubuntu-2204": "ubuntu-22.04",
     "ubuntu-2404": "ubuntu-24.04",
+    "ubuntu-2604": "ubuntu-26.04",
     "macos-14": "macos-14",
     "macos-15-intel": "macos-15-intel",
     "windows-2022": "windows-2022",
@@ -405,6 +416,7 @@ def generate_test_jobs():
                     "3006-8": BLACKLIST_3006,
                     "3007": BLACKLIST_3007,
                     "3007-1": BLACKLIST_3007,
+                    "3008": BLACKLIST_3008,
                 }
                 if bootstrap_type == "git":
                     BLACKLIST = {
@@ -419,10 +431,7 @@ def generate_test_jobs():
                     if salt_version.endswith("-0"):
                         continue
 
-                if (
-                    salt_version in ("3006", "3006-8", "3007", "3007-1", "master")
-                    and distro in BLACKLIST[salt_version]
-                ):
+                if distro in BLACKLIST.get(salt_version, []):
                     continue
 
                 test_target = f"{bootstrap_type}-{salt_version}"

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -64,12 +64,12 @@ jobs:
           /usr/bin/docker start ${{ github.run_id }}_salt-test
 
       - name: "Install Python Dependencies with pip breakage in container ${{ inputs.container-slug }}"
-        if: ${{ ( inputs.distro-slug == 'debian-12' ) || ( inputs.distro-slug == 'debian-13' ) || ( inputs.distro-slug == 'ubuntu-2404' ) }}
+        if: ${{ ( inputs.distro-slug == 'debian-12' ) || ( inputs.distro-slug == 'debian-13' ) || ( inputs.distro-slug == 'ubuntu-2404' ) || ( inputs.distro-slug == 'ubuntu-2604' ) }}
         run: |
           docker exec ${{ github.run_id}}_salt-test python3 -m pip install --break-system-packages -r /_w/btstrap/tests/requirements.txt
 
       - name: "Install Python Dependencies without pip breakage in container ${{ inputs.container-slug }}"
-        if: ${{ ( inputs.distro-slug != 'debian-12' ) && ( inputs.distro-slug != 'debian-13' ) && ( inputs.distro-slug != 'ubuntu-2404' ) }}
+        if: ${{ ( inputs.distro-slug != 'debian-12' ) && ( inputs.distro-slug != 'debian-13' ) && ( inputs.distro-slug != 'ubuntu-2404' ) && ( inputs.distro-slug != 'ubuntu-2604' ) }}
         run: |
           docker exec ${{ github.run_id}}_salt-test python3 -m pip install -r /_w/btstrap/tests/requirements.txt
 

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -664,7 +664,7 @@ elif [ "$ITYPE" = "stable" ]; then
         _ONEDIR_REV="latest"
         ITYPE="onedir"
     else
-        if [ "$(echo "$1" | grep -E '^(latest|3006|3007)$')" != "" ]; then
+        if [ "$(echo "$1" | grep -E '^(latest|[0-9]{4})$')" != "" ]; then
             STABLE_REV="$1"
             ONEDIR_REV="$1"
             _ONEDIR_REV="$1"
@@ -677,7 +677,7 @@ elif [ "$ITYPE" = "stable" ]; then
             ITYPE="onedir"
             shift
         else
-            echo "Unknown stable version: $1 (valid: 3006, 3007, latest), versions older than 3006 are not available"
+            echo "Unknown stable version: $1 (valid: any 4-digit major version e.g. 3006, 3007, 3008, or latest), versions older than 3006 are not available"
             exit 1
         fi
     fi
@@ -687,7 +687,7 @@ elif [ "$ITYPE" = "onedir" ]; then
         ONEDIR_REV="latest"
         STABLE_REV="latest"
     else
-        if [ "$(echo "$1" | grep -E '^(latest|3006|3007)$')" != "" ]; then
+        if [ "$(echo "$1" | grep -E '^(latest|[0-9]{4})$')" != "" ]; then
             ONEDIR_REV="$1"
             STABLE_REV="$1"
             shift
@@ -696,7 +696,7 @@ elif [ "$ITYPE" = "onedir" ]; then
             STABLE_REV="$1"
             shift
         else
-            echo "Unknown onedir version: $1 (valid: 3006, 3007, latest), versions older than 3006 are not available"
+            echo "Unknown onedir version: $1 (valid: any 4-digit major version e.g. 3006, 3007, 3008, or latest), versions older than 3006 are not available"
             exit 1
         fi
     fi
@@ -2031,7 +2031,13 @@ __apt_key_fetch() {
     tempfile="$(__temp_gpg_pub)"
     __fetch_url "$tempfile" "$url" || return 1
     mkdir -p /etc/apt/keyrings
-    cp -f "$tempfile" /etc/apt/keyrings/salt-archive-keyring.pgp && chmod 644 /etc/apt/keyrings/salt-archive-keyring.pgp || return 1
+    if __check_command_exists gpg; then
+        # Newer apt requires the keyring in binary (dearmored) format.
+        gpg --dearmor < "$tempfile" > /etc/apt/keyrings/salt-archive-keyring.pgp || return 1
+    else
+        cp -f "$tempfile" /etc/apt/keyrings/salt-archive-keyring.pgp || return 1
+    fi
+    chmod 644 /etc/apt/keyrings/salt-archive-keyring.pgp || return 1
     rm -f "$tempfile"
 
     return 0
@@ -2111,8 +2117,8 @@ __git_clone_and_checkout() {
         export GIT_SSL_NO_VERIFY=1
     fi
 
-    if [ "$(echo "$GIT_REV" | grep -E '^(3006|3007)$')" != "" ]; then
-        GIT_REV_ADJ="$GIT_REV.x"  # branches are 3006.x or 3007.x
+    if [ "$(echo "$GIT_REV" | grep -E '^[0-9]{4}$')" != "" ]; then
+        GIT_REV_ADJ="$GIT_REV.x"  # branches are 3006.x, 3007.x, 3008.x, ...
     else
         GIT_REV_ADJ="$GIT_REV"
     fi
@@ -3024,7 +3030,7 @@ __install_saltstack_ubuntu_repository() {
 
     if [ "$STABLE_REV" != "latest" ]; then
         # latest is default
-        if [ "$(echo "$STABLE_REV" | grep -E '^(3006|3007)$')" != "" ]; then
+        if [ "$(echo "$STABLE_REV" | grep -E '^[0-9]{4}$')" != "" ]; then
             echo "Package: salt-*" > /etc/apt/preferences.d/salt-pin-1001
             echo "Pin: version $STABLE_REV.*" >> /etc/apt/preferences.d/salt-pin-1001
             echo "Pin-Priority: 1001" >> /etc/apt/preferences.d/salt-pin-1001
@@ -3076,7 +3082,7 @@ __install_saltstack_ubuntu_onedir_repository() {
 
     if [ "$ONEDIR_REV" != "latest" ]; then
         # latest is default
-        if [ "$(echo "$ONEDIR_REV" | grep -E '^(3006|3007)$')" != "" ]; then
+        if [ "$(echo "$ONEDIR_REV" | grep -E '^[0-9]{4}$')" != "" ]; then
             echo "Package: salt-*" > /etc/apt/preferences.d/salt-pin-1001
             echo "Pin: version $ONEDIR_REV.*" >> /etc/apt/preferences.d/salt-pin-1001
             echo "Pin-Priority: 1001" >> /etc/apt/preferences.d/salt-pin-1001
@@ -3527,7 +3533,7 @@ __install_saltstack_debian_repository() {
 
     if [ "$STABLE_REV" != "latest" ]; then
         # latest is default
-        if [ "$(echo "$STABLE_REV" | grep -E '^(3006|3007)$')" != "" ]; then
+        if [ "$(echo "$STABLE_REV" | grep -E '^[0-9]{4}$')" != "" ]; then
             echo "Package: salt-*" > /etc/apt/preferences.d/salt-pin-1001
             echo "Pin: version $STABLE_REV.*" >> /etc/apt/preferences.d/salt-pin-1001
             echo "Pin-Priority: 1001" >> /etc/apt/preferences.d/salt-pin-1001
@@ -3572,7 +3578,7 @@ __install_saltstack_debian_onedir_repository() {
 
     if [ "$ONEDIR_REV" != "latest" ]; then
         # latest is default
-        if [ "$(echo "$ONEDIR_REV" | grep -E '^(3006|3007)$')" != "" ]; then
+        if [ "$(echo "$ONEDIR_REV" | grep -E '^[0-9]{4}$')" != "" ]; then
             echo "Package: salt-*" > /etc/apt/preferences.d/salt-pin-1001
             echo "Pin: version $ONEDIR_REV.*" >> /etc/apt/preferences.d/salt-pin-1001
             echo "Pin-Priority: 1001" >> /etc/apt/preferences.d/salt-pin-1001
@@ -3908,13 +3914,22 @@ __install_saltstack_fedora_onedir_repository() {
         __fetch_url "${YUM_REPO_FILE}" "${FETCH_URL}"
         if [ "$ONEDIR_REV" != "latest" ]; then
             # 3006.x is default, and latest for 3006.x branch
-            if [ "$(echo "$ONEDIR_REV" | grep -E '^(3006|3007)$')" != "" ]; then
-                # latest version for branch 3006 | 3007
+            if [ "$(echo "$ONEDIR_REV" | grep -E '^[0-9]{4}$')" != "" ]; then
+                # major version — enable the appropriate repo branch
                 REPO_REV_MAJOR=$(echo "$ONEDIR_REV" | cut -d '.' -f 1)
                 if [ "$REPO_REV_MAJOR" -eq "3007" ]; then
                     # Enable the Salt 3007 STS repo
                     dnf config-manager --set-disable salt-repo-*
                     dnf config-manager --set-enabled salt-repo-3007-sts
+                elif [ "$REPO_REV_MAJOR" -eq "3006" ]; then
+                    # Enable the Salt 3006 LTS repo; disable others so salt-repo-latest
+                    # (pointing to 3008+) does not take precedence
+                    dnf config-manager --set-disable salt-repo-*
+                    dnf config-manager --set-enabled salt-repo-3006-lts
+                else
+                    # 3008+ — use the latest repo
+                    dnf config-manager --set-disable salt-repo-*
+                    dnf config-manager --set-enabled salt-repo-latest
                 fi
             elif [ "$(echo "$ONEDIR_REV" | grep -E '^([3-9][0-5]{2}[6-9](\.[0-9]*)?)')" != "" ]; then
                 # using minor version
@@ -4150,7 +4165,7 @@ install_fedora_onedir() {
 
     STABLE_REV=$ONEDIR_REV
     #install_fedora_stable || return 1
-    if [ "$(echo "$STABLE_REV" | grep -E '^(3006|3007)$')" != "" ]; then
+    if [ "$(echo "$STABLE_REV" | grep -E '^[0-9]{4}$')" != "" ]; then
         # Major version Salt, config and repo already setup
         MINOR_VER_STRG=""
     elif [ "$(echo "$STABLE_REV" | grep -E '^([3-9][0-5]{2}[6-9](\.[0-9]*)?)')" != "" ]; then
@@ -4229,13 +4244,22 @@ __install_saltstack_rhel_onedir_repository() {
         __fetch_url "${YUM_REPO_FILE}" "${FETCH_URL}"
         if [ "$ONEDIR_REV" != "latest" ]; then
             # 3006.x is default, and latest for 3006.x branch
-            if [ "$(echo "$ONEDIR_REV" | grep -E '^(3006|3007)$')" != "" ]; then
-                # latest version for branch 3006 | 3007
+            if [ "$(echo "$ONEDIR_REV" | grep -E '^[0-9]{4}$')" != "" ]; then
+                # major version — enable the appropriate repo branch
                 REPO_REV_MAJOR=$(echo "$ONEDIR_REV" | cut -d '.' -f 1)
                 if [ "$REPO_REV_MAJOR" -eq "3007" ]; then
                     # Enable the Salt 3007 STS repo
                     yum config-manager --set-disable salt-repo-*
                     yum config-manager --set-enabled salt-repo-3007-sts
+                elif [ "$REPO_REV_MAJOR" -eq "3006" ]; then
+                    # Enable the Salt 3006 LTS repo; disable others so salt-repo-latest
+                    # (pointing to 3008+) does not take precedence
+                    yum config-manager --set-disable salt-repo-*
+                    yum config-manager --set-enabled salt-repo-3006-lts
+                else
+                    # 3008+ — use the latest repo
+                    yum config-manager --set-disable salt-repo-*
+                    yum config-manager --set-enabled salt-repo-latest
                 fi
             elif [ "$(echo "$ONEDIR_REV" | grep -E '^([3-9][0-5]{2}[6-9](\.[0-9]*)?)')" != "" ]; then
                 # using minor version
@@ -4306,7 +4330,7 @@ install_centos_stable_deps() {
 
 install_centos_stable() {
 
-    if [ "$(echo "$STABLE_REV" | grep -E '^(3006|3007)$')" != "" ]; then
+    if [ "$(echo "$STABLE_REV" | grep -E '^[0-9]{4}$')" != "" ]; then
         # Major version Salt, config and repo already setup
         MINOR_VER_STRG=""
     elif [ "$(echo "$STABLE_REV" | grep -E '^([3-9][0-5]{2}[6-9](\.[0-9]*)?)')" != "" ]; then
@@ -4526,7 +4550,7 @@ install_centos_onedir_deps() {
 
 install_centos_onedir() {
 
-    if [ "$(echo "$ONEDIR_REV" | grep -E '^(3006|3007)$')" != "" ]; then
+    if [ "$(echo "$ONEDIR_REV" | grep -E '^[0-9]{4}$')" != "" ]; then
         # Major version Salt, config and repo already setup
         MINOR_VER_STRG=""
     elif [ "$(echo "$ONEDIR_REV" | grep -E '^([3-9][0-5]{2}[6-9](\.[0-9]*)?)')" != "" ]; then
@@ -5649,9 +5673,9 @@ install_amazon_linux_ami_2_deps() {
             ## __fetch_url "${YUM_REPO_FILE}" "${FETCH_URL}"
             # shellcheck disable=SC2129
             if [ "$STABLE_REV" != "latest" ]; then
-                # 3006.x is default, and latest for 3006.x branch
-                if [ "$(echo "$STABLE_REV" | grep -E '^(3006|3007)$')" != "" ]; then
-                    # latest version for branch 3006 | 3007
+                # major version or specific minor version
+                if [ "$(echo "$STABLE_REV" | grep -E '^[0-9]{4}$')" != "" ]; then
+                    # major version
                     REPO_REV_MAJOR=$(echo "$STABLE_REV" | cut -d '.' -f 1)
                     if [ "$REPO_REV_MAJOR" -eq "3007" ]; then
                         # Enable the Salt 3007 STS repo
@@ -5665,8 +5689,8 @@ install_amazon_linux_ami_2_deps() {
                         echo "gpgcheck=1" >> "${YUM_REPO_FILE}"
                         echo "exclude=*3006* *3008* *3009* *3010*" >> "${YUM_REPO_FILE}"
                         echo "gpgkey=https://${_REPO_URL}/api/security/keypair/SaltProjectKey/public" >> "${YUM_REPO_FILE}"
-                    else
-                        # Salt 3006 repo
+                    elif [ "$REPO_REV_MAJOR" -eq "3006" ]; then
+                        # Salt 3006 LTS repo
                         echo "[salt-repo-3006-lts]" > "${YUM_REPO_FILE}"
                         echo "name=Salt Repo for Salt v3006 LTS" >> "${YUM_REPO_FILE}"
                         echo "baseurl=https://${_REPO_URL}/saltproject-rpm/" >> "${YUM_REPO_FILE}"
@@ -5676,6 +5700,17 @@ install_amazon_linux_ami_2_deps() {
                         echo "enabled_metadata=1" >> "${YUM_REPO_FILE}"
                         echo "gpgcheck=1" >> "${YUM_REPO_FILE}"
                         echo "exclude=*3007* *3008* *3009* *3010*" >> "${YUM_REPO_FILE}"
+                        echo "gpgkey=https://${_REPO_URL}/api/security/keypair/SaltProjectKey/public" >> "${YUM_REPO_FILE}"
+                    else
+                        # 3008+ — use the latest repo
+                        echo "[salt-repo-latest]" > "${YUM_REPO_FILE}"
+                        echo "name=Salt Repo for Salt LATEST release" >> "${YUM_REPO_FILE}"
+                        echo "baseurl=https://${_REPO_URL}/saltproject-rpm/" >> "${YUM_REPO_FILE}"
+                        echo "skip_if_unavailable=True" >> "${YUM_REPO_FILE}"
+                        echo "priority=10" >> "${YUM_REPO_FILE}"
+                        echo "enabled=1" >> "${YUM_REPO_FILE}"
+                        echo "enabled_metadata=1" >> "${YUM_REPO_FILE}"
+                        echo "gpgcheck=1" >> "${YUM_REPO_FILE}"
                         echo "gpgkey=https://${_REPO_URL}/api/security/keypair/SaltProjectKey/public" >> "${YUM_REPO_FILE}"
                     fi
                 elif [ "$(echo "$STABLE_REV" | grep -E '^([3-9][0-5]{2}[6-9](\.[0-9]*)?)')" != "" ]; then
@@ -5739,9 +5774,9 @@ install_amazon_linux_ami_2_onedir_deps() {
             ## __fetch_url "${YUM_REPO_FILE}" "${FETCH_URL}"
             # shellcheck disable=SC2129
             if [ "$ONEDIR_REV" != "latest" ]; then
-                # 3006.x is default, and latest for 3006.x branch
-                if [ "$(echo "$ONEDIR_REV" | grep -E '^(3006|3007)$')" != "" ]; then
-                    # latest version for branch 3006 | 3007
+                # major version or specific minor version
+                if [ "$(echo "$ONEDIR_REV" | grep -E '^[0-9]{4}$')" != "" ]; then
+                    # major version
                     REPO_REV_MAJOR=$(echo "$ONEDIR_REV" | cut -d '.' -f 1)
                     if [ "$REPO_REV_MAJOR" -eq "3007" ]; then
                         # Enable the Salt 3007 STS repo
@@ -5755,8 +5790,8 @@ install_amazon_linux_ami_2_onedir_deps() {
                         echo "gpgcheck=1" >> "${YUM_REPO_FILE}"
                         echo "exclude=*3006* *3008* *3009* *3010*" >> "${YUM_REPO_FILE}"
                         echo "gpgkey=https://${_REPO_URL}/api/security/keypair/SaltProjectKey/public" >> "${YUM_REPO_FILE}"
-                    else
-                        # Salt 3006 repo
+                    elif [ "$REPO_REV_MAJOR" -eq "3006" ]; then
+                        # Salt 3006 LTS repo
                         echo "[salt-repo-3006-lts]" > "${YUM_REPO_FILE}"
                         echo "name=Salt Repo for Salt v3006 LTS" >> "${YUM_REPO_FILE}"
                         echo "baseurl=https://${_REPO_URL}/saltproject-rpm/" >> "${YUM_REPO_FILE}"
@@ -5766,6 +5801,17 @@ install_amazon_linux_ami_2_onedir_deps() {
                         echo "enabled_metadata=1" >> "${YUM_REPO_FILE}"
                         echo "gpgcheck=1" >> "${YUM_REPO_FILE}"
                         echo "exclude=*3007* *3008* *3009* *3010*" >> "${YUM_REPO_FILE}"
+                        echo "gpgkey=https://${_REPO_URL}/api/security/keypair/SaltProjectKey/public" >> "${YUM_REPO_FILE}"
+                    else
+                        # 3008+ — use the latest repo
+                        echo "[salt-repo-latest]" > "${YUM_REPO_FILE}"
+                        echo "name=Salt Repo for Salt LATEST release" >> "${YUM_REPO_FILE}"
+                        echo "baseurl=https://${_REPO_URL}/saltproject-rpm/" >> "${YUM_REPO_FILE}"
+                        echo "skip_if_unavailable=True" >> "${YUM_REPO_FILE}"
+                        echo "priority=10" >> "${YUM_REPO_FILE}"
+                        echo "enabled=1" >> "${YUM_REPO_FILE}"
+                        echo "enabled_metadata=1" >> "${YUM_REPO_FILE}"
+                        echo "gpgcheck=1" >> "${YUM_REPO_FILE}"
                         echo "gpgkey=https://${_REPO_URL}/api/security/keypair/SaltProjectKey/public" >> "${YUM_REPO_FILE}"
                     fi
                 elif [ "$(echo "$ONEDIR_REV" | grep -E '^([3-9][0-5]{2}[6-9](\.[0-9]*)?)')" != "" ]; then
@@ -5921,9 +5967,9 @@ install_amazon_linux_ami_2023_onedir_deps() {
             ## __fetch_url "${YUM_REPO_FILE}" "${FETCH_URL}"
             # shellcheck disable=SC2129
             if [ "$ONEDIR_REV" != "latest" ]; then
-                # 3006.x is default, and latest for 3006.x branch
-                if [ "$(echo "$ONEDIR_REV" | grep -E '^(3006|3007)$')" != "" ]; then
-                    # latest version for branch 3006 | 3007
+                # major version or specific minor version
+                if [ "$(echo "$ONEDIR_REV" | grep -E '^[0-9]{4}$')" != "" ]; then
+                    # major version
                     REPO_REV_MAJOR=$(echo "$ONEDIR_REV" | cut -d '.' -f 1)
                     if [ "$REPO_REV_MAJOR" -eq "3007" ]; then
                         # Enable the Salt 3007 STS repo
@@ -5937,8 +5983,8 @@ install_amazon_linux_ami_2023_onedir_deps() {
                         echo "gpgcheck=1" >> "${YUM_REPO_FILE}"
                         echo "exclude=*3006* *3008* *3009* *3010*" >> "${YUM_REPO_FILE}"
                         echo "gpgkey=https://${_REPO_URL}/api/security/keypair/SaltProjectKey/public" >> "${YUM_REPO_FILE}"
-                    else
-                        # Salt 3006 repo
+                    elif [ "$REPO_REV_MAJOR" -eq "3006" ]; then
+                        # Salt 3006 LTS repo
                         echo "[salt-repo-3006-lts]" > "${YUM_REPO_FILE}"
                         echo "name=Salt Repo for Salt v3006 LTS" >> "${YUM_REPO_FILE}"
                         echo "baseurl=https://${_REPO_URL}/saltproject-rpm/" >> "${YUM_REPO_FILE}"
@@ -5948,6 +5994,17 @@ install_amazon_linux_ami_2023_onedir_deps() {
                         echo "enabled_metadata=1" >> "${YUM_REPO_FILE}"
                         echo "gpgcheck=1" >> "${YUM_REPO_FILE}"
                         echo "exclude=*3007* *3008* *3009* *3010*" >> "${YUM_REPO_FILE}"
+                        echo "gpgkey=https://${_REPO_URL}/api/security/keypair/SaltProjectKey/public" >> "${YUM_REPO_FILE}"
+                    else
+                        # 3008+ — use the latest repo
+                        echo "[salt-repo-latest]" > "${YUM_REPO_FILE}"
+                        echo "name=Salt Repo for Salt LATEST release" >> "${YUM_REPO_FILE}"
+                        echo "baseurl=https://${_REPO_URL}/saltproject-rpm/" >> "${YUM_REPO_FILE}"
+                        echo "skip_if_unavailable=True" >> "${YUM_REPO_FILE}"
+                        echo "priority=10" >> "${YUM_REPO_FILE}"
+                        echo "enabled=1" >> "${YUM_REPO_FILE}"
+                        echo "enabled_metadata=1" >> "${YUM_REPO_FILE}"
+                        echo "gpgcheck=1" >> "${YUM_REPO_FILE}"
                         echo "gpgkey=https://${_REPO_URL}/api/security/keypair/SaltProjectKey/public" >> "${YUM_REPO_FILE}"
                     fi
                 elif [ "$(echo "$ONEDIR_REV" | grep -E '^([3-9][0-5]{2}[6-9](\.[0-9]*)?)')" != "" ]; then
@@ -6461,9 +6518,9 @@ __install_saltstack_vmware_photon_os_onedir_repository() {
         ## __fetch_url "${YUM_REPO_FILE}" "${FETCH_URL}"
         # shellcheck disable=SC2129
         if [ "$ONEDIR_REV" != "latest" ]; then
-            # 3006.x is default, and latest for 3006.x branch
-            if [ "$(echo "$ONEDIR_REV" | grep -E '^(3006|3007)$')" != "" ]; then
-                # latest version for branch 3006 | 3007
+            # major version or specific minor version
+            if [ "$(echo "$ONEDIR_REV" | grep -E '^[0-9]{4}$')" != "" ]; then
+                # major version
                 REPO_REV_MAJOR=$(echo "$ONEDIR_REV" | cut -d '.' -f 1)
                 if [ "$REPO_REV_MAJOR" -eq "3007" ]; then
                     # Enable the Salt 3007 STS repo
@@ -6479,8 +6536,8 @@ __install_saltstack_vmware_photon_os_onedir_repository() {
                     echo "gpgcheck=1" >> "${YUM_REPO_FILE}"
                     echo "exclude=*3006* *3008* *3009* *3010*" >> "${YUM_REPO_FILE}"
                     echo "gpgkey=https://${_REPO_URL}/api/security/keypair/SaltProjectKey/public" >> "${YUM_REPO_FILE}"
-                else
-                    # Salt 3006 repo
+                elif [ "$REPO_REV_MAJOR" -eq "3006" ]; then
+                    # Salt 3006 LTS repo
                     echo "[salt-repo-3006-lts]" > "${YUM_REPO_FILE}"
                     echo "name=Salt Repo for Salt v3006 LTS" >> "${YUM_REPO_FILE}"
                     echo "baseurl=https://${_REPO_URL}/saltproject-rpm/" >> "${YUM_REPO_FILE}"
@@ -6490,6 +6547,17 @@ __install_saltstack_vmware_photon_os_onedir_repository() {
                     echo "enabled_metadata=1" >> "${YUM_REPO_FILE}"
                     echo "gpgcheck=1" >> "${YUM_REPO_FILE}"
                     echo "exclude=*3007* *3008* *3009* *3010*" >> "${YUM_REPO_FILE}"
+                    echo "gpgkey=https://${_REPO_URL}/api/security/keypair/SaltProjectKey/public" >> "${YUM_REPO_FILE}"
+                else
+                    # 3008+ — use the latest repo
+                    echo "[salt-repo-latest]" > "${YUM_REPO_FILE}"
+                    echo "name=Salt Repo for Salt LATEST release" >> "${YUM_REPO_FILE}"
+                    echo "baseurl=https://${_REPO_URL}/saltproject-rpm/" >> "${YUM_REPO_FILE}"
+                    echo "skip_if_unavailable=True" >> "${YUM_REPO_FILE}"
+                    echo "priority=10" >> "${YUM_REPO_FILE}"
+                    echo "enabled=1" >> "${YUM_REPO_FILE}"
+                    echo "enabled_metadata=1" >> "${YUM_REPO_FILE}"
+                    echo "gpgcheck=1" >> "${YUM_REPO_FILE}"
                     echo "gpgkey=https://${_REPO_URL}/api/security/keypair/SaltProjectKey/public" >> "${YUM_REPO_FILE}"
                 fi
             elif [ "$(echo "$ONEDIR_REV" | grep -E '^([3-9][0-5]{2}[6-9](\.[0-9]*)?)')" != "" ]; then
@@ -6785,7 +6853,7 @@ install_vmware_photon_os_onedir() {
     STABLE_REV=$ONEDIR_REV
     _GENERIC_PKG_VERSION=""
 
-    if [ "$(echo "$STABLE_REV" | grep -E '^(3006|3007)$')" != "" ]; then
+    if [ "$(echo "$STABLE_REV" | grep -E '^[0-9]{4}$')" != "" ]; then
         # Major version Salt, config and repo already setup
         __get_packagesite_onedir_latest "$STABLE_REV" || return 1
         MINOR_VER_STRG="-$_GENERIC_PKG_VERSION"
@@ -6853,9 +6921,9 @@ __check_and_refresh_suse_pkg_repo() {
         ZYPPER_REPO_FILE="/etc/zypp/repos.d/salt.repo"
         # shellcheck disable=SC2129
         if [ "$ONEDIR_REV" != "latest" ]; then
-            # 3006.x is default, and latest for 3006.x branch
-            if [ "$(echo "$ONEDIR_REV" | grep -E '^(3006|3007)$')" != "" ]; then
-                # latest version for branch 3006 | 3007
+            # major version or specific minor version
+            if [ "$(echo "$ONEDIR_REV" | grep -E '^[0-9]{4}$')" != "" ]; then
+                # major version
                 REPO_REV_MAJOR=$(echo "$ONEDIR_REV" | cut -d '.' -f 1)
                 if [ "$REPO_REV_MAJOR" -eq "3007" ]; then
                     # Enable the Salt 3007 STS repo
@@ -6870,8 +6938,8 @@ __check_and_refresh_suse_pkg_repo() {
                     echo "gpgcheck=1" >> "${ZYPPER_REPO_FILE}"
                     echo "gpgkey=https://${_REPO_URL}/api/security/keypair/SaltProjectKey/public" >> "${ZYPPER_REPO_FILE}"
                     zypper addlock "salt-* < 3007" && zypper addlock "salt-* >= 3008"
-                else
-                    # Salt 3006 repo
+                elif [ "$REPO_REV_MAJOR" -eq "3006" ]; then
+                    # Salt 3006 LTS repo
                     echo "[salt-repo-3006-lts]" > "${ZYPPER_REPO_FILE}"
                     echo "name=Salt Repo for Salt v3006 LTS" >> "${ZYPPER_REPO_FILE}"
                     echo "baseurl=https://${_REPO_URL}/saltproject-rpm/" >> "${ZYPPER_REPO_FILE}"
@@ -6883,6 +6951,19 @@ __check_and_refresh_suse_pkg_repo() {
                     echo "gpgcheck=1" >> "${ZYPPER_REPO_FILE}"
                     echo "gpgkey=https://${_REPO_URL}/api/security/keypair/SaltProjectKey/public" >> "${ZYPPER_REPO_FILE}"
                     zypper addlock "salt-* < 3006" && zypper addlock "salt-* >= 3007"
+                else
+                    # 3008+ — use the latest repo
+                    REPO_REV_MAJOR_PLUS=$((REPO_REV_MAJOR + 1))
+                    echo "[salt-repo-latest]" > "${ZYPPER_REPO_FILE}"
+                    echo "name=Salt Repo for Salt LATEST release" >> "${ZYPPER_REPO_FILE}"
+                    echo "baseurl=https://${_REPO_URL}/saltproject-rpm/" >> "${ZYPPER_REPO_FILE}"
+                    echo "skip_if_unavailable=True" >> "${ZYPPER_REPO_FILE}"
+                    echo "priority=10" >> "${ZYPPER_REPO_FILE}"
+                    echo "enabled=1" >> "${ZYPPER_REPO_FILE}"
+                    echo "enabled_metadata=1" >> "${ZYPPER_REPO_FILE}"
+                    echo "gpgcheck=1" >> "${ZYPPER_REPO_FILE}"
+                    echo "gpgkey=https://${_REPO_URL}/api/security/keypair/SaltProjectKey/public" >> "${ZYPPER_REPO_FILE}"
+                    zypper addlock "salt-* < ${REPO_REV_MAJOR}" && zypper addlock "salt-* >= ${REPO_REV_MAJOR_PLUS}"
                 fi
             elif [ "$(echo "$ONEDIR_REV" | grep -E '^([3-9][0-5]{2}[6-9](\.[0-9]*)?)')" != "" ]; then
                 # using minor version
@@ -7045,7 +7126,7 @@ install_opensuse_onedir_deps() {
 }
 
 install_opensuse_stable() {
-    if [ "$(echo "$STABLE_REV" | grep -E '^(3006|3007)$')" != "" ]; then
+    if [ "$(echo "$STABLE_REV" | grep -E '^[0-9]{4}$')" != "" ]; then
         # Major version Salt, config and repo already setup
         MINOR_VER_STRG=""
     elif [ "$(echo "$STABLE_REV" | grep -E '^([3-9][0-5]{2}[6-9](\.[0-9]*)?)')" != "" ]; then
@@ -7513,7 +7594,7 @@ __gentoo_pre_dep() {
     # Enable Python 3.10 target for Salt 3006 or later, otherwise 3.7 as previously, using GIT
     if [ "${ITYPE}" = "git" ]; then
         GIT_REV_MAJOR=$(echo "${GIT_REV}" | awk -F "." '{print $1}')
-        if [ "${GIT_REV_MAJOR}" = "v3006" ] || [ "${GIT_REV_MAJOR}" = "v3007" ]; then
+        if echo "${GIT_REV_MAJOR}" | grep -qE '^v[0-9]{4}$'; then
             EXTRA_PYTHON_TARGET=python3_10
         else
             # assume pre-3006, so leave it as Python 3.7
@@ -7915,7 +7996,7 @@ __macosx_get_packagesite_onedir() {
     SALT_MACOS_PKGDIR_URL="https://${_REPO_URL}/${_ONEDIR_TYPE}/macos"
     if [ "$(echo "$_ONEDIR_REV" | grep -E '^(latest)$')" != "" ]; then
         __macosx_get_packagesite_onedir_latest || return 1
-    elif [ "$(echo "$_ONEDIR_REV" | grep -E '^(3006|3007)$')" != "" ]; then
+    elif [ "$(echo "$_ONEDIR_REV" | grep -E '^[0-9]{4}$')" != "" ]; then
         # need to get latest for major version
         __macosx_get_packagesite_onedir_latest "$_ONEDIR_REV" || return 1
     elif [ "$(echo "$_ONEDIR_REV" | grep -E '^([3-9][0-9]{3}(\.[0-9]*)?)')" != "" ]; then

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -6722,11 +6722,7 @@ install_vmware_photon_os_git() {
 
     install_vmware_photon_os_git_deps
 
-    if [ -f "${_SALT_GIT_CHECKOUT_DIR}/salt/syspaths.py" ]; then
-        ${_PYEXE} setup.py --salt-config-dir="$_SALT_ETC_DIR" --salt-cache-dir="${_SALT_CACHE_DIR}" ${SETUP_PY_INSTALL_ARGS} install --prefix=/usr || return 1
-    else
-        ${_PYEXE} setup.py ${SETUP_PY_INSTALL_ARGS} install --prefix=/usr || return 1
-    fi
+    __install_salt_from_repo "${_PYEXE}" || return 1
     return 0
 }
 


### PR DESCRIPTION
### What does this PR do?

Issue https://github.com/saltstack/salt-bootstrap/issues/2113 — Salt 3008 (and future major versions) was not recognized
as a valid major version because every version check in the script used
the hardcoded pattern `^(3006|3007)$`. This caused `3008` to fall into
the "minor version" branch, appending `-3008` to RPM package names
(`yum install salt-minion-3008`) and failing. Fixed by replacing all
~20 occurrences of `'^(3006|3007)$'` with `'^[0-9]{4}$'` so any
4-digit CalVer major is handled generically. Repo setup for new major
versions (3008+) falls back to `salt-repo-latest`. Version validation
at argument-parse time updated to match, with improved error messages.

Issue https://github.com/saltstack/salt-bootstrap/issues/2118 — Bootstrap fails on Ubuntu 26.04 with `NO_PUBKEY` because
`__apt_key_fetch()` was copying the ASCII-armored GPG key directly to
`/etc/apt/keyrings/salt-archive-keyring.pgp`, but newer apt requires
that file in binary (dearmored) format. Fixed by piping the downloaded
key through `gpg --dearmor` when gpg is available (it is, since gnupg
is installed earlier in the same deps step), with a fallback to the
previous `cp` behaviour on systems without gpg.

Issue https://github.com/saltstack/salt-bootstrap/issues/2119 — When bootstrapping with `3006` as the major version on
RHEL-based systems, the fetched `salt.repo` from the install-guide
contains multiple repo entries including `salt-repo-latest` (which now
resolves to 3008). The `3006` case in the `yum`/`dnf` config-manager
sections was a no-op, leaving `salt-repo-latest` enabled and allowing
yum/dnf to install 3008 instead of the requested 3006. Fixed by adding
explicit `config-manager --set-disable salt-repo-*` followed by
`--set-enabled salt-repo-3006-lts`, matching the same pattern already
used for 3007.

ci: add Salt 3008 and Ubuntu 26.04 to test matrix
Add onedir-3008, stable-3008, and git-3008 test targets across all
Linux distros to cover the 3008 major version support added in the
previous commit. Add Ubuntu 26.04 to all distro lists (LINUX_DISTROS,
STABLE_DISTROS, ONEDIR_DISTROS, ONEDIR_RC_DISTROS) without blacklisting
3006 or 3007 since there are no 26.04-specific packages and the
generic Ubuntu packages are used. Regenerate ci.yml.

### What issues does this PR fix or reference?
Fixes #2113 
Fixes #2118 
Fixes #2119 
