### PR TITLE
feat(altlinux): add ALT Linux 10/11 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,6 +180,36 @@ jobs:
 
 
 
+  altlinux-10:
+    name: ALT Linux 10
+    if: github.event_name == 'push' || needs.collect-changed-files.outputs.run-tests == 'true'
+    uses: ./.github/workflows/test-linux.yml
+    needs:
+      - lint
+      - generate-actions-workflow
+    with:
+      distro-slug: altlinux-10
+      display-name: ALT Linux 10
+      container-slug: altlinux-10
+      timeout: 20
+      instances: '["stable-3006", "git-3006", "onedir-3006", "stable-3006-24", "stable-3007", "git-3007", "onedir-3007", "stable-3007-1", "git-master", "latest", "default"]'
+
+
+  altlinux-11:
+    name: ALT Linux 11
+    if: github.event_name == 'push' || needs.collect-changed-files.outputs.run-tests == 'true'
+    uses: ./.github/workflows/test-linux.yml
+    needs:
+      - lint
+      - generate-actions-workflow
+    with:
+      distro-slug: altlinux-11
+      display-name: ALT Linux 11
+      container-slug: altlinux-11
+      timeout: 20
+      instances: '["stable-3007", "git-3007", "onedir-3007", "stable-3007-1", "stable-3008", "git-3008", "onedir-3008", "git-master", "latest", "default"]'
+
+
   amazonlinux-2023:
     name: Amazon 2023
     if: github.event_name == 'push' || needs.collect-changed-files.outputs.run-tests == 'true'
@@ -312,6 +342,8 @@ jobs:
       - macos-15-intel
       - windows-2022
       - windows-2025
+      - altlinux-10
+      - altlinux-11
       - amazonlinux-2023
       - debian-11
       - debian-12

--- a/.github/workflows/templates/generate.py
+++ b/.github/workflows/templates/generate.py
@@ -16,6 +16,8 @@ os.chdir(os.path.abspath(os.path.dirname(__file__)))
 #    "ubuntu-2004",
 #    "ubuntu-2404",
 LINUX_DISTROS = [
+    "altlinux-10",
+    "altlinux-11",
     "amazonlinux-2023",
     "debian-11",
     "debian-12",
@@ -43,6 +45,8 @@ OSX = [
 #    "ubuntu-2004",
 #    "ubuntu-2404",
 STABLE_DISTROS = [
+    "altlinux-10",
+    "altlinux-11",
     "amazonlinux-2023",
     "debian-11",
     "debian-12",
@@ -60,6 +64,8 @@ STABLE_DISTROS = [
 #    "ubuntu-2004",
 #    "ubuntu-2404",
 ONEDIR_DISTROS = [
+    "altlinux-10",
+    "altlinux-11",
     "amazonlinux-2023",
     "debian-11",
     "debian-12",
@@ -77,6 +83,8 @@ ONEDIR_DISTROS = [
 #    "rockylinux-8",
 #    "ubuntu-2404",
 ONEDIR_RC_DISTROS = [
+    "altlinux-10",
+    "altlinux-11",
     "debian-12",
     "photon-5",
     "rockylinux-9",
@@ -85,6 +93,7 @@ ONEDIR_RC_DISTROS = [
 ]
 
 BLACKLIST_3006 = [
+    "altlinux-11",
     "debian-12",
     "fedora-40",
     "ubuntu-2404",
@@ -95,10 +104,13 @@ BLACKLIST_3007 = [
     "photon-4",
 ]
 
-BLACKLIST_3008 = []
+BLACKLIST_3008 = [
+    "altlinux-10",
+]
 
 #    "ubuntu-2204",
 BLACKLIST_GIT_3006 = [
+    "altlinux-11",
     "amazonlinux-2",
     "amazonlinux-2023",
     "debian-11",
@@ -125,6 +137,10 @@ BLACKLIST_GIT_3007 = [
     "rockylinux-9",
     "ubuntu-2004",
     "ubuntu-2404",
+]
+
+BLACKLIST_GIT_3008 = [
+    "altlinux-10",
 ]
 
 #    "debian-12",
@@ -201,6 +217,8 @@ GIT_DISTRO_BLACKLIST = [
 LATEST_PKG_BLACKLIST = []
 
 DISTRO_DISPLAY_NAMES = {
+    "altlinux-10": "ALT Linux 10",
+    "altlinux-11": "ALT Linux 11",
     "amazonlinux-2": "Amazon 2",
     "amazonlinux-2023": "Amazon 2023",
     "debian-11": "Debian 11",
@@ -222,6 +240,8 @@ DISTRO_DISPLAY_NAMES = {
 }
 
 CONTAINER_SLUG_NAMES = {
+    "altlinux-10": "altlinux-10",
+    "altlinux-11": "altlinux-11",
     "amazonlinux-2": "amazonlinux-2",
     "amazonlinux-2023": "amazonlinux-2023",
     "debian-11": "debian-11",
@@ -422,6 +442,7 @@ def generate_test_jobs():
                     BLACKLIST = {
                         "3006": BLACKLIST_GIT_3006,
                         "3007": BLACKLIST_GIT_3007,
+                        "3008": BLACKLIST_GIT_3008,
                         "master": BLACKLIST_GIT_MASTER,
                     }
 

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -52,6 +52,7 @@ Dan Mick                    dmick                  dan.mick@inktank.com
 Daniel Poelzleithner        poelzi
 Daniel Wallace              gtmanfred              danielwallace@gtmanfred.com
 Darko Cerdic                darkocerdic
+Daniil Chistyakov           KegsZooL               danil.chistyakov.2015@inbox.ru
 Daryl Turner                darylturner            d.turner@arkadin.com
 David J. Felix              DavidJFelix
 David Murphy                daithi                david-dm.murphy@broadcom.com

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1100,7 +1100,7 @@ __strip_duplicates() {
 #                 enough.
 #----------------------------------------------------------------------------------------------------------------------
 __sort_release_files() {
-    KNOWN_RELEASE_FILES=$(echo "(arch|alpine|centos|debian|ubuntu|fedora|redhat|suse|\
+    KNOWN_RELEASE_FILES=$(echo "(altlinux|arch|alpine|centos|debian|ubuntu|fedora|redhat|suse|\
         mandrake|mandriva|gentoo|slackware|turbolinux|unitedlinux|void|lsb|system|\
         oracle|os|almalinux|rocky)(-|_)(release|version)" | sed -E 's:[[:space:]]::g')
     primary_release_files=""
@@ -1116,7 +1116,7 @@ __sort_release_files() {
     done
 
     # Now let's sort by know files importance, max important goes last in the max_prio list
-    max_prio="redhat-release centos-release oracle-release fedora-release almalinux-release rocky-release"
+    max_prio="redhat-release centos-release oracle-release fedora-release almalinux-release rocky-release altlinux-release"
     for entry in $max_prio; do
         if [ "$(echo "${primary_release_files}" | grep "$entry")" != "" ]; then
             primary_release_files=$(echo "${primary_release_files}" | sed -e "s:\\(.*\\)\\($entry\\)\\(.*\\):\\2 \\1 \\3:g")
@@ -1232,6 +1232,7 @@ __gather_linux_system_info() {
                     n="<R>ed <H>at <L>inux"
                 fi
                 ;;
+            altlinux           ) n="ALT Linux"      ;;
             arch               ) n="Arch Linux"     ;;
             alpine             ) n="Alpine Linux"   ;;
             centos             ) n="CentOS"         ;;
@@ -1746,6 +1747,15 @@ __check_end_of_life_versions() {
                 echoerror "End of life distributions are not supported."
                 echoerror "Please consider upgrading to the next stable. See:"
                 echoerror "    https://aws.amazon.com/amazon-linux-ami/"
+                exit 1
+            fi
+            ;;
+        alt*linux)
+            # ALT Linux versions lower than 10 are no longer supported
+            if [ "$DISTRO_MAJOR_VERSION" -lt 10 ]; then
+                echoerror "End of life distributions are not supported."
+                echoerror "Please consider upgrading to the next stable. See:"
+                echoerror "    https://www.basealt.ru/updates/"
                 exit 1
             fi
             ;;
@@ -2801,6 +2811,14 @@ __install_salt_from_repo() {
     else
         echoerror "Salt static CI requirements not found: expected requirements/static/ci/py${_py_version}/linux.lock or requirements/static/ci/py${_py_version}/linux.txt"
         return 1
+    fi
+
+    # mercurial==6.0.1 fails to build on Python 3.12 (uses removed PyLongObject.ob_digit)
+    # pygit2==1.13.1 requires libgit2 1.7.x, ALT ships 1.9.6 - use ALT's native
+    # python3-module-pygit2 package instead
+    if [ "${DISTRO_NAME_L}" = "alt_linux" ]; then
+        echodebug "Removing incompatible 'mercurial'/'pygit2' pins from ${_salt_static_ci_linux_req}"
+        sed -i -E '/^(mercurial|pygit2)==/d' "${_salt_static_ci_linux_req}"
     fi
 
     echodebug "Installing Salt requirements from PyPi, ${_pip_cmd} install ${_USE_BREAK_SYSTEM_PACKAGES} --ignore-installed ${_PIP_INSTALL_ARGS} -r ${_salt_static_ci_linux_req}"
@@ -8163,6 +8181,264 @@ install_macosx_restart_daemons() {
 }
 #
 #   Ended OS X / Darwin Install Functions
+#
+#######################################################################################################################
+
+#######################################################################################################################
+#
+#   ALT Linux Install Functions
+#
+
+install_alt_linux_git_deps() {
+
+    if [ -n "$_PY_EXE" ] && [ "$_PY_MAJOR_VERSION" -ne 3 ]; then
+        echoerror "Python version is no longer supported, only Python 3"
+        return 1
+    fi
+
+    apt-get update || return 1
+
+    __PACKAGES=""
+    if ! __check_command_exists ps; then
+        __PACKAGES="${__PACKAGES} procps"
+    fi
+    if ! __check_command_exists git; then
+        __PACKAGES="${__PACKAGES} git"
+    fi
+
+    if [ -n "${__PACKAGES}" ]; then
+        # shellcheck disable=SC2086
+        __apt_get_install_noinput ${__PACKAGES} || return 1
+        __PACKAGES=""
+    fi
+
+    # shellcheck disable=SC2119
+    __git_clone_and_checkout || return 1
+
+    __PACKAGES="python${PY_PKG_VER}-dev python${PY_PKG_VER}-module-pip python${PY_PKG_VER}-module-pygit2"
+    __PACKAGES="${__PACKAGES} python${PY_PKG_VER}-module-setuptools gcc gcc-c++"
+
+    # shellcheck disable=SC2086
+    __apt_get_install_noinput ${__PACKAGES} || return 1
+
+    # Let's trigger config_salt()
+    if [ "$_TEMP_CONFIG_DIR" = "null" ]; then
+        _TEMP_CONFIG_DIR="${_SALT_GIT_CHECKOUT_DIR}/conf"
+        CONFIG_SALT_FUNC="config_salt"
+    fi
+
+    return 0
+}
+
+install_alt_linux_deps() {
+
+    if [ "$_UPGRADE_SYS" -eq $BS_TRUE ]; then
+        apt-get update || return 1
+        apt-get -y dist-upgrade || return 1
+    fi
+
+    __PACKAGES="${__PACKAGES:=}"
+    if [ -n "$_PY_EXE" ] && [ "$_PY_MAJOR_VERSION" -ne 3 ]; then
+        echoerror "Python version is no longer supported, only Python 3"
+        return 1
+    fi
+
+    PY_PKG_VER=3
+
+    __PACKAGES="${__PACKAGES} python${PY_PKG_VER} procps"
+    __PACKAGES="${__PACKAGES} python${PY_PKG_VER}-module-yaml python${PY_PKG_VER}-module-jinja2"
+    __PACKAGES="${__PACKAGES} python${PY_PKG_VER}-module-msgpack python${PY_PKG_VER}-module-cryptography"
+    __PACKAGES="${__PACKAGES} python${PY_PKG_VER}-module-zmq python${PY_PKG_VER}-module-pip"
+
+    if [ "${_EXTRA_PACKAGES}" != "" ]; then
+        echoinfo "Installing the following extra packages as requested: ${_EXTRA_PACKAGES}"
+    fi
+
+    # shellcheck disable=SC2086
+    __apt_get_install_noinput ${__PACKAGES} ${_EXTRA_PACKAGES} || return 1
+
+    return 0
+}
+
+install_alt_linux_onedir_deps() {
+    __apt_get_install_noinput wget tar gzip gnupg ca-certificates || return 1
+    return 0
+}
+
+install_alt_linux_stable() {
+
+    __PACKAGES=""
+
+    if [ "$_INSTALL_MASTER" -eq $BS_TRUE ]; then
+        __PACKAGES="${__PACKAGES} salt-master"
+    fi
+    if [ "$_INSTALL_MINION" -eq $BS_TRUE ]; then
+        __PACKAGES="${__PACKAGES} salt-minion"
+    fi
+    if [ "$_INSTALL_SALT_API" -eq $BS_TRUE ]; then
+        __PACKAGES="${__PACKAGES} salt-api"
+    fi
+
+    # shellcheck disable=SC2086
+    __apt_get_install_noinput ${__PACKAGES} || return 1
+
+    return 0
+}
+
+install_alt_linux_post() {
+
+    SYSTEMD_RELOAD=$BS_FALSE
+
+    for fname in api master minion syndic; do
+        # Skip salt-api since the service should be opt-in and not necessarily started on boot
+        [ $fname = "api" ] && continue
+
+        # Skip if not meant to be installed
+        [ $fname = "master" ] && [ "$_INSTALL_MASTER" -eq $BS_FALSE ] && continue
+        [ $fname = "minion" ] && [ "$_INSTALL_MINION" -eq $BS_FALSE ] && continue
+
+        if [ "$_SYSTEMD_FUNCTIONAL" -eq $BS_TRUE ]; then
+            /bin/systemctl is-enabled salt-${fname}.service > /dev/null 2>&1 || (
+                /bin/systemctl preset salt-${fname}.service > /dev/null 2>&1 &&
+                /bin/systemctl enable salt-${fname}.service > /dev/null 2>&1
+            )
+        fi
+    done
+
+    if [ "$SYSTEMD_RELOAD" -eq $BS_TRUE ]; then
+        /bin/systemctl daemon-reload
+    fi
+
+    return 0
+}
+
+install_alt_linux_git() {
+    install_fedora_git || return 1
+    return 0
+}
+
+install_alt_linux_git_post() {
+
+    for fname in api master minion syndic; do
+        # Skip if not meant to be installed
+        [ $fname = "api" ] && \
+            ([ "$_INSTALL_MASTER" -eq $BS_FALSE ] || ! __check_command_exists "salt-${fname}") && continue
+        [ $fname = "master" ] && [ "$_INSTALL_MASTER" -eq $BS_FALSE ] && continue
+        [ $fname = "minion" ] && [ "$_INSTALL_MINION" -eq $BS_FALSE ] && continue
+        [ $fname = "syndic" ] && [ "$_INSTALL_SYNDIC" -eq $BS_FALSE ] && continue
+
+        # Account for new path for services files in later releases
+        if [ -f "${_SALT_GIT_CHECKOUT_DIR}/pkg/common/salt-${fname}.service" ]; then
+          _SERVICE_DIR="${_SALT_GIT_CHECKOUT_DIR}/pkg/common"
+        else
+          _SERVICE_DIR="${_SALT_GIT_CHECKOUT_DIR}/pkg/rpm"
+        fi
+        __copyfile "${_SERVICE_DIR}/salt-${fname}.service" "/lib/systemd/system/salt-${fname}.service"
+
+        # Skip salt-api since the service should be opt-in and not necessarily started on boot
+        [ $fname = "api" ] && continue
+
+        systemctl is-enabled salt-$fname.service || (systemctl preset salt-$fname.service && systemctl enable salt-$fname.service)
+        sleep 1
+        systemctl daemon-reload
+
+    done
+}
+
+install_alt_linux_onedir() {
+    version="${ONEDIR_REV:-latest}"
+    arch="x86_64"
+    [ "$(uname -m)" = "aarch64" ] && arch="aarch64"
+
+    # Resolve "latest" to actual version
+    if [ "$version" = "latest" ]; then
+        version=$(wget -qO- https://api.github.com/repos/saltstack/salt/releases/latest \
+                  | sed -n 's/.*"tag_name": *"v\([0-9.]*\(-[0-9]*\)\?\)".*/\1/p') || return 1
+    fi
+
+    version=$(__salt_version_string "$version")
+
+    tarball="salt-${version}-onedir-linux-${arch}.tar.xz"
+    url="https://github.com/saltstack/salt/releases/download/v${version}/${tarball}"
+    extractdir="/opt/saltstack/salt"
+
+    echoinfo "Downloading Salt onedir: $url"
+    wget -q "$url" -O "/tmp/${tarball}" || return 1
+
+    # Validate tarball
+    if ! tar -tf "/tmp/${tarball}" >/dev/null 2>&1; then
+        echoerror "Invalid or corrupt onedir tarball"
+        return 1
+    fi
+
+    # Prepare extraction
+    rm -rf /opt/saltstack/salt || true
+    mkdir -p "${extractdir}"
+    tar --strip-components=1 -xf "/tmp/${tarball}" -C "$extractdir" || return 1
+
+    chmod -R 755 "${extractdir}"
+
+    return 0
+}
+
+install_alt_linux_onedir_post() {
+
+    # Add onedir paths system-wide
+    cat >/etc/profile.d/saltstack.sh <<'EOF'
+export PATH=/opt/saltstack/salt:/opt/saltstack/salt/bin:$PATH
+EOF
+
+    chmod 644 /etc/profile.d/saltstack.sh
+
+    for fname in api master minion syndic; do
+        # Skip salt-api since the service should be opt-in and not necessarily started on boot
+        [ $fname = "api" ] && continue
+
+        # Skip if not meant to be installed
+        [ $fname = "master" ] && [ "$_INSTALL_MASTER" -eq $BS_FALSE ] && continue
+        [ $fname = "minion" ] && [ "$_INSTALL_MINION" -eq $BS_FALSE ] && continue
+        [ $fname = "syndic" ] && [ "$_INSTALL_SYNDIC" -eq $BS_FALSE ] && continue
+
+        systemctl disable --now "salt-${fname}.service" 2>/dev/null || true
+
+        cat >"/etc/systemd/system/salt-${fname}.service" <<EOF
+[Unit]
+Description=Salt ${fname} (onedir)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/opt/saltstack/salt/salt-${fname} -c /etc/salt
+Restart=always
+LimitNOFILE=100000
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+        if [ "$_START_DAEMONS" -eq $BS_TRUE ]; then
+            systemctl enable --now "salt-${fname}.service"
+        fi
+    done
+
+    systemctl daemon-reload
+
+    return 0
+}
+
+install_alt_linux_restart_daemons() {
+    install_fedora_restart_daemons || return 1
+    return 0
+}
+
+install_alt_linux_check_services() {
+    install_fedora_check_services || return 1
+    return 0
+}
+
+#
+#   Ended ALT Linux Install Functions
 #
 #######################################################################################################################
 

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -8394,12 +8394,19 @@ install_alt_linux_onedir() {
 
 install_alt_linux_onedir_post() {
 
-    # Add onedir paths system-wide
+    # Add onedir paths system-wide. This only takes effect for login/interactive
+    # shells that source /etc/profile.d - it does not help something like
+    # `docker exec <container> salt-call ...`, which runs without one, so also
+    # symlink the onedir binaries into /usr/bin, already on PATH everywhere.
     cat >/etc/profile.d/saltstack.sh <<'EOF'
 export PATH=/opt/saltstack/salt:/opt/saltstack/salt/bin:$PATH
 EOF
 
     chmod 644 /etc/profile.d/saltstack.sh
+
+    for bin in /opt/saltstack/salt/salt*; do
+        [ -f "$bin" ] && [ -x "$bin" ] && ln -sf "$bin" "/usr/bin/$(basename "$bin")"
+    done
 
     for fname in api master minion syndic; do
         # Skip salt-api since the service should be opt-in and not necessarily started on boot

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -1268,6 +1268,10 @@ __gather_linux_system_info() {
                         n="Alpine Linux"
                         v="${rv}"
                         ;;
+                    altlinux    )
+                        n="ALT Linux"
+                        v="${rv}"
+                        ;;
                     amzn        )
                         # Amazon AMI's after 2014.09 match here
                         n="Amazon Linux AMI"

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -8353,7 +8353,8 @@ install_alt_linux_git_post() {
 install_alt_linux_onedir() {
     version="${ONEDIR_REV:-latest}"
     arch="x86_64"
-    [ "$(uname -m)" = "aarch64" ] && arch="aarch64"
+    # Onedir tarball filenames use "arm64", not the "aarch64" uname reports.
+    [ "$(uname -m)" = "aarch64" ] && arch="arm64"
 
     # Resolve "latest", or a bare major version (e.g. "3006"), to the actual
     # latest GA release for that series via the artifactory directory listing
@@ -8370,7 +8371,12 @@ install_alt_linux_onedir() {
     fi
 
     tarball="salt-${version}-onedir-linux-${arch}.tar.xz"
-    url="https://github.com/saltstack/salt/releases/download/v${version}/${tarball}"
+    # GitHub Releases doesn't carry an onedir tarball asset for every
+    # historical point release (only newer ones do), while the artifactory
+    # generic repo has the complete history - it's the same source already
+    # used by the macOS/Windows/Photon onedir installers, and by the CI
+    # images' own provisioning.
+    url="https://${_REPO_URL}/saltproject-generic/onedir/${version}/${tarball}"
     extractdir="/opt/saltstack/salt"
 
     echoinfo "Downloading Salt onedir: $url"

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -8355,13 +8355,19 @@ install_alt_linux_onedir() {
     arch="x86_64"
     [ "$(uname -m)" = "aarch64" ] && arch="aarch64"
 
-    # Resolve "latest" to actual version
+    # Resolve "latest", or a bare major version (e.g. "3006"), to the actual
+    # latest GA release for that series via the artifactory directory listing
+    # (same mechanism used for macOS/Windows/Photon onedir installs). A full
+    # version string (e.g. "3006.26") is used as-is.
     if [ "$version" = "latest" ]; then
-        version=$(wget -qO- https://api.github.com/repos/saltstack/salt/releases/latest \
-                  | sed -n 's/.*"tag_name": *"v\([0-9.]*\(-[0-9]*\)\?\)".*/\1/p') || return 1
+        __get_packagesite_onedir_latest || return 1
+        version="$_GENERIC_PKG_VERSION"
+    elif [ "$(echo "$version" | grep -E '^[0-9]{4}$')" != "" ]; then
+        __get_packagesite_onedir_latest "$version" || return 1
+        version="$_GENERIC_PKG_VERSION"
+    else
+        version=$(__salt_version_string "$version")
     fi
-
-    version=$(__salt_version_string "$version")
 
     tarball="salt-${version}-onedir-linux-${arch}.tar.xz"
     url="https://github.com/saltstack/salt/releases/download/v${version}/${tarball}"

--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -8265,6 +8265,7 @@ install_alt_linux_deps() {
 }
 
 install_alt_linux_onedir_deps() {
+    __wait_for_apt apt-get update || return 1
     __apt_get_install_noinput wget tar gzip gnupg ca-certificates || return 1
     return 0
 }


### PR DESCRIPTION
### What does this PR do?
Adds[ ALT Linux](https://www.basealt.ru/) 10 and 11 support to `bootstrap-salt.sh`: detection, and install functions for **stable**/**onedir**/**git** install types

### What issues does this PR fix or reference?

Requires [saltstack/salt-ci-containers#131](https://github.com/saltstack/salt-ci-containers/pull/131) to be merged first

### Previous Behavior

ALT Linux wasn't present in this repo at all