### PR TITLE
fix(bootstrap): add missing install_ubuntu_onedir_post function

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -3396,6 +3396,11 @@ install_ubuntu_stable_post() {
     return 0
 }
 
+install_ubuntu_onedir_post() {
+    install_ubuntu_stable_post || return 1
+    return 0
+}
+
 install_ubuntu_git_post() {
 
     for fname in api master minion syndic; do


### PR DESCRIPTION
### What does this PR do?
Ubuntu had install_ubuntu_stable_post and install_ubuntu_git_post but no install_ubuntu_onedir_post. Since ITYPE is set to onedir for onedir installs, the post-install function dispatch never matched any candidate name and silently skipped enabling the salt-* systemd services, causing check_install_services to fail on Ubuntu 24.04.

Add install_ubuntu_onedir_post as a thin wrapper delegating to install_ubuntu_stable_post, matching the existing pattern used by other distros (e.g. install_suse_15_onedir_post, install_rocky_linux_onedir_post).

### What issues does this PR fix or reference?
Fixes #2128 