### PR TITLE
fix(bootstrap): rename apt keyring to .gpg, drop SHA1/MD5, remove dead md5sum code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
       container-slug: macos-14
       timeout: 20
       runs-on: macos-14
-      instances: '["stable-3006", "stable-3006-8", "stable-3007", "stable-3007-1", "stable-3008", "latest"]'
+      instances: '["stable-3006", "stable-3006-24", "stable-3007", "stable-3007-1", "stable-3008", "latest"]'
 
 
   macos-15-intel:
@@ -143,7 +143,7 @@ jobs:
       container-slug: macos-15-intel
       timeout: 20
       runs-on: macos-15-intel
-      instances: '["stable-3006", "stable-3006-8", "stable-3007", "stable-3007-1", "stable-3008", "latest"]'
+      instances: '["stable-3006", "stable-3006-24", "stable-3007", "stable-3007-1", "stable-3008", "latest"]'
 
 
 
@@ -160,7 +160,7 @@ jobs:
       container-slug: windows-2022
       timeout: 20
       runs-on: windows-2022
-      instances: '["stable-3006", "stable-3006-8", "stable-3007", "stable-3007-1", "stable-3008", "latest"]'
+      instances: '["stable-3006", "stable-3006-24", "stable-3007", "stable-3007-1", "stable-3008", "latest"]'
 
 
   windows-2025:
@@ -176,7 +176,7 @@ jobs:
       container-slug: windows-2025
       timeout: 20
       runs-on: windows-2025
-      instances: '["stable-3006", "stable-3006-8", "stable-3007", "stable-3007-1", "stable-3008", "latest"]'
+      instances: '["stable-3006", "stable-3006-24", "stable-3007", "stable-3007-1", "stable-3008", "latest"]'
 
 
 
@@ -192,7 +192,7 @@ jobs:
       display-name: Amazon 2023
       container-slug: amazonlinux-2023
       timeout: 20
-      instances: '["stable-3006", "onedir-3006", "stable-3006-8", "stable-3007", "onedir-3007", "stable-3007-1", "stable-3008", "git-3008", "onedir-3008", "latest", "default"]'
+      instances: '["stable-3006", "onedir-3006", "stable-3006-24", "stable-3007", "onedir-3007", "stable-3007-1", "stable-3008", "git-3008", "onedir-3008", "latest", "default"]'
 
 
   debian-11:
@@ -207,7 +207,7 @@ jobs:
       display-name: Debian 11
       container-slug: debian-11
       timeout: 20
-      instances: '["stable-3006", "onedir-3006", "stable-3006-8", "stable-3007", "onedir-3007", "stable-3007-1", "stable-3008", "git-3008", "onedir-3008", "git-master", "latest", "default"]'
+      instances: '["stable-3006", "onedir-3006", "stable-3006-24", "stable-3007", "onedir-3007", "stable-3007-1", "stable-3008", "git-3008", "onedir-3008", "git-master", "latest", "default"]'
 
 
   debian-12:
@@ -237,7 +237,7 @@ jobs:
       display-name: Photon OS 5
       container-slug: photon-5
       timeout: 20
-      instances: '["stable-3006", "onedir-3006", "stable-3006-8", "stable-3007", "onedir-3007", "stable-3007-1", "stable-3008", "git-3008", "onedir-3008", "latest", "default"]'
+      instances: '["stable-3006", "onedir-3006", "stable-3006-24", "stable-3007", "onedir-3007", "stable-3007-1", "stable-3008", "git-3008", "onedir-3008", "latest", "default"]'
 
 
   rockylinux-8:
@@ -252,7 +252,7 @@ jobs:
       display-name: Rocky Linux 8
       container-slug: rockylinux-8
       timeout: 20
-      instances: '["stable-3006", "onedir-3006", "stable-3006-8", "stable-3007", "onedir-3007", "stable-3007-1", "stable-3008", "onedir-3008", "latest", "default"]'
+      instances: '["stable-3006", "onedir-3006", "stable-3006-24", "stable-3007", "onedir-3007", "stable-3007-1", "stable-3008", "onedir-3008", "latest", "default"]'
 
 
   rockylinux-9:
@@ -267,7 +267,7 @@ jobs:
       display-name: Rocky Linux 9
       container-slug: rockylinux-9
       timeout: 20
-      instances: '["stable-3006", "onedir-3006", "stable-3006-8", "stable-3007", "onedir-3007", "stable-3007-1", "stable-3008", "git-3008", "onedir-3008", "latest", "default"]'
+      instances: '["stable-3006", "onedir-3006", "stable-3006-24", "stable-3007", "onedir-3007", "stable-3007-1", "stable-3008", "git-3008", "onedir-3008", "latest", "default"]'
 
 
   ubuntu-2204:
@@ -282,7 +282,7 @@ jobs:
       display-name: Ubuntu 22.04
       container-slug: ubuntu-22.04
       timeout: 20
-      instances: '["stable-3006", "git-3006", "onedir-3006", "stable-3006-8", "stable-3007", "git-3007", "onedir-3007", "stable-3007-1", "stable-3008", "git-3008", "onedir-3008", "git-master", "latest", "default"]'
+      instances: '["stable-3006", "git-3006", "onedir-3006", "stable-3006-24", "stable-3007", "git-3007", "onedir-3007", "stable-3007-1", "stable-3008", "git-3008", "onedir-3008", "git-master", "latest", "default"]'
 
 
   ubuntu-2604:
@@ -297,7 +297,7 @@ jobs:
       display-name: Ubuntu 26.04
       container-slug: ubuntu-26.04
       timeout: 20
-      instances: '["stable-3006", "git-3006", "onedir-3006", "stable-3006-8", "stable-3007", "git-3007", "onedir-3007", "stable-3007-1", "stable-3008", "git-3008", "onedir-3008", "git-master", "latest", "default"]'
+      instances: '["stable-3006", "git-3006", "onedir-3006", "stable-3006-24", "stable-3007", "git-3007", "onedir-3007", "stable-3007-1", "stable-3008", "git-3008", "onedir-3008", "git-master", "latest", "default"]'
 
 
   set-pipeline-exit-status:

--- a/.github/workflows/templates/generate.py
+++ b/.github/workflows/templates/generate.py
@@ -140,7 +140,7 @@ BLACKLIST_GIT_MASTER = [
 
 SALT_VERSIONS = [
     "3006",
-    "3006-8",
+    "3006-24",
     "3007",
     "3007-1",
     "3008",
@@ -160,7 +160,7 @@ ONEDIR_RC_SALT_VERSIONS = []
 
 VERSION_DISPLAY_NAMES = {
     "3006": "v3006",
-    "3006-8": "v3006.8",
+    "3006-24": "v3006.24",
     "3007": "v3007",
     "3007-1": "v3007.1",
     "3008": "v3008",
@@ -180,7 +180,7 @@ MAC_STABLE_VERSION_BLACKLIST = [
 ]
 
 GIT_VERSION_BLACKLIST = [
-    "3006-8",
+    "3006-24",
     "3007-1",
     "nightly",
 ]
@@ -413,7 +413,7 @@ def generate_test_jobs():
 
                 BLACKLIST = {
                     "3006": BLACKLIST_3006,
-                    "3006-8": BLACKLIST_3006,
+                    "3006-24": BLACKLIST_3006,
                     "3007": BLACKLIST_3007,
                     "3007-1": BLACKLIST_3007,
                     "3008": BLACKLIST_3008,

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -60,7 +60,7 @@ jobs:
           # We need to get the version here and make it an environment variable
           # It is used to install via bootstrap and in the test
           # The version is in the instance name:
-          # ["stable-3006", "stable-3006-8", "stable-3007", "stable-3007-1", "latest"]
+          # ["stable-3006", "stable-3006-24", "stable-3007", "stable-3007-1", "latest"]
           $instance = "${{ matrix.instance }}"
           $version = $instance -split "-",2
           if ( $version.Count -gt 1 ) {

--- a/bootstrap-salt.ps1
+++ b/bootstrap-salt.ps1
@@ -328,14 +328,12 @@ function Get-FileHash {
 
         [Parameter(Mandatory=$false)]
         [ValidateSet(
-                "SHA1",
                 "SHA256",
                 "SHA384",
                 "SHA512",
                 # https://serverfault.com/questions/820300/
                 # why-isnt-mactripledes-algorithm-output-in-powershell-stable
                 "MACTripleDES", # don't use
-                "MD5",
                 "RIPEMD160",
                 IgnoreCase=$true)]
         [String] $Algorithm = "SHA256"
@@ -354,9 +352,6 @@ function Get-FileHash {
     $Path = Resolve-Path -Path $Path
 
     Switch ($Algorithm) {
-        SHA1 {
-            $hasher = [System.Security.Cryptography.SHA1CryptoServiceProvider]::Create()
-        }
         SHA256 {
             $hasher = [System.Security.Cryptography.SHA256]::Create()
         }
@@ -368,9 +363,6 @@ function Get-FileHash {
         }
         MACTripleDES {
             $hasher = [System.Security.Cryptography.MACTripleDES]::Create()
-        }
-        MD5 {
-            $hasher = [System.Security.Cryptography.MD5]::Create()
         }
         RIPEMD160 {
             $hasher = [System.Security.Cryptography.RIPEMD160]::Create()

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -957,28 +957,6 @@ __fetch_url() {
 }
 
 #---  FUNCTION  -------------------------------------------------------------------------------------------------------
-#         NAME:  __fetch_verify
-#  DESCRIPTION:  Retrieves a URL, verifies its content and writes it to standard output
-#----------------------------------------------------------------------------------------------------------------------
-__fetch_verify() {
-
-    fetch_verify_url="$1"
-    fetch_verify_sum="$2"
-    fetch_verify_size="$3"
-
-    fetch_verify_tmpf=$(mktemp) && \
-    __fetch_url "$fetch_verify_tmpf" "$fetch_verify_url" && \
-    test "$(stat --format=%s "$fetch_verify_tmpf")" -eq "$fetch_verify_size" && \
-    test "$(md5sum "$fetch_verify_tmpf" | awk '{ print $1 }')" = "$fetch_verify_sum" && \
-    cat "$fetch_verify_tmpf" && \
-    if rm -f "$fetch_verify_tmpf"; then
-        return 0
-    fi
-    echo "Failed verification of $fetch_verify_url"
-    return 1
-}
-
-#---  FUNCTION  -------------------------------------------------------------------------------------------------------
 #         NAME:  __check_url_exists
 #  DESCRIPTION:  Checks if a URL exists
 #----------------------------------------------------------------------------------------------------------------------
@@ -2033,11 +2011,11 @@ __apt_key_fetch() {
     mkdir -p /etc/apt/keyrings
     if __check_command_exists gpg; then
         # Newer apt requires the keyring in binary (dearmored) format.
-        gpg --dearmor < "$tempfile" > /etc/apt/keyrings/salt-archive-keyring.pgp || return 1
+        gpg --dearmor < "$tempfile" > /etc/apt/keyrings/salt-archive-keyring.gpg || return 1
     else
-        cp -f "$tempfile" /etc/apt/keyrings/salt-archive-keyring.pgp || return 1
+        cp -f "$tempfile" /etc/apt/keyrings/salt-archive-keyring.gpg || return 1
     fi
-    chmod 644 /etc/apt/keyrings/salt-archive-keyring.pgp || return 1
+    chmod 644 /etc/apt/keyrings/salt-archive-keyring.gpg || return 1
     rm -f "$tempfile"
 
     return 0
@@ -3025,6 +3003,7 @@ __install_saltstack_ubuntu_repository() {
 
     # SaltStack's stable Ubuntu repository:
     __fetch_url "/etc/apt/sources.list.d/salt.sources" "https://github.com/saltstack/salt-install-guide/releases/latest/download/salt.sources"
+    [ -f /etc/apt/sources.list.d/salt.sources ] && sed -i "s#salt-archive-keyring\.pgp#salt-archive-keyring.gpg#" /etc/apt/sources.list.d/salt.sources
     __apt_key_fetch "${HTTP_VAL}://${_REPO_URL}/api/security/keypair/SaltProjectKey/public" || return 1
     __wait_for_apt apt-get update || return 1
 
@@ -3077,6 +3056,7 @@ __install_saltstack_ubuntu_onedir_repository() {
 
     # SaltStack's stable Ubuntu repository:
     __fetch_url "/etc/apt/sources.list.d/salt.sources" "https://github.com/saltstack/salt-install-guide/releases/latest/download/salt.sources"
+    [ -f /etc/apt/sources.list.d/salt.sources ] && sed -i "s#salt-archive-keyring\.pgp#salt-archive-keyring.gpg#" /etc/apt/sources.list.d/salt.sources
     __apt_key_fetch "${HTTP_VAL}://${_REPO_URL}/api/security/keypair/SaltProjectKey/public" || return 1
     __wait_for_apt apt-get update || return 1
 
@@ -3528,6 +3508,7 @@ __install_saltstack_debian_repository() {
     __apt_get_install_noinput ${__PACKAGES} || return 1
 
     __fetch_url "/etc/apt/sources.list.d/salt.sources" "https://github.com/saltstack/salt-install-guide/releases/latest/download/salt.sources"
+    [ -f /etc/apt/sources.list.d/salt.sources ] && sed -i "s#salt-archive-keyring\.pgp#salt-archive-keyring.gpg#" /etc/apt/sources.list.d/salt.sources
     __apt_key_fetch "${HTTP_VAL}://${_REPO_URL}/api/security/keypair/SaltProjectKey/public" || return 1
     __wait_for_apt apt-get update || return 1
 
@@ -3573,6 +3554,7 @@ __install_saltstack_debian_onedir_repository() {
     __apt_get_install_noinput ${__PACKAGES} || return 1
 
     __fetch_url "/etc/apt/sources.list.d/salt.sources" "https://github.com/saltstack/salt-install-guide/releases/latest/download/salt.sources"
+    [ -f /etc/apt/sources.list.d/salt.sources ] && sed -i "s#salt-archive-keyring\.pgp#salt-archive-keyring.gpg#" /etc/apt/sources.list.d/salt.sources
     __apt_key_fetch "${HTTP_VAL}://${_REPO_URL}/api/security/keypair/SaltProjectKey/public" || return 1
     __wait_for_apt apt-get update || return 1
 

--- a/salt-quick-start.ps1
+++ b/salt-quick-start.ps1
@@ -84,14 +84,12 @@ function Get-FileHash {
 
         [Parameter(Mandatory=$false)]
         [ValidateSet(
-                "SHA1",
                 "SHA256",
                 "SHA384",
                 "SHA512",
         # https://serverfault.com/questions/820300/
         # why-isnt-mactripledes-algorithm-output-in-powershell-stable
                 "MACTripleDES", # don't use
-                "MD5",
                 "RIPEMD160",
                 IgnoreCase=$true)]
         [String] $Algorithm = "SHA256"
@@ -110,9 +108,6 @@ function Get-FileHash {
     $Path = Resolve-Path -Path $Path
 
     Switch ($Algorithm) {
-        SHA1 {
-            $hasher = [System.Security.Cryptography.SHA1CryptoServiceProvider]::Create()
-        }
         SHA256 {
             $hasher = [System.Security.Cryptography.SHA256]::Create()
         }
@@ -124,9 +119,6 @@ function Get-FileHash {
         }
         MACTripleDES {
             $hasher = [System.Security.Cryptography.MACTripleDES]::Create()
-        }
-        MD5 {
-            $hasher = [System.Security.Cryptography.MD5]::Create()
         }
         RIPEMD160 {
             $hasher = [System.Security.Cryptography.RIPEMD160]::Create()

--- a/tests/integration/test_installation.py
+++ b/tests/integration/test_installation.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 import platform
+import shutil
 import subprocess
 
 import pytest
@@ -80,3 +81,42 @@ def test_target_salt_version(path, target_salt_version):
     # Returns: {'saltversion': '3006.9+217.g53cfa53040'}
     adj_saltversion = result["saltversion"].split("+")[0]
     assert adj_saltversion == target_salt_version
+
+
+def test_apt_keyring_is_trusted():
+    """
+    Regression test for https://github.com/saltstack/salt/issues/69740
+    apt only recognizes .gpg (binary) or .asc (armored) keyring files. A
+    keyring referenced by an extension apt doesn't recognize is silently
+    ignored, which apt reports as a NO_PUBKEY / unsigned-repository error.
+    """
+    if platform.system() != "Linux" or shutil.which("apt-get") is None:
+        pytest.skip("Not an apt-based system")
+
+    sources_file = "/etc/apt/sources.list.d/salt.sources"
+    if not os.path.exists(sources_file):
+        pytest.skip("No salt.sources file present")
+
+    signed_by = None
+    with open(sources_file) as fp:
+        for line in fp:
+            if line.strip().startswith("Signed-By:"):
+                signed_by = line.split(":", 1)[1].strip()
+                break
+
+    assert signed_by, "salt.sources has no Signed-By line"
+    assert os.path.exists(signed_by), f"Signed-By keyring {signed_by} does not exist"
+    assert signed_by.endswith(
+        ".gpg"
+    ), f"apt does not recognize {signed_by}'s extension as a valid keyring"
+
+    # Confirm the keyring is actually binary GPG data, not raw ASCII-armored text
+    file_result = subprocess.run(
+        ["file", signed_by], capture_output=True, text=True
+    )
+    assert "PGP public key block" not in file_result.stdout, file_result.stdout
+
+    result = subprocess.run(["apt-get", "update"], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+    assert "NO_PUBKEY" not in result.stderr, result.stderr
+    assert "unsupported filetype" not in result.stderr, result.stderr


### PR DESCRIPTION
### What does this PR do?
apt only recognizes .gpg (binary) or .asc (armored) keyring extensions; salt-archive-keyring.pgp was silently ignored, causing NO_PUBKEY/unsigned repository failures on newer apt (saltstack/salt#69740). Rename the keyring bootstrap writes to .gpg and rewrite the fetched salt.sources Signed-By line to match, so this fix doesn't depend on salt-install-guide's release timing.

Also remove SHA1 and MD5 as selectable Get-FileHash algorithms in the PowerShell scripts, and delete the unused md5sum-based __fetch_verify() function from bootstrap-salt.sh.

Add a regression test asserting the apt keyring is trusted and apt-get update succeeds without NO_PUBKEY/unsupported-filetype errors.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/69740