### PR TITLE
fix(bootstrap): port ALT Linux onedir fixes to Arch Linux

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -6274,19 +6274,30 @@ install_arch_linux_onedir() {
 
     version="${ONEDIR_REV:-latest}"
     arch="x86_64"
-    [ "$(uname -m)" = "aarch64" ] && arch="aarch64"
+    # Onedir tarball filenames use "arm64", not the "aarch64" uname reports.
+    [ "$(uname -m)" = "aarch64" ] && arch="arm64"
 
-    # Resolve "latest" to actual version
+    # Resolve "latest", or a bare major version (e.g. "3006"), to the actual
+    # latest GA release for that series via the artifactory directory listing
+    # (same mechanism used for macOS/Windows/Photon onedir installs). A full
+    # version string (e.g. "3006.26") is used as-is.
     if [ "$version" = "latest" ]; then
-        version=$(wget -qO- https://api.github.com/repos/saltstack/salt/releases/latest \
-                  | grep -Eo '"tag_name": *"v[0-9.]+(-[0-9]+)?"' \
-                  | sed 's/"tag_name": *"v//;s/"//') || return 1
+        __get_packagesite_onedir_latest || return 1
+        version="$_GENERIC_PKG_VERSION"
+    elif [ "$(echo "$version" | grep -E '^[0-9]{4}$')" != "" ]; then
+        __get_packagesite_onedir_latest "$version" || return 1
+        version="$_GENERIC_PKG_VERSION"
+    else
+        version=$(__salt_version_string "$version")
     fi
 
-    version=$(__salt_version_string "$version")
-
     tarball="salt-${version}-onedir-linux-${arch}.tar.xz"
-    url="https://github.com/saltstack/salt/releases/download/v${version}/${tarball}"
+    # GitHub Releases doesn't carry an onedir tarball asset for every
+    # historical point release (only newer ones do), while the artifactory
+    # generic repo has the complete history - it's the same source already
+    # used by the macOS/Windows/Photon onedir installers, and by the CI
+    # images' own provisioning.
+    url="https://${_REPO_URL}/saltproject-generic/onedir/${version}/${tarball}"
     extractdir="/tmp/salt-${version}-onedir-linux-${arch}"
 
     echoinfo "Downloading Salt onedir: $url"
@@ -6477,12 +6488,19 @@ EOF
 
     systemctl daemon-reload
 
-    # Add onedir paths system-wide
+    # Add onedir paths system-wide. This only takes effect for login/interactive
+    # shells that source /etc/profile.d - it does not help something like
+    # `docker exec <container> salt-call ...`, which runs without one, so also
+    # symlink the onedir binaries into /usr/bin, already on PATH everywhere.
     cat >/etc/profile.d/saltstack.sh <<'EOF'
 export PATH=/opt/saltstack/salt:/opt/saltstack/salt/bin:$PATH
 EOF
 
     chmod 644 /etc/profile.d/saltstack.sh
+
+    for bin in /opt/saltstack/salt/salt*; do
+        [ -f "$bin" ] && [ -x "$bin" ] && ln -sf "$bin" "/usr/bin/$(basename "$bin")"
+    done
 
     if [ "$_START_DAEMONS" -eq $BS_TRUE ]; then
         systemctl enable --now salt-minion.service


### PR DESCRIPTION
### What does this PR do?

`install_arch_linux_onedir()`/`install_arch_linux_onedir_post()` carry the same three bugs just fixed for ALT Linux (its code was evidently copied from Arch's originally):

1. **Bare major version isn't resolved.** `ONEDIR_REV` can legitimately be a bare 4-digit major version (e.g. `"3006"`) - a documented, valid input per `__validate_salt_version_arg`. It passed through unresolved and produced a nonexistent GitHub release tag (`v3006`).
2. **GitHub Releases doesn't carry an onedir tarball asset for every historical point release.** E.g. `v3007.1`'s release page exists but only has source tarballs/docs/epub, no onedir asset - only newer releases got onedir assets attached to GitHub Releases.
3. **Wrong arm64 filename.** `arch="aarch64"` was used, but onedir tarball filenames (on both GitHub and Broadcom's artifactory) use `arm64`, not `aarch64`.
4. **`install_arch_linux_onedir_post()` only exports `PATH` via `/etc/profile.d`**, which a non-login-shell invocation (e.g. `docker exec <container> salt-call ...`, exactly how this repo's own CI invokes tests) never sources.

Fix: reuse `__get_packagesite_onedir_latest()` (already used by the macOS/Windows/Photon onedir installers) to resolve `latest`/bare-major versions via the artifactory directory listing, fetch the tarball from the artifactory generic repo instead of GitHub Releases, fix the arm64 filename, and symlink onedir binaries into `/usr/bin`.

### Verification

**Arch Linux has no CI coverage in this repo** - no `arch`/`archlinux` reference anywhere in `.github/workflows/test-linux.yml` or `.github/workflows/templates/generate.py` - which is exactly how these bugs went unnoticed while the identical ALT Linux code got caught immediately by its own CI matrix. Since this couldn't be verified end-to-end via CI, verified instead:
- `bash -n bootstrap-salt.sh` syntax check
- The version-resolution logic exercised in isolation (stubbed `__get_packagesite_onedir_latest`) against `latest`, bare-major (`3006`), full-minor (`3007.13`), and package-release-suffix (`3008.1-1`) inputs - all resolve and build URLs correctly
- The resulting artifactory URLs confirmed live (200) for a real version, both `x86_64` and `arm64`

Given the lack of CI coverage, extra reviewer scrutiny (or a follow-up "add Arch Linux to the CI matrix" issue) is probably warranted here.

### What issues does this PR fix or reference?

Same class of bug as salt-bootstrap#2125 (ALT Linux onedir fixes), applied to Arch Linux's pre-existing, structurally identical code.